### PR TITLE
feat: access controller 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ config.yaml
 
 # Ignore IOTA key files
 *.key
+
+# Ignore at the moment. In case developers want to use a different linker
+.cargo/config.toml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1067,7 +1067,7 @@ dependencies = [
 [[package]]
 name = "bin-version"
 version = "0.9.0-alpha"
-source = "git+https://github.com/iotaledger/iota#da3fb8a5ec11eb566988aab7f135b6743873a243"
+source = "git+https://github.com/iotaledger/iota#0d5f0884d4b167203d5e40198e942702fd08878e"
 dependencies = [
  "const-str",
  "git-version",
@@ -1813,7 +1813,7 @@ dependencies = [
 [[package]]
 name = "consensus-config"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#da3fb8a5ec11eb566988aab7f135b6743873a243"
+source = "git+https://github.com/iotaledger/iota#0d5f0884d4b167203d5e40198e942702fd08878e"
 dependencies = [
  "fastcrypto 0.1.8",
  "iota-network-stack",
@@ -1825,7 +1825,7 @@ dependencies = [
 [[package]]
 name = "consensus-core"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#da3fb8a5ec11eb566988aab7f135b6743873a243"
+source = "git+https://github.com/iotaledger/iota#0d5f0884d4b167203d5e40198e942702fd08878e"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2675,9 +2675,9 @@ dependencies = [
 [[package]]
 name = "enum-compat-util"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#da3fb8a5ec11eb566988aab7f135b6743873a243"
+source = "git+https://github.com/iotaledger/iota#0d5f0884d4b167203d5e40198e942702fd08878e"
 dependencies = [
- "serde_yaml",
+ "serde_yaml 0.8.26",
 ]
 
 [[package]]
@@ -4507,7 +4507,7 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 [[package]]
 name = "iota-adapter-latest"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#da3fb8a5ec11eb566988aab7f135b6743873a243"
+source = "git+https://github.com/iotaledger/iota#0d5f0884d4b167203d5e40198e942702fd08878e"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4535,7 +4535,7 @@ dependencies = [
 [[package]]
 name = "iota-archival"
 version = "0.9.0-alpha"
-source = "git+https://github.com/iotaledger/iota#da3fb8a5ec11eb566988aab7f135b6743873a243"
+source = "git+https://github.com/iotaledger/iota#0d5f0884d4b167203d5e40198e942702fd08878e"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -4560,7 +4560,7 @@ dependencies = [
 [[package]]
 name = "iota-authority-aggregation"
 version = "0.9.0-alpha"
-source = "git+https://github.com/iotaledger/iota#da3fb8a5ec11eb566988aab7f135b6743873a243"
+source = "git+https://github.com/iotaledger/iota#0d5f0884d4b167203d5e40198e942702fd08878e"
 dependencies = [
  "futures",
  "iota-metrics",
@@ -4572,7 +4572,7 @@ dependencies = [
 [[package]]
 name = "iota-bridge"
 version = "0.9.0-alpha"
-source = "git+https://github.com/iotaledger/iota#da3fb8a5ec11eb566988aab7f135b6743873a243"
+source = "git+https://github.com/iotaledger/iota#0d5f0884d4b167203d5e40198e942702fd08878e"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4619,7 +4619,7 @@ dependencies = [
 [[package]]
 name = "iota-common"
 version = "0.9.0-alpha"
-source = "git+https://github.com/iotaledger/iota#da3fb8a5ec11eb566988aab7f135b6743873a243"
+source = "git+https://github.com/iotaledger/iota#0d5f0884d4b167203d5e40198e942702fd08878e"
 dependencies = [
  "futures",
  "parking_lot 0.12.3",
@@ -4629,7 +4629,7 @@ dependencies = [
 [[package]]
 name = "iota-config"
 version = "0.9.0-alpha"
-source = "git+https://github.com/iotaledger/iota#da3fb8a5ec11eb566988aab7f135b6743873a243"
+source = "git+https://github.com/iotaledger/iota#0d5f0884d4b167203d5e40198e942702fd08878e"
 dependencies = [
  "anemo",
  "anyhow",
@@ -4650,14 +4650,14 @@ dependencies = [
  "reqwest 0.12.12",
  "serde",
  "serde_with",
- "serde_yaml",
+ "serde_yaml 0.8.26",
  "tracing",
 ]
 
 [[package]]
 name = "iota-core"
 version = "0.9.0-alpha"
-source = "git+https://github.com/iotaledger/iota#da3fb8a5ec11eb566988aab7f135b6743873a243"
+source = "git+https://github.com/iotaledger/iota#0d5f0884d4b167203d5e40198e942702fd08878e"
 dependencies = [
  "anemo",
  "anyhow",
@@ -4779,15 +4779,15 @@ dependencies = [
 [[package]]
 name = "iota-enum-compat-util"
 version = "0.9.0-alpha"
-source = "git+https://github.com/iotaledger/iota#da3fb8a5ec11eb566988aab7f135b6743873a243"
+source = "git+https://github.com/iotaledger/iota#0d5f0884d4b167203d5e40198e942702fd08878e"
 dependencies = [
- "serde_yaml",
+ "serde_yaml 0.8.26",
 ]
 
 [[package]]
 name = "iota-execution"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#da3fb8a5ec11eb566988aab7f135b6743873a243"
+source = "git+https://github.com/iotaledger/iota#0d5f0884d4b167203d5e40198e942702fd08878e"
 dependencies = [
  "iota-adapter-latest",
  "iota-move-natives-latest",
@@ -4804,7 +4804,7 @@ dependencies = [
 [[package]]
 name = "iota-framework"
 version = "0.9.0-alpha"
-source = "git+https://github.com/iotaledger/iota#da3fb8a5ec11eb566988aab7f135b6743873a243"
+source = "git+https://github.com/iotaledger/iota#0d5f0884d4b167203d5e40198e942702fd08878e"
 dependencies = [
  "bcs",
  "iota-types",
@@ -4818,7 +4818,7 @@ dependencies = [
 [[package]]
 name = "iota-framework-snapshot"
 version = "0.9.0-alpha"
-source = "git+https://github.com/iotaledger/iota#da3fb8a5ec11eb566988aab7f135b6743873a243"
+source = "git+https://github.com/iotaledger/iota#0d5f0884d4b167203d5e40198e942702fd08878e"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4862,6 +4862,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "serde_yaml 0.9.34+deprecated",
  "shared-crypto",
  "tap",
  "telemetry-subscribers",
@@ -4875,7 +4876,7 @@ dependencies = [
 [[package]]
 name = "iota-genesis-builder"
 version = "0.9.0-alpha"
-source = "git+https://github.com/iotaledger/iota#da3fb8a5ec11eb566988aab7f135b6743873a243"
+source = "git+https://github.com/iotaledger/iota#0d5f0884d4b167203d5e40198e942702fd08878e"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4916,7 +4917,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "serde_yaml",
+ "serde_yaml 0.8.26",
  "shared-crypto",
  "tempfile",
  "thiserror 1.0.69",
@@ -4928,7 +4929,7 @@ dependencies = [
 [[package]]
 name = "iota-genesis-common"
 version = "0.9.0-alpha"
-source = "git+https://github.com/iotaledger/iota#da3fb8a5ec11eb566988aab7f135b6743873a243"
+source = "git+https://github.com/iotaledger/iota#0d5f0884d4b167203d5e40198e942702fd08878e"
 dependencies = [
  "iota-execution",
  "iota-protocol-config",
@@ -4939,7 +4940,7 @@ dependencies = [
 [[package]]
 name = "iota-json"
 version = "0.9.0-alpha"
-source = "git+https://github.com/iotaledger/iota#da3fb8a5ec11eb566988aab7f135b6743873a243"
+source = "git+https://github.com/iotaledger/iota#0d5f0884d4b167203d5e40198e942702fd08878e"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4956,7 +4957,7 @@ dependencies = [
 [[package]]
 name = "iota-json-rpc"
 version = "0.9.0-alpha"
-source = "git+https://github.com/iotaledger/iota#da3fb8a5ec11eb566988aab7f135b6743873a243"
+source = "git+https://github.com/iotaledger/iota#0d5f0884d4b167203d5e40198e942702fd08878e"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -5008,7 +5009,7 @@ dependencies = [
 [[package]]
 name = "iota-json-rpc-api"
 version = "0.9.0-alpha"
-source = "git+https://github.com/iotaledger/iota#da3fb8a5ec11eb566988aab7f135b6743873a243"
+source = "git+https://github.com/iotaledger/iota#0d5f0884d4b167203d5e40198e942702fd08878e"
 dependencies = [
  "anyhow",
  "fastcrypto 0.1.8",
@@ -5028,7 +5029,7 @@ dependencies = [
 [[package]]
 name = "iota-json-rpc-types"
 version = "0.9.0-alpha"
-source = "git+https://github.com/iotaledger/iota#da3fb8a5ec11eb566988aab7f135b6743873a243"
+source = "git+https://github.com/iotaledger/iota#0d5f0884d4b167203d5e40198e942702fd08878e"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5058,7 +5059,7 @@ dependencies = [
 [[package]]
 name = "iota-keys"
 version = "0.9.0-alpha"
-source = "git+https://github.com/iotaledger/iota#da3fb8a5ec11eb566988aab7f135b6743873a243"
+source = "git+https://github.com/iotaledger/iota#0d5f0884d4b167203d5e40198e942702fd08878e"
 dependencies = [
  "anyhow",
  "bip32",
@@ -5077,7 +5078,7 @@ dependencies = [
 [[package]]
 name = "iota-macros"
 version = "0.9.0-alpha"
-source = "git+https://github.com/iotaledger/iota#da3fb8a5ec11eb566988aab7f135b6743873a243"
+source = "git+https://github.com/iotaledger/iota#0d5f0884d4b167203d5e40198e942702fd08878e"
 dependencies = [
  "futures",
  "iota-proc-macros",
@@ -5088,7 +5089,7 @@ dependencies = [
 [[package]]
 name = "iota-metrics"
 version = "0.9.0-alpha"
-source = "git+https://github.com/iotaledger/iota#da3fb8a5ec11eb566988aab7f135b6743873a243"
+source = "git+https://github.com/iotaledger/iota#0d5f0884d4b167203d5e40198e942702fd08878e"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -5112,7 +5113,7 @@ dependencies = [
 [[package]]
 name = "iota-move-build"
 version = "0.9.0-alpha"
-source = "git+https://github.com/iotaledger/iota#da3fb8a5ec11eb566988aab7f135b6743873a243"
+source = "git+https://github.com/iotaledger/iota#0d5f0884d4b167203d5e40198e942702fd08878e"
 dependencies = [
  "anyhow",
  "fastcrypto 0.1.8",
@@ -5136,7 +5137,7 @@ dependencies = [
 [[package]]
 name = "iota-move-natives-latest"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#da3fb8a5ec11eb566988aab7f135b6743873a243"
+source = "git+https://github.com/iotaledger/iota#0d5f0884d4b167203d5e40198e942702fd08878e"
 dependencies = [
  "bcs",
  "better_any",
@@ -5159,7 +5160,7 @@ dependencies = [
 [[package]]
 name = "iota-network"
 version = "0.9.0-alpha"
-source = "git+https://github.com/iotaledger/iota#da3fb8a5ec11eb566988aab7f135b6743873a243"
+source = "git+https://github.com/iotaledger/iota#0d5f0884d4b167203d5e40198e942702fd08878e"
 dependencies = [
  "anemo",
  "anemo-build",
@@ -5194,7 +5195,7 @@ dependencies = [
 [[package]]
 name = "iota-network-stack"
 version = "0.9.0-alpha"
-source = "git+https://github.com/iotaledger/iota#da3fb8a5ec11eb566988aab7f135b6743873a243"
+source = "git+https://github.com/iotaledger/iota#0d5f0884d4b167203d5e40198e942702fd08878e"
 dependencies = [
  "anemo",
  "bcs",
@@ -5218,7 +5219,7 @@ dependencies = [
 [[package]]
 name = "iota-node"
 version = "0.9.0-alpha"
-source = "git+https://github.com/iotaledger/iota#da3fb8a5ec11eb566988aab7f135b6743873a243"
+source = "git+https://github.com/iotaledger/iota#0d5f0884d4b167203d5e40198e942702fd08878e"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -5269,7 +5270,7 @@ dependencies = [
 [[package]]
 name = "iota-open-rpc"
 version = "0.9.0-alpha"
-source = "git+https://github.com/iotaledger/iota#da3fb8a5ec11eb566988aab7f135b6743873a243"
+source = "git+https://github.com/iotaledger/iota#0d5f0884d4b167203d5e40198e942702fd08878e"
 dependencies = [
  "schemars",
  "serde",
@@ -5280,7 +5281,7 @@ dependencies = [
 [[package]]
 name = "iota-open-rpc-macros"
 version = "0.9.0-alpha"
-source = "git+https://github.com/iotaledger/iota#da3fb8a5ec11eb566988aab7f135b6743873a243"
+source = "git+https://github.com/iotaledger/iota#0d5f0884d4b167203d5e40198e942702fd08878e"
 dependencies = [
  "derive-syn-parse",
  "itertools 0.13.0",
@@ -5293,7 +5294,7 @@ dependencies = [
 [[package]]
 name = "iota-package-management"
 version = "0.9.0-alpha"
-source = "git+https://github.com/iotaledger/iota#da3fb8a5ec11eb566988aab7f135b6743873a243"
+source = "git+https://github.com/iotaledger/iota#0d5f0884d4b167203d5e40198e942702fd08878e"
 dependencies = [
  "anyhow",
  "iota-json-rpc-types",
@@ -5309,7 +5310,7 @@ dependencies = [
 [[package]]
 name = "iota-package-resolver"
 version = "0.9.0-alpha"
-source = "git+https://github.com/iotaledger/iota#da3fb8a5ec11eb566988aab7f135b6743873a243"
+source = "git+https://github.com/iotaledger/iota#0d5f0884d4b167203d5e40198e942702fd08878e"
 dependencies = [
  "async-trait",
  "bcs",
@@ -5327,7 +5328,7 @@ dependencies = [
 [[package]]
 name = "iota-proc-macros"
 version = "0.9.0-alpha"
-source = "git+https://github.com/iotaledger/iota#da3fb8a5ec11eb566988aab7f135b6743873a243"
+source = "git+https://github.com/iotaledger/iota#0d5f0884d4b167203d5e40198e942702fd08878e"
 dependencies = [
  "msim-macros",
  "proc-macro2",
@@ -5338,7 +5339,7 @@ dependencies = [
 [[package]]
 name = "iota-protocol-config"
 version = "0.9.0-alpha"
-source = "git+https://github.com/iotaledger/iota#da3fb8a5ec11eb566988aab7f135b6743873a243"
+source = "git+https://github.com/iotaledger/iota#0d5f0884d4b167203d5e40198e942702fd08878e"
 dependencies = [
  "clap",
  "iota-protocol-config-macros",
@@ -5352,7 +5353,7 @@ dependencies = [
 [[package]]
 name = "iota-protocol-config-macros"
 version = "0.9.0-alpha"
-source = "git+https://github.com/iotaledger/iota#da3fb8a5ec11eb566988aab7f135b6743873a243"
+source = "git+https://github.com/iotaledger/iota#0d5f0884d4b167203d5e40198e942702fd08878e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5362,7 +5363,7 @@ dependencies = [
 [[package]]
 name = "iota-rest-api"
 version = "0.9.0-alpha"
-source = "git+https://github.com/iotaledger/iota#da3fb8a5ec11eb566988aab7f135b6743873a243"
+source = "git+https://github.com/iotaledger/iota#0d5f0884d4b167203d5e40198e942702fd08878e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5383,7 +5384,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "serde_yaml",
+ "serde_yaml 0.8.26",
  "tap",
  "thiserror 1.0.69",
  "tokio",
@@ -5413,7 +5414,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk"
 version = "0.9.0-alpha"
-source = "git+https://github.com/iotaledger/iota#da3fb8a5ec11eb566988aab7f135b6743873a243"
+source = "git+https://github.com/iotaledger/iota#0d5f0884d4b167203d5e40198e942702fd08878e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5480,7 +5481,7 @@ dependencies = [
 [[package]]
 name = "iota-simulator"
 version = "0.9.0-alpha"
-source = "git+https://github.com/iotaledger/iota#da3fb8a5ec11eb566988aab7f135b6743873a243"
+source = "git+https://github.com/iotaledger/iota#0d5f0884d4b167203d5e40198e942702fd08878e"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -5503,7 +5504,7 @@ dependencies = [
 [[package]]
 name = "iota-snapshot"
 version = "0.9.0-alpha"
-source = "git+https://github.com/iotaledger/iota#da3fb8a5ec11eb566988aab7f135b6743873a243"
+source = "git+https://github.com/iotaledger/iota#0d5f0884d4b167203d5e40198e942702fd08878e"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5531,7 +5532,7 @@ dependencies = [
 [[package]]
 name = "iota-storage"
 version = "0.9.0-alpha"
-source = "git+https://github.com/iotaledger/iota#da3fb8a5ec11eb566988aab7f135b6743873a243"
+source = "git+https://github.com/iotaledger/iota#0d5f0884d4b167203d5e40198e942702fd08878e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5583,7 +5584,7 @@ dependencies = [
 [[package]]
 name = "iota-swarm"
 version = "0.9.0-alpha"
-source = "git+https://github.com/iotaledger/iota#da3fb8a5ec11eb566988aab7f135b6743873a243"
+source = "git+https://github.com/iotaledger/iota#0d5f0884d4b167203d5e40198e942702fd08878e"
 dependencies = [
  "anyhow",
  "futures",
@@ -5609,7 +5610,7 @@ dependencies = [
 [[package]]
 name = "iota-swarm-config"
 version = "0.9.0-alpha"
-source = "git+https://github.com/iotaledger/iota#da3fb8a5ec11eb566988aab7f135b6743873a243"
+source = "git+https://github.com/iotaledger/iota#0d5f0884d4b167203d5e40198e942702fd08878e"
 dependencies = [
  "anemo",
  "anyhow",
@@ -5626,7 +5627,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_with",
- "serde_yaml",
+ "serde_yaml 0.8.26",
  "shared-crypto",
  "tempfile",
  "tracing",
@@ -5635,7 +5636,7 @@ dependencies = [
 [[package]]
 name = "iota-test-transaction-builder"
 version = "0.9.0-alpha"
-source = "git+https://github.com/iotaledger/iota#da3fb8a5ec11eb566988aab7f135b6743873a243"
+source = "git+https://github.com/iotaledger/iota#0d5f0884d4b167203d5e40198e942702fd08878e"
 dependencies = [
  "bcs",
  "iota-genesis-builder",
@@ -5649,7 +5650,7 @@ dependencies = [
 [[package]]
 name = "iota-tls"
 version = "0.9.0-alpha"
-source = "git+https://github.com/iotaledger/iota#da3fb8a5ec11eb566988aab7f135b6743873a243"
+source = "git+https://github.com/iotaledger/iota#0d5f0884d4b167203d5e40198e942702fd08878e"
 dependencies = [
  "anyhow",
  "axum 0.7.9",
@@ -5670,7 +5671,7 @@ dependencies = [
 [[package]]
 name = "iota-transaction-builder"
 version = "0.9.0-alpha"
-source = "git+https://github.com/iotaledger/iota#da3fb8a5ec11eb566988aab7f135b6743873a243"
+source = "git+https://github.com/iotaledger/iota#0d5f0884d4b167203d5e40198e942702fd08878e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5687,7 +5688,7 @@ dependencies = [
 [[package]]
 name = "iota-transaction-checks"
 version = "0.9.0-alpha"
-source = "git+https://github.com/iotaledger/iota#da3fb8a5ec11eb566988aab7f135b6743873a243"
+source = "git+https://github.com/iotaledger/iota#0d5f0884d4b167203d5e40198e942702fd08878e"
 dependencies = [
  "fastcrypto-zkp",
  "iota-config",
@@ -5702,7 +5703,7 @@ dependencies = [
 [[package]]
 name = "iota-types"
 version = "0.9.0-alpha"
-source = "git+https://github.com/iotaledger/iota#da3fb8a5ec11eb566988aab7f135b6743873a243"
+source = "git+https://github.com/iotaledger/iota#0d5f0884d4b167203d5e40198e942702fd08878e"
 dependencies = [
  "anemo",
  "anyhow",
@@ -5772,7 +5773,7 @@ dependencies = [
 [[package]]
 name = "iota-verifier-latest"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#da3fb8a5ec11eb566988aab7f135b6743873a243"
+source = "git+https://github.com/iotaledger/iota#0d5f0884d4b167203d5e40198e942702fd08878e"
 dependencies = [
  "iota-protocol-config",
  "iota-types",
@@ -6551,7 +6552,7 @@ dependencies = [
 [[package]]
 name = "move-abstract-interpreter"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#da3fb8a5ec11eb566988aab7f135b6743873a243"
+source = "git+https://github.com/iotaledger/iota#0d5f0884d4b167203d5e40198e942702fd08878e"
 dependencies = [
  "move-binary-format",
  "move-bytecode-verifier-meter",
@@ -6560,12 +6561,12 @@ dependencies = [
 [[package]]
 name = "move-abstract-stack"
 version = "0.0.1"
-source = "git+https://github.com/iotaledger/iota#da3fb8a5ec11eb566988aab7f135b6743873a243"
+source = "git+https://github.com/iotaledger/iota#0d5f0884d4b167203d5e40198e942702fd08878e"
 
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/iotaledger/iota#da3fb8a5ec11eb566988aab7f135b6743873a243"
+source = "git+https://github.com/iotaledger/iota#0d5f0884d4b167203d5e40198e942702fd08878e"
 dependencies = [
  "anyhow",
  "enum-compat-util",
@@ -6579,12 +6580,12 @@ dependencies = [
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/iotaledger/iota#da3fb8a5ec11eb566988aab7f135b6743873a243"
+source = "git+https://github.com/iotaledger/iota#0d5f0884d4b167203d5e40198e942702fd08878e"
 
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#da3fb8a5ec11eb566988aab7f135b6743873a243"
+source = "git+https://github.com/iotaledger/iota#0d5f0884d4b167203d5e40198e942702fd08878e"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6599,7 +6600,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#da3fb8a5ec11eb566988aab7f135b6743873a243"
+source = "git+https://github.com/iotaledger/iota#0d5f0884d4b167203d5e40198e942702fd08878e"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -6612,7 +6613,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#da3fb8a5ec11eb566988aab7f135b6743873a243"
+source = "git+https://github.com/iotaledger/iota#0d5f0884d4b167203d5e40198e942702fd08878e"
 dependencies = [
  "move-abstract-interpreter",
  "move-abstract-stack",
@@ -6627,7 +6628,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier-meter"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#da3fb8a5ec11eb566988aab7f135b6743873a243"
+source = "git+https://github.com/iotaledger/iota#0d5f0884d4b167203d5e40198e942702fd08878e"
 dependencies = [
  "move-binary-format",
  "move-core-types",
@@ -6637,7 +6638,7 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#da3fb8a5ec11eb566988aab7f135b6743873a243"
+source = "git+https://github.com/iotaledger/iota#0d5f0884d4b167203d5e40198e942702fd08878e"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6657,7 +6658,7 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/iotaledger/iota#da3fb8a5ec11eb566988aab7f135b6743873a243"
+source = "git+https://github.com/iotaledger/iota#0d5f0884d4b167203d5e40198e942702fd08878e"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6689,7 +6690,7 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/iotaledger/iota#da3fb8a5ec11eb566988aab7f135b6743873a243"
+source = "git+https://github.com/iotaledger/iota#0d5f0884d4b167203d5e40198e942702fd08878e"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6712,7 +6713,7 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#da3fb8a5ec11eb566988aab7f135b6743873a243"
+source = "git+https://github.com/iotaledger/iota#0d5f0884d4b167203d5e40198e942702fd08878e"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6732,7 +6733,7 @@ dependencies = [
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#da3fb8a5ec11eb566988aab7f135b6743873a243"
+source = "git+https://github.com/iotaledger/iota#0d5f0884d4b167203d5e40198e942702fd08878e"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6752,7 +6753,7 @@ dependencies = [
 [[package]]
 name = "move-docgen"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#da3fb8a5ec11eb566988aab7f135b6743873a243"
+source = "git+https://github.com/iotaledger/iota#0d5f0884d4b167203d5e40198e942702fd08878e"
 dependencies = [
  "anyhow",
  "codespan",
@@ -6770,7 +6771,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#da3fb8a5ec11eb566988aab7f135b6743873a243"
+source = "git+https://github.com/iotaledger/iota#0d5f0884d4b167203d5e40198e942702fd08878e"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -6788,7 +6789,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#da3fb8a5ec11eb566988aab7f135b6743873a243"
+source = "git+https://github.com/iotaledger/iota#0d5f0884d4b167203d5e40198e942702fd08878e"
 dependencies = [
  "anyhow",
  "hex",
@@ -6801,7 +6802,7 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#da3fb8a5ec11eb566988aab7f135b6743873a243"
+source = "git+https://github.com/iotaledger/iota#0d5f0884d4b167203d5e40198e942702fd08878e"
 dependencies = [
  "hex",
  "move-command-line-common",
@@ -6814,7 +6815,7 @@ dependencies = [
 [[package]]
 name = "move-model"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#da3fb8a5ec11eb566988aab7f135b6743873a243"
+source = "git+https://github.com/iotaledger/iota#0d5f0884d4b167203d5e40198e942702fd08878e"
 dependencies = [
  "anyhow",
  "codespan",
@@ -6838,7 +6839,7 @@ dependencies = [
 [[package]]
 name = "move-package"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#da3fb8a5ec11eb566988aab7f135b6743873a243"
+source = "git+https://github.com/iotaledger/iota#0d5f0884d4b167203d5e40198e942702fd08878e"
 dependencies = [
  "anyhow",
  "clap",
@@ -6858,7 +6859,7 @@ dependencies = [
  "petgraph 0.5.1",
  "regex",
  "serde",
- "serde_yaml",
+ "serde_yaml 0.8.26",
  "sha2 0.9.9",
  "tempfile",
  "toml 0.5.11",
@@ -6872,7 +6873,7 @@ dependencies = [
 [[package]]
 name = "move-proc-macros"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#da3fb8a5ec11eb566988aab7f135b6743873a243"
+source = "git+https://github.com/iotaledger/iota#0d5f0884d4b167203d5e40198e942702fd08878e"
 dependencies = [
  "quote",
  "syn 2.0.96",
@@ -6881,7 +6882,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib-natives"
 version = "0.1.1"
-source = "git+https://github.com/iotaledger/iota#da3fb8a5ec11eb566988aab7f135b6743873a243"
+source = "git+https://github.com/iotaledger/iota#0d5f0884d4b167203d5e40198e942702fd08878e"
 dependencies = [
  "hex",
  "move-binary-format",
@@ -6896,7 +6897,7 @@ dependencies = [
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#da3fb8a5ec11eb566988aab7f135b6743873a243"
+source = "git+https://github.com/iotaledger/iota#0d5f0884d4b167203d5e40198e942702fd08878e"
 dependencies = [
  "once_cell",
  "phf",
@@ -6906,7 +6907,7 @@ dependencies = [
 [[package]]
 name = "move-vm-config"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#da3fb8a5ec11eb566988aab7f135b6743873a243"
+source = "git+https://github.com/iotaledger/iota#0d5f0884d4b167203d5e40198e942702fd08878e"
 dependencies = [
  "move-binary-format",
  "once_cell",
@@ -6915,7 +6916,7 @@ dependencies = [
 [[package]]
 name = "move-vm-profiler"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#da3fb8a5ec11eb566988aab7f135b6743873a243"
+source = "git+https://github.com/iotaledger/iota#0d5f0884d4b167203d5e40198e942702fd08878e"
 dependencies = [
  "move-vm-config",
  "once_cell",
@@ -6925,7 +6926,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#da3fb8a5ec11eb566988aab7f135b6743873a243"
+source = "git+https://github.com/iotaledger/iota#0d5f0884d4b167203d5e40198e942702fd08878e"
 dependencies = [
  "better_any",
  "fail",
@@ -6944,7 +6945,7 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#da3fb8a5ec11eb566988aab7f135b6743873a243"
+source = "git+https://github.com/iotaledger/iota#0d5f0884d4b167203d5e40198e942702fd08878e"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -6958,7 +6959,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#da3fb8a5ec11eb566988aab7f135b6743873a243"
+source = "git+https://github.com/iotaledger/iota#0d5f0884d4b167203d5e40198e942702fd08878e"
 dependencies = [
  "bcs",
  "move-binary-format",
@@ -8370,7 +8371,7 @@ dependencies = [
 [[package]]
 name = "prometheus-closure-metric"
 version = "0.9.0-alpha"
-source = "git+https://github.com/iotaledger/iota#da3fb8a5ec11eb566988aab7f135b6743873a243"
+source = "git+https://github.com/iotaledger/iota#0d5f0884d4b167203d5e40198e942702fd08878e"
 dependencies = [
  "anyhow",
  "prometheus",
@@ -9679,6 +9680,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap 2.7.1",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "serdect"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9763,7 +9777,7 @@ dependencies = [
 [[package]]
 name = "shared-crypto"
 version = "0.9.0-alpha"
-source = "git+https://github.com/iotaledger/iota#da3fb8a5ec11eb566988aab7f135b6743873a243"
+source = "git+https://github.com/iotaledger/iota#0d5f0884d4b167203d5e40198e942702fd08878e"
 dependencies = [
  "bcs",
  "eyre",
@@ -10359,7 +10373,7 @@ dependencies = [
 [[package]]
 name = "telemetry-subscribers"
 version = "0.9.0-alpha"
-source = "git+https://github.com/iotaledger/iota#da3fb8a5ec11eb566988aab7f135b6743873a243"
+source = "git+https://github.com/iotaledger/iota#0d5f0884d4b167203d5e40198e942702fd08878e"
 dependencies = [
  "atomic_float",
  "bytes",
@@ -10435,7 +10449,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 [[package]]
 name = "test-cluster"
 version = "0.9.0-alpha"
-source = "git+https://github.com/iotaledger/iota#da3fb8a5ec11eb566988aab7f135b6743873a243"
+source = "git+https://github.com/iotaledger/iota#0d5f0884d4b167203d5e40198e942702fd08878e"
 dependencies = [
  "anyhow",
  "bcs",
@@ -11155,7 +11169,7 @@ dependencies = [
 [[package]]
 name = "typed-store"
 version = "0.9.0-alpha"
-source = "git+https://github.com/iotaledger/iota#da3fb8a5ec11eb566988aab7f135b6743873a243"
+source = "git+https://github.com/iotaledger/iota#0d5f0884d4b167203d5e40198e942702fd08878e"
 dependencies = [
  "async-trait",
  "bcs",
@@ -11184,7 +11198,7 @@ dependencies = [
 [[package]]
 name = "typed-store-derive"
 version = "0.9.0-alpha"
-source = "git+https://github.com/iotaledger/iota#da3fb8a5ec11eb566988aab7f135b6743873a243"
+source = "git+https://github.com/iotaledger/iota#0d5f0884d4b167203d5e40198e942702fd08878e"
 dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
@@ -11195,7 +11209,7 @@ dependencies = [
 [[package]]
 name = "typed-store-error"
 version = "0.9.0-alpha"
-source = "git+https://github.com/iotaledger/iota#da3fb8a5ec11eb566988aab7f135b6743873a243"
+source = "git+https://github.com/iotaledger/iota#0d5f0884d4b167203d5e40198e942702fd08878e"
 dependencies = [
  "serde",
  "thiserror 1.0.69",
@@ -11301,6 +11315,12 @@ dependencies = [
  "crypto-common",
  "subtle",
 ]
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "unsigned-varint"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3997,6 +3997,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "hostname"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9c7c7c8ac16c798734b8a24560c1362120597c40d5e1459f09498f8f6c8f2ba"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows 0.52.0",
+]
+
+[[package]]
 name = "http"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4845,13 +4856,15 @@ dependencies = [
  "fastcrypto 0.1.9",
  "futures-util",
  "git-version",
+ "hostname",
  "iota-config",
  "iota-json-rpc-types",
  "iota-metrics",
  "iota-sdk 0.9.0-alpha",
  "iota-swarm-config",
  "iota-types",
- "itertools 0.12.1",
+ "itertools 0.14.0",
+ "lazy_static",
  "once_cell",
  "parking_lot 0.12.3",
  "prometheus",
@@ -5870,6 +5883,15 @@ name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -11695,6 +11717,16 @@ dependencies = [
  "windows_i686_msvc 0.36.1",
  "windows_x86_64_gnu 0.36.1",
  "windows_x86_64_msvc 0.36.1",
+]
+
+[[package]]
+name = "windows"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
+dependencies = [
+ "windows-core 0.52.0",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ tracing = "0.1.40"
 tokio = { version = "1.39.2", features = ["full"] }
 tokio-retry = "0.3.0"
 serde_json = "1.0.108"
+serde_yaml = "0.9.33"
 
 [dev-dependencies]
 rand = "0.8.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,8 @@ const-str = "0.5.6"
 eyre = "0.6.9"
 futures-util = "0.3.30"
 git-version = "0.3.9"
-itertools = "0.12.0"
+hostname = "0.4.0"
+itertools = "0.14.0"
 once_cell = "1.19.0"
 parking_lot = "0.12.1"
 prometheus = "0.13.3"
@@ -50,6 +51,8 @@ tokio = { version = "1.39.2", features = ["full"] }
 tokio-retry = "0.3.0"
 serde_json = "1.0.108"
 serde_yaml = "0.9.33"
+lazy_static = "1.5.0"
+
 
 [dev-dependencies]
 rand = "0.8.5"

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,3 @@
-
-
-
 redis-start:
 	docker run -d --name redis -p 6379:6379 redis:7.2.5
 

--- a/Makefile
+++ b/Makefile
@@ -6,4 +6,3 @@ redis-restart:
 	docker rm redis
 	docker run -d --name redis -p 6379:6379 redis:7.2.5
 
-

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+
+
+
+redis-start:
+	docker run -d --name redis -p 6379:6379 redis:7.2.5
+
+redis-restart:
+	docker stop redis
+	docker rm redis
+	docker run -d --name redis -p 6379:6379 redis:7.2.5
+
+

--- a/README.md
+++ b/README.md
@@ -133,7 +133,18 @@ The **Gas Pool Server** includes an **Access Controller** mechanism to manage ac
 
 We plan to extend the filtering functionality to include additional transaction parameters in future updates.
 
+
 To use the Access Controller, you must enable it in the `config.yaml` file.
+
+### Monitoring
+
+### Prometheus Metrics
+
+The service exposes Prometheus metrics endpoints with a variety of metrics. The port can be configured in `config.yaml` using the `metrics-port` setting.
+
+### Transactions Logging
+
+For more detailed and granular monitoring, you can log transaction effects for every signed transaction. This can be enabled by setting the environment variable `TRANSACTIONS_LOGGING` to `true`.
 
 #### Access Controller Examples
 

--- a/README.md
+++ b/README.md
@@ -196,18 +196,6 @@ The **Gas Pool Server** includes an **Access Controller** mechanism to manage ac
 
 ---
 
-- Enable Access for All Requests but Block a Specific Address
-
-   This configuration allows all incoming requests but blocks those from the specified sender address (`0x00000000`):
-
-   ```yaml
-   access-controller:
-   access-policy: allow-all
-   rules:
-      - sender-address: "0x00000000"
-        action: 'deny'
-   ```
-
 #### Access Controller Rule syntax
 
 |  parameter              | mandatory  | possible values                                                |

--- a/README.md
+++ b/README.md
@@ -131,8 +131,6 @@ implementations:
 
 The **Gas Pool Server** includes an **Access Controller** mechanism to manage access to the `/execute_tx` endpoint. This feature allows you to implement filtering logic based on properties derived from transactions. Currently, the Access Controller supports filtering based on the sender's address, enabling you to block or allow specific addresses.
 
-We plan to extend the filtering functionality to include additional transaction parameters in future updates.
-
 #### Access Controller Examples
 
 - Disable All Requests and Allow Only a Specific Address
@@ -219,16 +217,13 @@ We plan to extend the filtering functionality to include additional transaction 
 | `action`                |  yes       | `'allow'`,  `'deny'`                                           |
 
 
-
-To use the Access Controller, you must enable it in the `config.yaml` file.
-
 ### Monitoring
 
-### Prometheus Metrics
+#### Prometheus Metrics
 
 The service exposes Prometheus metrics endpoints with a variety of metrics. The port can be configured in `config.yaml` using the `metrics-port` setting.
 
-### Transactions Logging
+#### Transactions Logging
 
 For more detailed and granular monitoring, you can log transaction effects for every signed transaction. This can be enabled by setting the environment variable `TRANSACTIONS_LOGGING` to `true`.
 

--- a/README.md
+++ b/README.md
@@ -129,22 +129,9 @@ implementations:
 
 ### Gas Pool Server Access Controller
 
-The **Gas Pool Server** includes an **Access Controller** mechanism to manage access to the `execute_tx` endpoint. This feature allows you to implement filtering logic based on properties derived from transactions. Currently, the Access Controller supports filtering based on the sender's address, enabling you to block or allow specific addresses.
+The **Gas Pool Server** includes an **Access Controller** mechanism to manage access to the `/execute_tx` endpoint. This feature allows you to implement filtering logic based on properties derived from transactions. Currently, the Access Controller supports filtering based on the sender's address, enabling you to block or allow specific addresses.
 
 We plan to extend the filtering functionality to include additional transaction parameters in future updates.
-
-
-To use the Access Controller, you must enable it in the `config.yaml` file.
-
-### Monitoring
-
-### Prometheus Metrics
-
-The service exposes Prometheus metrics endpoints with a variety of metrics. The port can be configured in `config.yaml` using the `metrics-port` setting.
-
-### Transactions Logging
-
-For more detailed and granular monitoring, you can log transaction effects for every signed transaction. This can be enabled by setting the environment variable `TRANSACTIONS_LOGGING` to `true`.
 
 #### Access Controller Examples
 
@@ -185,7 +172,7 @@ For more detailed and granular monitoring, you can log transaction effects for e
    access-policy: deny-all
    rules:
       - sender-address: "0x00000000"
-        gas-budget: '<1000000' # allowed operators: =, !=, <, >, <=, >=
+        transaction-gas-budget: '<1000000' # allowed operators: =, !=, <, >, <=, >=
         action: 'allow'
    ```
 
@@ -200,11 +187,11 @@ For more detailed and granular monitoring, you can log transaction effects for e
    access-policy: deny-all
    rules:
       - sender-address: "0x00000000"
-        gas-budget: '<=10000000'
+        transaction-gas-budget: '<=10000000'
         action: 'allow'
 
       - sender-address: '*'
-        gas-budget: '<500000'
+        transaction-gas-budget: '<500000'
         action: 'allow'
 
    ```
@@ -222,6 +209,29 @@ For more detailed and granular monitoring, you can log transaction effects for e
       - sender-address: "0x00000000"
         action: 'deny'
    ```
+
+#### Access Controller Rule syntax
+
+|  parameter              | mandatory  | possible values                                                |
+|------------------------ | -----------|-----------------------------------------------------------------|
+| `sender-address`        |  yes       | `'0x0000000'`, `[0x00000000, 0x11111111]`, `'*'`               |
+| `gas-budget`            |  no        | `'=100'`, `'<100'`,  `'<=100'`, `'>100'`, `'>=100'`, `'!=100'` |
+| `action`                |  yes       | `'allow'`,  `'deny'`                                           |
+
+
+
+To use the Access Controller, you must enable it in the `config.yaml` file.
+
+### Monitoring
+
+### Prometheus Metrics
+
+The service exposes Prometheus metrics endpoints with a variety of metrics. The port can be configured in `config.yaml` using the `metrics-port` setting.
+
+### Transactions Logging
+
+For more detailed and granular monitoring, you can log transaction effects for every signed transaction. This can be enabled by setting the environment variable `TRANSACTIONS_LOGGING` to `true`.
+
 
 ## Binaries
 

--- a/src/access_controller/decision.rs
+++ b/src/access_controller/decision.rs
@@ -1,0 +1,47 @@
+// Copyright (c) 2024 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use std::ops::{BitAnd, BitOr};
+
+use serde::{Deserialize, Serialize};
+
+use super::policy::AccessPolicy;
+
+/// The Decision enum represents the decision of the access controller.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum Decision {
+    Allow,
+    Deny,
+}
+
+impl BitAnd for Decision {
+    type Output = Self;
+
+    fn bitand(self, rhs: Self) -> Self::Output {
+        match (self, rhs) {
+            (Decision::Allow, Decision::Allow) => Decision::Allow,
+            _ => Decision::Deny,
+        }
+    }
+}
+
+impl BitOr for Decision {
+    type Output = Self;
+
+    fn bitor(self, rhs: Self) -> Self::Output {
+        match (self, rhs) {
+            (Decision::Deny, Decision::Deny) => Decision::Deny,
+            _ => Decision::Allow,
+        }
+    }
+}
+
+impl From<AccessPolicy> for Decision {
+    fn from(policy: AccessPolicy) -> Self {
+        match policy {
+            AccessPolicy::AllowAll => Decision::Allow,
+            AccessPolicy::DenyAll => Decision::Deny,
+            AccessPolicy::Disabled => Decision::Allow,
+        }
+    }
+}

--- a/src/access_controller/mod.rs
+++ b/src/access_controller/mod.rs
@@ -19,6 +19,7 @@ use serde::{Deserialize, Serialize};
 #[serde(rename_all = "kebab-case")]
 pub struct AccessController {
     access_policy: AccessPolicy,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
     rules: Vec<AccessRule>,
 }
 

--- a/src/access_controller/mod.rs
+++ b/src/access_controller/mod.rs
@@ -1,0 +1,193 @@
+// Copyright (c) 2024 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! This module implements the access controller for the gas station.
+//! It provides a way to control the constraints for executing transactions, ensuring that only authorized addresses can perform specific actions.
+
+pub mod decision;
+pub mod policy;
+pub mod predicates;
+pub mod rule;
+
+use anyhow::{anyhow, Result};
+use decision::Decision;
+use policy::AccessPolicy;
+use rule::{AccessRule, TransactionDescription};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "kebab-case")]
+pub struct AccessController {
+    access_policy: AccessPolicy,
+    rules: Vec<AccessRule>,
+}
+
+impl AccessController {
+    /// Creates a new instance of the access controller.
+    pub fn new(access_policy: AccessPolicy, rules: impl IntoIterator<Item = AccessRule>) -> Self {
+        Self {
+            access_policy,
+            rules: rules.into_iter().collect(),
+        }
+    }
+
+    /// Checks if the transaction can be executed based on the access controller's rules.
+    pub fn check_access(&self, transaction_description: &TransactionDescription) -> Result<()> {
+        if self.is_disabled() {
+            return Ok(());
+        }
+
+        // In case of allow_all, we looking for the first rule that deny the access
+        if self.access_policy == AccessPolicy::AllowAll {
+            for (i, rule) in self.rules.iter().enumerate() {
+                if rule.check_access(self.access_policy, &transaction_description) == Decision::Deny
+                {
+                    // TODO for security reasons we shouldn't reveal information about the rule that denied the access
+                    return Err(anyhow!("Access denied by rule {}", i));
+                }
+            }
+            return Ok(());
+        }
+        // In case of deny_all, we looking for the first rule that allow the access
+        if self.access_policy == AccessPolicy::DenyAll {
+            for rule in &self.rules {
+                if rule.check_access(self.access_policy, &transaction_description)
+                    == Decision::Allow
+                {
+                    return Ok(());
+                }
+            }
+            return Err(anyhow!("Access denied by policy"));
+        }
+
+        Ok(())
+    }
+
+    /// Adds a new rule to the access controller.
+    pub fn add_rule(&mut self, rule: AccessRule) {
+        self.rules.push(rule);
+    }
+
+    /// Adds multiple rules to the access controller.
+    pub fn add_rules(&mut self, rules: impl IntoIterator<Item = AccessRule>) {
+        self.rules.extend(rules);
+    }
+
+    /// Returns true if the access controller is disabled.
+    pub fn is_disabled(&self) -> bool {
+        self.access_policy == AccessPolicy::Disabled
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use iota_types::base_types::IotaAddress;
+
+    use crate::access_controller::AccessController;
+
+    use super::{
+        policy::AccessPolicy,
+        predicates::ValueNumber,
+        rule::{AccessRuleBuilder, TransactionDescription},
+    };
+
+    #[test]
+    fn test_deny_policy_rules_should_allow() {
+        let sender_address = IotaAddress::new([1; 32]);
+        let blocked_address = IotaAddress::new([2; 32]);
+        let allow_rule = AccessRuleBuilder::new()
+            .sender_address(sender_address)
+            .allow()
+            .build();
+        let allowed_tx = TransactionDescription {
+            sender_address: sender_address.clone(),
+            ..Default::default()
+        };
+        let blocked_tx = TransactionDescription {
+            sender_address: blocked_address.clone(),
+            ..Default::default()
+        };
+
+        let mut ac = AccessController::new(AccessPolicy::DenyAll, []);
+
+        assert!(ac.check_access(&allowed_tx).is_err());
+        assert!(ac.check_access(&blocked_tx).is_err());
+
+        ac.add_rule(allow_rule);
+
+        assert!(ac.check_access(&allowed_tx).is_ok());
+        assert!(ac.check_access(&blocked_tx).is_err());
+    }
+
+    #[test]
+    fn test_allow_policy_rules_should_block() {
+        let blocked_address = IotaAddress::new([1; 32]);
+        let sender_address = IotaAddress::new([2; 32]);
+
+        let deny_rule = AccessRuleBuilder::new()
+            .sender_address(blocked_address)
+            .denied()
+            .build();
+
+        let blocked_transaction_description = TransactionDescription {
+            sender_address: blocked_address.clone(),
+            ..Default::default()
+        };
+        let allowed_transaction_description = TransactionDescription {
+            sender_address: sender_address.clone(),
+            ..Default::default()
+        };
+        let mut ac = AccessController::new(AccessPolicy::AllowAll, []);
+
+        assert!(ac.check_access(&allowed_transaction_description).is_ok());
+        assert!(ac.check_access(&blocked_transaction_description).is_ok());
+
+        ac.add_rule(deny_rule);
+
+        assert!(ac.check_access(&allowed_transaction_description).is_ok());
+        assert!(ac.check_access(&blocked_transaction_description).is_err());
+    }
+
+    #[test]
+    fn test_deny_policy_rules_gas_budget() {
+        let sender_address = IotaAddress::new([1; 32]);
+        let gas_budget = 100;
+        let allow_rule = AccessRuleBuilder::new()
+            .sender_address(sender_address)
+            .gas_budget(ValueNumber::LessThan(gas_budget))
+            .allow()
+            .build();
+        let allowed_tx = TransactionDescription::default()
+            .with_sender_address(sender_address)
+            .with_gas_budget(gas_budget - 1);
+        let blocked_tx = TransactionDescription::default()
+            .with_sender_address(sender_address)
+            .with_gas_budget(gas_budget);
+
+        let ac = AccessController::new(AccessPolicy::DenyAll, [allow_rule]);
+
+        assert!(ac.check_access(&allowed_tx).is_ok());
+        assert!(ac.check_access(&blocked_tx).is_err());
+    }
+
+    #[test]
+    fn test_allow_policy_rules_gas_budget() {
+        let sender_address = IotaAddress::new([1; 32]);
+        let gas_budget = 100;
+        let deny_rule = AccessRuleBuilder::new()
+            .sender_address(sender_address)
+            .gas_budget(ValueNumber::GreaterThanOrEqual(gas_budget))
+            .denied()
+            .build();
+        let allowed_tx = TransactionDescription::default()
+            .with_sender_address(sender_address)
+            .with_gas_budget(gas_budget - 1);
+        let blocked_tx = TransactionDescription::default()
+            .with_sender_address(sender_address)
+            .with_gas_budget(gas_budget);
+
+        let ac = AccessController::new(AccessPolicy::AllowAll, [deny_rule]);
+        assert!(ac.check_access(&allowed_tx).is_ok());
+        assert!(ac.check_access(&blocked_tx).is_err());
+    }
+}

--- a/src/access_controller/mod.rs
+++ b/src/access_controller/mod.rs
@@ -42,7 +42,6 @@ impl AccessController {
             for (i, rule) in self.rules.iter().enumerate() {
                 if rule.check_access(self.access_policy, &transaction_description) == Decision::Deny
                 {
-                    // TODO for security reasons we shouldn't reveal information about the rule that denied the access
                     return Err(anyhow!("Access denied by rule {}", i));
                 }
             }

--- a/src/access_controller/policy.rs
+++ b/src/access_controller/policy.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 
 /// The AccessPolicy enum represents the access policy of the gas station.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, PartialOrd, Eq, Ord, Default)]
-#[serde(untagged, rename_all = "kebab-case")]
+#[serde(rename_all = "kebab-case")]
 pub enum AccessPolicy {
     #[default]
     /// The access controller is disabled, meaning there is no control over the access.
@@ -14,4 +14,30 @@ pub enum AccessPolicy {
     DenyAll,
     /// The access controller is set to allow for all transactions. You create rules to deny a transactions.
     AllowAll,
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn serde_access_policy() {
+        let policy = AccessPolicy::Disabled;
+        let serialized = serde_json::to_string(&policy).unwrap();
+        assert_eq!(serialized, "\"disabled\"");
+        let deserialized: AccessPolicy = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(policy, deserialized);
+
+        let policy = AccessPolicy::DenyAll;
+        let serialized = serde_json::to_string(&policy).unwrap();
+        assert_eq!(serialized, "\"deny-all\"");
+        let deserialized: AccessPolicy = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(policy, deserialized);
+
+        let policy = AccessPolicy::AllowAll;
+        let serialized = serde_json::to_string(&policy).unwrap();
+        assert_eq!(serialized, "\"allow-all\"");
+        let deserialized: AccessPolicy = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(policy, deserialized);
+    }
 }

--- a/src/access_controller/policy.rs
+++ b/src/access_controller/policy.rs
@@ -1,0 +1,17 @@
+// Copyright (c) 2024 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use serde::{Deserialize, Serialize};
+
+/// The AccessPolicy enum represents the access policy of the gas station.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, PartialOrd, Eq, Ord, Default)]
+#[serde(untagged, rename_all = "kebab-case")]
+pub enum AccessPolicy {
+    #[default]
+    /// The access controller is disabled, meaning there is no control over the access.
+    Disabled,
+    /// The access controller is set to deny for all transactions. You create rules to allow a transactions.
+    DenyAll,
+    /// The access controller is set to allow for all transactions. You create rules to deny a transactions.
+    AllowAll,
+}

--- a/src/access_controller/predicates/action.rs
+++ b/src/access_controller/predicates/action.rs
@@ -4,7 +4,7 @@
 use serde::{Deserialize, Serialize};
 
 /// Action enum represents the action of the access controller. It can be either Allow or Deny.
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
 pub enum Action {
     #[default]

--- a/src/access_controller/predicates/action.rs
+++ b/src/access_controller/predicates/action.rs
@@ -1,0 +1,13 @@
+// Copyright (c) 2024 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use serde::{Deserialize, Serialize};
+
+/// Action enum represents the action of the access controller. It can be either Allow or Deny.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "kebab-case")]
+pub enum Action {
+    #[default]
+    Allow,
+    Deny,
+}

--- a/src/access_controller/predicates/iota_address.rs
+++ b/src/access_controller/predicates/iota_address.rs
@@ -1,0 +1,132 @@
+// Copyright (c) 2024 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use iota_types::base_types::IotaAddress;
+use serde::{de::IntoDeserializer, Deserialize, Serialize};
+
+/// The ValueIotaAddress enum represents a single IotaAddress, a list of IotaAddress or all IotaAddress.
+#[derive(Debug, Clone, Default)]
+pub enum ValueIotaAddress {
+    #[default]
+    All,
+    Single(IotaAddress),
+    List(Vec<IotaAddress>),
+}
+
+impl ValueIotaAddress {
+    pub fn new(addresses: impl IntoIterator<Item = IotaAddress>) -> Self {
+        let addresses: Vec<_> = addresses.into_iter().collect();
+        if addresses.is_empty() {
+            ValueIotaAddress::All
+        } else if addresses.len() == 1 {
+            ValueIotaAddress::Single(addresses.into_iter().next().unwrap())
+        } else {
+            ValueIotaAddress::List(addresses)
+        }
+    }
+
+    pub fn includes(&self, address: &IotaAddress) -> bool {
+        match self {
+            ValueIotaAddress::All => true,
+            ValueIotaAddress::Single(single) => single == address,
+            ValueIotaAddress::List(list) => list.contains(address),
+        }
+    }
+}
+
+impl Serialize for ValueIotaAddress {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::ser::Serializer,
+    {
+        match self {
+            ValueIotaAddress::All => serializer.serialize_str("*"),
+            ValueIotaAddress::Single(address) => address.serialize(serializer),
+            ValueIotaAddress::List(addresses) => addresses.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for ValueIotaAddress {
+    fn deserialize<D>(deserializer: D) -> Result<ValueIotaAddress, D::Error>
+    where
+        D: serde::de::Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        if value == "*" {
+            Ok(ValueIotaAddress::All)
+        } else {
+            IotaAddress::deserialize(value.into_deserializer()).map(ValueIotaAddress::Single)
+        }
+    }
+}
+
+impl<K> From<K> for ValueIotaAddress
+where
+    K: IntoIterator<Item = IotaAddress>,
+{
+    fn from(k: K) -> Self {
+        ValueIotaAddress::new(k)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use iota_types::base_types::IotaAddress;
+
+    use super::ValueIotaAddress;
+
+    #[test]
+    fn test_include_from_one() {
+        let iota_address = IotaAddress::new([1; 32]);
+        let iota_address_not_included = IotaAddress::new([2; 32]);
+
+        let value_iota_address = ValueIotaAddress::from([iota_address]);
+
+        assert!(value_iota_address.includes(&iota_address));
+        assert!(!value_iota_address.includes(&iota_address_not_included));
+    }
+
+    #[test]
+    fn test_include_from_many() {
+        let iota_address1 = IotaAddress::new([1; 32]);
+        let iota_address2 = IotaAddress::new([2; 32]);
+        let iota_address_not_included = IotaAddress::new([3; 32]);
+
+        let value_iota_address = ValueIotaAddress::from([iota_address1, iota_address2]);
+
+        assert!(value_iota_address.includes(&iota_address1));
+        assert!(value_iota_address.includes(&iota_address2));
+        assert!(!value_iota_address.includes(&iota_address_not_included));
+    }
+
+    #[test]
+    fn test_serde_one_address() {
+        let iota_address = IotaAddress::new([1; 32]);
+        let value_iota_address = ValueIotaAddress::Single(iota_address);
+        let data = serde_yaml::to_string(&value_iota_address).unwrap();
+        assert_eq!(
+            "0x0101010101010101010101010101010101010101010101010101010101010101\n",
+            data
+        );
+    }
+
+    #[test]
+    fn test_serde_multiple_addresses() {
+        let iota_address = IotaAddress::new([1; 32]);
+        let value_iota_address = ValueIotaAddress::List(vec![iota_address, iota_address]);
+        let data = serde_yaml::to_string(&value_iota_address).unwrap();
+        assert_eq!(
+            "- 0x0101010101010101010101010101010101010101010101010101010101010101
+- 0x0101010101010101010101010101010101010101010101010101010101010101\n",
+            data
+        );
+    }
+
+    #[test]
+    fn test_serde_all_addresses() {
+        let value_iota_address = ValueIotaAddress::All;
+        let data = serde_yaml::to_string(&value_iota_address).unwrap();
+        assert_eq!("'*'\n", data);
+    }
+}

--- a/src/access_controller/predicates/iota_address.rs
+++ b/src/access_controller/predicates/iota_address.rs
@@ -4,7 +4,7 @@
 use iota_types::base_types::IotaAddress;
 use serde::{de::IntoDeserializer, Deserialize, Serialize};
 
-/// The ValueIotaAddress enum represents a single IotaAddress, a list of IotaAddress or all IotaAddress.
+/// The ValueIotaAddress enum represents a single IotaAddress, a list of IotaAddress or all IotaAddresses.
 #[derive(Debug, Clone, Default)]
 pub enum ValueIotaAddress {
     #[default]

--- a/src/access_controller/predicates/mod.rs
+++ b/src/access_controller/predicates/mod.rs
@@ -1,0 +1,9 @@
+// Copyright (c) 2024 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+mod action;
+mod iota_address;
+mod number;
+pub use action::Action;
+pub use iota_address::ValueIotaAddress;
+pub use number::ValueNumber;

--- a/src/access_controller/predicates/number.rs
+++ b/src/access_controller/predicates/number.rs
@@ -10,10 +10,6 @@ pub const OP_NE: &str = "!=";
 pub const OP_GT: &str = ">";
 pub const OP_LT: &str = "<";
 
-// list all supported operators. The order is important, because it is used in the serialization and deserialization.
-// Operators with more characters should be first.
-pub const OPERATORS: [&str; 6] = [OP_GE, OP_LE, OP_EQ, OP_NE, OP_GT, OP_LT];
-
 // The ValueNumber represents the number value in the rule. It can represent a single number or a range of number
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ValueNumber {
@@ -76,6 +72,11 @@ impl<'de> Deserialize<'de> for ValueNumber {
     where
         D: serde::Deserializer<'de>,
     {
+        // The order is important.
+        // Operators with overlapping characters should have the longer operators
+        // first to avoid mix-ups during parsing, e.g. '<=' before '<'.".
+        static OPERATORS: [&str; 6] = [OP_GE, OP_LE, OP_EQ, OP_NE, OP_GT, OP_LT];
+
         let s: &str = Deserialize::deserialize(deserializer)?;
         for operator in OPERATORS.iter() {
             if s.starts_with(operator) {

--- a/src/access_controller/predicates/number.rs
+++ b/src/access_controller/predicates/number.rs
@@ -74,7 +74,7 @@ impl<'de> Deserialize<'de> for ValueNumber {
     {
         // The order is important.
         // Operators with overlapping characters should have the longer operators
-        // first to avoid mix-ups during parsing, e.g. '<=' before '<'.".
+        // first to avoid mix-ups during parsing, e.g. '<=' before '<'.
         static OPERATORS: [&str; 6] = [OP_GE, OP_LE, OP_EQ, OP_NE, OP_GT, OP_LT];
 
         let s: String = Deserialize::deserialize(deserializer)?;

--- a/src/access_controller/predicates/number.rs
+++ b/src/access_controller/predicates/number.rs
@@ -77,7 +77,7 @@ impl<'de> Deserialize<'de> for ValueNumber {
         // first to avoid mix-ups during parsing, e.g. '<=' before '<'.".
         static OPERATORS: [&str; 6] = [OP_GE, OP_LE, OP_EQ, OP_NE, OP_GT, OP_LT];
 
-        let s: &str = Deserialize::deserialize(deserializer)?;
+        let s: String = Deserialize::deserialize(deserializer)?;
         for operator in OPERATORS.iter() {
             if s.starts_with(operator) {
                 let number = s

--- a/src/access_controller/predicates/number.rs
+++ b/src/access_controller/predicates/number.rs
@@ -1,0 +1,190 @@
+// Copyright (c) 2024 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use serde::{Deserialize, Serialize};
+
+pub const OP_GE: &str = ">=";
+pub const OP_LE: &str = "<=";
+pub const OP_EQ: &str = "=";
+pub const OP_NE: &str = "!=";
+pub const OP_GT: &str = ">";
+pub const OP_LT: &str = "<";
+
+// list all supported operators. The order is important, because it is used in the serialization and deserialization.
+// Operators with more characters should be first.
+pub const OPERATORS: [&str; 6] = [OP_GE, OP_LE, OP_EQ, OP_NE, OP_GT, OP_LT];
+
+// The ValueNumber represents the number value in the rule. It can represent a single number or a range of number
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ValueNumber {
+    GreaterThan(u64),
+    LessThan(u64),
+    Equal(u64),
+    NotEqual(u64),
+    GreaterThanOrEqual(u64),
+    LessThanOrEqual(u64),
+}
+
+impl From<u64> for ValueNumber {
+    fn from(value: u64) -> Self {
+        ValueNumber::Equal(value)
+    }
+}
+
+impl ValueNumber {
+    /// Check if the value matches the number.
+    pub fn matches(&self, value: u64) -> bool {
+        match self {
+            ValueNumber::GreaterThan(number) => value > *number,
+            ValueNumber::LessThan(number) => value < *number,
+            ValueNumber::Equal(number) => value == *number,
+            ValueNumber::NotEqual(number) => value != *number,
+            ValueNumber::GreaterThanOrEqual(number) => value >= *number,
+            ValueNumber::LessThanOrEqual(number) => value <= *number,
+        }
+    }
+}
+
+impl Serialize for ValueNumber {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            ValueNumber::GreaterThan(number) => {
+                serializer.serialize_str(&format!("{}{}", OP_GT, number))
+            }
+            ValueNumber::LessThan(number) => {
+                serializer.serialize_str(&format!("{}{}", OP_LT, number))
+            }
+            ValueNumber::Equal(number) => serializer.serialize_str(&format!("{}{}", OP_EQ, number)),
+            ValueNumber::NotEqual(number) => {
+                serializer.serialize_str(&format!("{}{}", OP_NE, number))
+            }
+            ValueNumber::GreaterThanOrEqual(number) => {
+                serializer.serialize_str(&format!("{}{}", OP_GE, number))
+            }
+            ValueNumber::LessThanOrEqual(number) => {
+                serializer.serialize_str(&format!("{}{}", OP_LE, number))
+            }
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for ValueNumber {
+    fn deserialize<D>(deserializer: D) -> Result<ValueNumber, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s: &str = Deserialize::deserialize(deserializer)?;
+        for operator in OPERATORS.iter() {
+            if s.starts_with(operator) {
+                let number = s
+                    .strip_prefix(operator)
+                    .unwrap()
+                    .parse()
+                    .map_err(serde::de::Error::custom)?;
+                match *operator {
+                    OP_GE => return Ok(ValueNumber::GreaterThanOrEqual(number)),
+                    OP_LE => return Ok(ValueNumber::LessThanOrEqual(number)),
+                    OP_EQ => return Ok(ValueNumber::Equal(number)),
+                    OP_NE => return Ok(ValueNumber::NotEqual(number)),
+                    OP_GT => return Ok(ValueNumber::GreaterThan(number)),
+                    OP_LT => return Ok(ValueNumber::LessThan(number)),
+                    _ => return Err(serde::de::Error::custom("Invalid operator")),
+                }
+            }
+        }
+        Err(serde::de::Error::custom("Invalid operator"))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    #[test]
+    fn test_matches() {
+        let number = super::ValueNumber::Equal(42);
+        assert!(number.matches(42));
+        assert!(!number.matches(43));
+
+        let number = super::ValueNumber::NotEqual(42);
+        assert!(!number.matches(42));
+        assert!(number.matches(43));
+
+        let number = super::ValueNumber::GreaterThan(42);
+        assert!(!number.matches(42));
+        assert!(number.matches(43));
+
+        let number = super::ValueNumber::LessThan(42);
+        assert!(number.matches(41));
+        assert!(!number.matches(42));
+
+        let number = super::ValueNumber::GreaterThanOrEqual(42);
+        assert!(number.matches(42));
+        assert!(number.matches(43));
+
+        let number = super::ValueNumber::LessThanOrEqual(42);
+        assert!(number.matches(42));
+        assert!(number.matches(41));
+    }
+
+    #[test]
+    fn test_serialization_eq() {
+        let number = super::ValueNumber::Equal(42);
+        let serialized = serde_json::to_string(&number).unwrap();
+        assert_eq!(serialized, "\"=42\"");
+
+        let deserialized: super::ValueNumber = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(deserialized, number);
+    }
+
+    #[test]
+    fn test_serialization_ne() {
+        let number = super::ValueNumber::NotEqual(42);
+        let serialized = serde_json::to_string(&number).unwrap();
+        assert_eq!(serialized, "\"!=42\"");
+
+        let deserialized: super::ValueNumber = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(deserialized, number);
+    }
+
+    #[test]
+    fn test_serialization_gt() {
+        let number = super::ValueNumber::GreaterThan(42);
+        let serialized = serde_json::to_string(&number).unwrap();
+        assert_eq!(serialized, "\">42\"");
+
+        let deserialized: super::ValueNumber = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(deserialized, number);
+    }
+
+    #[test]
+    fn test_serialization_lt() {
+        let number = super::ValueNumber::LessThan(42);
+        let serialized = serde_json::to_string(&number).unwrap();
+        assert_eq!(serialized, "\"<42\"");
+
+        let deserialized: super::ValueNumber = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(deserialized, number);
+    }
+
+    #[test]
+    fn test_serialization_ge() {
+        let number = super::ValueNumber::GreaterThanOrEqual(42);
+        let serialized = serde_json::to_string(&number).unwrap();
+        assert_eq!(serialized, "\">=42\"");
+
+        let deserialized: super::ValueNumber = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(deserialized, number);
+    }
+
+    #[test]
+    fn test_serialization_le() {
+        let number = super::ValueNumber::LessThanOrEqual(42);
+        let serialized = serde_json::to_string(&number).unwrap();
+        assert_eq!(serialized, "\"<=42\"");
+
+        let deserialized: super::ValueNumber = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(deserialized, number);
+    }
+}

--- a/src/access_controller/rule.rs
+++ b/src/access_controller/rule.rs
@@ -59,7 +59,7 @@ impl AccessRuleBuilder {
     }
 
     pub fn gas_budget(mut self, gas_size: ValueNumber) -> Self {
-        self.rule.gas_budget = Some(gas_size);
+        self.rule.transaction_gas_budget = Some(gas_size);
         self
     }
 }
@@ -69,7 +69,7 @@ impl AccessRuleBuilder {
 #[skip_serializing_none]
 pub struct AccessRule {
     pub sender_address: ValueIotaAddress,
-    pub gas_budget: Option<ValueNumber>,
+    pub transaction_gas_budget: Option<ValueNumber>,
 
     pub action: Action,
 }
@@ -92,7 +92,7 @@ impl AccessRule {
     pub fn rule_matches(&self, data: &TransactionDescription) -> bool {
         self.sender_address.includes(&data.sender_address)
             && self
-                .gas_budget
+                .transaction_gas_budget
                 .map(|size| size.matches(data.transaction_budget))
                 // If the gas size is not defined then the rule matches
                 .unwrap_or(true)

--- a/src/access_controller/rule.rs
+++ b/src/access_controller/rule.rs
@@ -156,18 +156,21 @@ mod test {
             action: Action::Allow,
             ..Default::default()
         };
-        let data_with_valid_sender =
+        let data_with_allowed_sender =
             TransactionDescription::default().with_sender_address(sender_address);
-        let data_with_invalid_sender = TransactionDescription::default();
+        let data_with_denied_sender = TransactionDescription::default();
 
         assert!(
-            rule.check_access(AccessPolicy::DenyAll, &data_with_valid_sender) == Decision::Allow
+            rule.check_access(AccessPolicy::DenyAll, &data_with_allowed_sender) == Decision::Allow
         );
         assert!(
-            rule.check_access(AccessPolicy::DenyAll, &data_with_invalid_sender) == Decision::Deny
+            rule.check_access(AccessPolicy::DenyAll, &data_with_denied_sender) == Decision::Deny
         );
         assert!(
-            rule.check_access(AccessPolicy::AllowAll, &data_with_valid_sender) == Decision::Allow
+            rule.check_access(AccessPolicy::AllowAll, &data_with_allowed_sender) == Decision::Allow
+        );
+        assert!(
+            rule.check_access(AccessPolicy::AllowAll, &data_with_denied_sender) == Decision::Allow
         );
     }
 
@@ -187,7 +190,7 @@ mod test {
             rule.check_access(AccessPolicy::AllowAll, &data_with_valid_sender) == Decision::Deny
         );
         assert!(
-            rule.check_access(AccessPolicy::AllowAll, &data_with_invalid_sender) == Decision::Allow
+            rule.check_access(AccessPolicy::DenyAll, &data_with_valid_sender) == Decision::Deny
         );
         assert!(
             rule.check_access(AccessPolicy::DenyAll, &data_with_invalid_sender) == Decision::Deny

--- a/src/access_controller/rule.rs
+++ b/src/access_controller/rule.rs
@@ -182,21 +182,21 @@ mod test {
             action: Action::Deny,
             ..Default::default()
         };
-        let data_with_valid_sender =
+        let data_with_allowed_sender =
             TransactionDescription::default().with_sender_address(sender_address);
-        let data_with_invalid_sender = TransactionDescription::default();
+        let data_with_denied_sender = TransactionDescription::default();
 
         assert!(
-            rule.check_access(AccessPolicy::AllowAll, &data_with_valid_sender) == Decision::Deny
+            rule.check_access(AccessPolicy::AllowAll, &data_with_allowed_sender) == Decision::Deny
         );
         assert!(
-            rule.check_access(AccessPolicy::DenyAll, &data_with_valid_sender) == Decision::Deny
+            rule.check_access(AccessPolicy::DenyAll, &data_with_allowed_sender) == Decision::Deny
         );
         assert!(
-            rule.check_access(AccessPolicy::DenyAll, &data_with_invalid_sender) == Decision::Deny
+            rule.check_access(AccessPolicy::DenyAll, &data_with_denied_sender) == Decision::Deny
         );
         assert!(
-            rule.check_access(AccessPolicy::DenyAll, &data_with_invalid_sender) == Decision::Deny
+            rule.check_access(AccessPolicy::DenyAll, &data_with_denied_sender) == Decision::Deny
         );
     }
 

--- a/src/access_controller/rule.rs
+++ b/src/access_controller/rule.rs
@@ -1,0 +1,269 @@
+// Copyright (c) 2024 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use iota_types::{
+    base_types::IotaAddress,
+    signature::GenericSignature,
+    transaction::{TransactionData, TransactionDataAPI},
+};
+use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
+
+use super::{
+    decision::Decision,
+    predicates::{Action, ValueIotaAddress, ValueNumber},
+    AccessPolicy,
+};
+
+/// The AccessRuleBuilder is used to build an AccessRule with fluent API.
+pub struct AccessRuleBuilder {
+    rule: AccessRule,
+}
+
+impl AccessRuleBuilder {
+    pub fn new() -> Self {
+        Self {
+            rule: AccessRule::default(),
+        }
+    }
+
+    pub fn build(self) -> AccessRule {
+        self.rule
+    }
+
+    pub fn sender_address(mut self, sender_address: impl Into<IotaAddress>) -> Self {
+        let iota_address = sender_address.into();
+        match &mut self.rule.sender_address {
+            ValueIotaAddress::All => {
+                self.rule.sender_address = ValueIotaAddress::Single(iota_address);
+            }
+            ValueIotaAddress::Single(_) => {
+                self.rule.sender_address = ValueIotaAddress::List(vec![iota_address]);
+            }
+            ValueIotaAddress::List(list) => {
+                list.push(iota_address);
+            }
+        }
+        self
+    }
+
+    /// Sets the action of the AccessRule to allow.
+    pub fn allow(mut self) -> Self {
+        self.rule.action = Action::Allow;
+        self
+    }
+
+    pub fn denied(mut self) -> Self {
+        self.rule.action = Action::Deny;
+        self
+    }
+
+    pub fn gas_budget(mut self, gas_size: ValueNumber) -> Self {
+        self.rule.gas_budget = Some(gas_size);
+        self
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "kebab-case")]
+#[skip_serializing_none]
+pub struct AccessRule {
+    pub sender_address: ValueIotaAddress,
+    pub gas_budget: Option<ValueNumber>,
+
+    pub action: Action,
+}
+
+impl AccessRule {
+    /// Checks if the transaction can be executed based on the access rule and the access policy.
+    pub fn check_access(
+        &self,
+        access_policy: AccessPolicy,
+        data: &TransactionDescription,
+    ) -> Decision {
+        if self.rule_matches(data) {
+            return self.evaluate_access_action(access_policy);
+        }
+
+        return access_policy.into();
+    }
+
+    /// Checks if the rule matches the transaction data.
+    pub fn rule_matches(&self, data: &TransactionDescription) -> bool {
+        self.sender_address.includes(&data.sender_address)
+            && self
+                .gas_budget
+                .map(|size| size.matches(data.transaction_budget))
+                // If the gas size is not defined then the rule matches
+                .unwrap_or(true)
+    }
+
+    /// Evaluates the access action based on the access policy.
+    pub fn evaluate_access_action(&self, _general_policy: AccessPolicy) -> Decision {
+        match self.action {
+            Action::Allow => {
+                return Decision::Allow;
+            }
+            Action::Deny => {
+                return Decision::Deny;
+            }
+        }
+    }
+}
+
+// This input is used to check the access policy.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct TransactionDescription {
+    pub sender_address: IotaAddress,
+    pub transaction_budget: u64,
+}
+
+impl TransactionDescription {
+    pub fn new(_signature: &GenericSignature, transaction_data: &TransactionData) -> Self {
+        Self {
+            sender_address: transaction_data.sender().clone(),
+            transaction_budget: transaction_data.gas_budget(),
+        }
+    }
+
+    pub fn with_sender_address(mut self, sender_address: IotaAddress) -> Self {
+        self.sender_address = sender_address;
+        self
+    }
+
+    pub fn with_gas_budget(mut self, transaction_budget: u64) -> Self {
+        self.transaction_budget = transaction_budget;
+        self
+    }
+}
+
+#[cfg(test)]
+mod test {
+
+    use iota_types::base_types::IotaAddress;
+
+    use crate::access_controller::{
+        policy::AccessPolicy,
+        predicates::ValueNumber,
+        rule::{AccessRule, AccessRuleBuilder, Action, Decision, TransactionDescription},
+    };
+
+    #[test]
+    fn test_constraint_src_address_defined_and_allowed() {
+        let sender_address = IotaAddress::new([1; 32]);
+        let rule = super::AccessRule {
+            sender_address: [sender_address].into(),
+            action: Action::Allow,
+            ..Default::default()
+        };
+        let data_with_valid_sender =
+            TransactionDescription::default().with_sender_address(sender_address);
+        let data_with_invalid_sender = TransactionDescription::default();
+
+        assert!(
+            rule.check_access(AccessPolicy::DenyAll, &data_with_valid_sender) == Decision::Allow
+        );
+        assert!(
+            rule.check_access(AccessPolicy::DenyAll, &data_with_invalid_sender) == Decision::Deny
+        );
+        assert!(
+            rule.check_access(AccessPolicy::AllowAll, &data_with_valid_sender) == Decision::Allow
+        );
+    }
+
+    #[test]
+    fn test_constraint_src_address_defined_and_denied() {
+        let sender_address = IotaAddress::new([1; 32]);
+        let rule = super::AccessRule {
+            sender_address: [sender_address].into(),
+            action: Action::Deny,
+            ..Default::default()
+        };
+        let data_with_valid_sender =
+            TransactionDescription::default().with_sender_address(sender_address);
+        let data_with_invalid_sender = TransactionDescription::default();
+
+        assert!(
+            rule.check_access(AccessPolicy::AllowAll, &data_with_valid_sender) == Decision::Deny
+        );
+        assert!(
+            rule.check_access(AccessPolicy::AllowAll, &data_with_invalid_sender) == Decision::Allow
+        );
+        assert!(
+            rule.check_access(AccessPolicy::DenyAll, &data_with_invalid_sender) == Decision::Deny
+        );
+        assert!(
+            rule.check_access(AccessPolicy::DenyAll, &data_with_invalid_sender) == Decision::Deny
+        );
+    }
+
+    #[test]
+    fn test_constraint_gas_budget() {
+        let gas_limit = 100;
+        let rule_allow = AccessRuleBuilder::new()
+            .gas_budget(ValueNumber::LessThanOrEqual(gas_limit))
+            .allow()
+            .build();
+
+        let rule_deny = AccessRuleBuilder::new()
+            .gas_budget(ValueNumber::GreaterThan(gas_limit))
+            .denied()
+            .build();
+
+        let low_transaction_budget = TransactionDescription::default().with_gas_budget(50);
+        let high_transaction_budget = TransactionDescription::default().with_gas_budget(200);
+
+        assert_eq!(
+            rule_deny.check_access(AccessPolicy::AllowAll, &low_transaction_budget),
+            Decision::Allow
+        );
+        assert_eq!(
+            rule_deny.check_access(AccessPolicy::AllowAll, &high_transaction_budget),
+            Decision::Deny
+        );
+
+        // now when policy is deny
+        assert_eq!(
+            rule_deny.check_access(AccessPolicy::DenyAll, &low_transaction_budget),
+            Decision::Deny
+        );
+        assert_eq!(
+            rule_deny.check_access(AccessPolicy::DenyAll, &high_transaction_budget),
+            Decision::Deny
+        );
+
+        assert_eq!(
+            rule_allow.check_access(AccessPolicy::AllowAll, &low_transaction_budget),
+            Decision::Allow
+        );
+        assert_eq!(
+            rule_allow.check_access(AccessPolicy::AllowAll, &high_transaction_budget),
+            Decision::Allow
+        );
+        assert_eq!(
+            rule_allow.check_access(AccessPolicy::DenyAll, &low_transaction_budget),
+            Decision::Allow
+        );
+        assert_eq!(
+            rule_allow.check_access(AccessPolicy::DenyAll, &high_transaction_budget),
+            Decision::Deny
+        );
+    }
+
+    #[test]
+    fn test_allow_when_deny_all() {
+        let policy = super::AccessPolicy::DenyAll;
+        let sender_address = IotaAddress::new([0; 32]);
+        let input = TransactionDescription::default().with_sender_address(sender_address);
+        let access_rule = AccessRule {
+            sender_address: [sender_address].into(),
+            action: Action::Allow,
+            ..Default::default()
+        };
+
+        assert_eq!(
+            access_rule.check_access(policy, &input),
+            super::Decision::Allow
+        );
+    }
+}

--- a/src/command.rs
+++ b/src/command.rs
@@ -8,6 +8,7 @@ use crate::iota_client::IotaClient;
 use crate::metrics::{GasPoolCoreMetrics, GasPoolRpcMetrics, StorageMetrics};
 use crate::rpc::GasPoolServer;
 use crate::storage::connect_storage;
+use crate::{TRANSACTION_LOGGING_ENV_NAME, TRANSACTION_LOGGING_TARGET_NAME};
 use clap::*;
 use iota_config::Config;
 use std::net::{IpAddr, SocketAddr};
@@ -29,7 +30,6 @@ pub struct Command {
 impl Command {
     pub async fn execute(self) {
         let config: GasStationConfig = GasStationConfig::load(self.config_path).unwrap();
-        print!("Config: {:?}", config);
         let GasStationConfig {
             signer_config,
             gas_pool_config,
@@ -46,17 +46,22 @@ impl Command {
         let metric_address = SocketAddr::new(IpAddr::V4(rpc_host_ip), metrics_port);
         let registry_service = iota_metrics::start_prometheus_server(metric_address);
         let prometheus_registry = registry_service.default_registry();
-        let telemetry_config = telemetry_subscribers::TelemetryConfig::new()
+        let mut telemetry_config = telemetry_subscribers::TelemetryConfig::new()
             .with_log_level("off,iota_gas_station=debug")
             .with_env()
             .with_prom_registry(&prometheus_registry);
-        let _guard = telemetry_config.init();
-        info!("Metrics server started at {:?}", metric_address);
 
+        if std::env::var(TRANSACTION_LOGGING_ENV_NAME) == Ok("true".to_string()) {
+            telemetry_config = telemetry_config.with_trace_target(TRANSACTION_LOGGING_TARGET_NAME);
+        }
+        let _guard = telemetry_config.init();
+
+        info!("Metrics server started at {:?}", metric_address);
         let signer = signer_config.new_signer().await;
         let storage_metrics = StorageMetrics::new(&prometheus_registry);
         let sponsor_address = signer.get_address();
         info!("Sponsor address: {:?}", sponsor_address);
+
         let storage = connect_storage(&gas_pool_config, sponsor_address, storage_metrics).await;
         let iota_client = IotaClient::new(&fullnode_url, fullnode_basic_auth).await;
         let _coin_init_task = if let Some(coin_init_config) = coin_init_config {

--- a/src/command.rs
+++ b/src/command.rs
@@ -12,6 +12,7 @@ use clap::*;
 use iota_config::Config;
 use std::net::{IpAddr, SocketAddr};
 use std::path::PathBuf;
+use std::sync::Arc;
 use tracing::info;
 
 #[derive(Parser)]
@@ -39,6 +40,7 @@ impl Command {
             metrics_port,
             coin_init_config,
             daily_gas_usage_cap,
+            access_controller,
         } = config;
 
         let metric_address = SocketAddr::new(IpAddr::V4(rpc_host_ip), metrics_port);
@@ -81,11 +83,15 @@ impl Command {
         .await;
 
         let rpc_metrics = GasPoolRpcMetrics::new(&prometheus_registry);
+
+        let access_controller = Arc::new(access_controller);
+
         let server = GasPoolServer::new(
             container.get_gas_pool_arc(),
             rpc_host_ip,
             rpc_port,
             rpc_metrics,
+            access_controller,
         )
         .await;
         server.handle.await.unwrap();

--- a/src/command.rs
+++ b/src/command.rs
@@ -55,8 +55,8 @@ impl Command {
             telemetry_config = telemetry_config.with_trace_target(TRANSACTION_LOGGING_TARGET_NAME);
         }
         let _guard = telemetry_config.init();
-
         info!("Metrics server started at {:?}", metric_address);
+
         let signer = signer_config.new_signer().await;
         let storage_metrics = StorageMetrics::new(&prometheus_registry);
         let sponsor_address = signer.get_address();

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::access_controller::AccessController;
 use crate::tx_signer::{SidecarTxSigner, TestTxSigner, TxSigner};
 use iota_config::Config;
 use iota_types::crypto::{get_account_key_pair, IotaKeyPair};
@@ -41,6 +42,8 @@ pub struct GasStationConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub coin_init_config: Option<CoinInitConfig>,
     pub daily_gas_usage_cap: u64,
+    #[serde(default)]
+    pub access_controller: AccessController,
 }
 
 impl Config for GasStationConfig {}
@@ -57,6 +60,7 @@ impl Default for GasStationConfig {
             fullnode_basic_auth: None,
             coin_init_config: Some(CoinInitConfig::default()),
             daily_gas_usage_cap: DEFAULT_DAILY_GAS_USAGE_CAP,
+            access_controller: AccessController::default(),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,16 +1,17 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod access_controller;
 pub mod benchmarks;
 pub mod command;
 pub mod config;
 pub mod errors;
 pub mod gas_pool;
 pub mod gas_pool_initializer;
+pub mod iota_client;
 pub mod metrics;
 pub mod rpc;
 pub mod storage;
-pub mod iota_client;
 #[cfg(test)]
 pub mod test_env;
 pub mod tx_signer;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ pub mod errors;
 pub mod gas_pool;
 pub mod gas_pool_initializer;
 pub mod iota_client;
+pub mod logging;
 pub mod metrics;
 pub mod rpc;
 pub mod storage;
@@ -18,6 +19,8 @@ pub mod tx_signer;
 pub mod types;
 
 pub const AUTH_ENV_NAME: &str = "GAS_STATION_AUTH";
+pub const TRANSACTION_LOGGING_ENV_NAME: &str = "TRANSACTIONS_LOGGING";
+pub const TRANSACTION_LOGGING_TARGET_NAME: &str = "transactions";
 
 pub fn read_auth_env() -> String {
     std::env::var(AUTH_ENV_NAME)

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,0 +1,42 @@
+// Copyright (c) 2024 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use std::fmt::{Display, Formatter};
+
+use serde::Serialize;
+
+#[derive(Debug, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct TxLogMessage<D: Serialize + Clone> {
+    pub timestamp: i64,
+    pub level: String,
+    pub host: String,
+    pub message: String,
+    pub details: D,
+}
+
+impl<D> TxLogMessage<D>
+where
+    D: Serialize + Clone,
+{
+    pub fn new(transaction_effects: D) -> Self {
+        let hostname = hostname::get().unwrap().to_string_lossy().to_string();
+        Self {
+            timestamp: chrono::Utc::now().timestamp(),
+            level: "trace".to_string(),
+            host: hostname,
+            message: "transaction data".to_string(),
+            details: transaction_effects,
+        }
+    }
+}
+
+impl<D> Display for TxLogMessage<D>
+where
+    D: Serialize + Clone,
+{
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let serialized = serde_json::to_string(&self).unwrap();
+        write!(f, "{}", serialized)
+    }
+}

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,8 +1,9 @@
 // Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::fmt::{Display, Formatter};
+use std::fmt::{self, Display, Formatter};
 
+use anyhow::Context;
 use serde::Serialize;
 
 #[derive(Debug, Serialize, Clone)]
@@ -36,7 +37,8 @@ where
     D: Serialize + Clone,
 {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let serialized = serde_json::to_string(&self).unwrap();
+        let serialized =
+            serde_json::to_string(&self).map_err(|e| format!("Serialization error: {}", e))?;
         write!(f, "{}", serialized)
     }
 }

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -3,7 +3,6 @@
 
 use std::fmt::{self, Display, Formatter};
 
-use anyhow::Context;
 use serde::Serialize;
 
 #[derive(Debug, Serialize, Clone)]
@@ -37,8 +36,7 @@ where
     D: Serialize + Clone,
 {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let serialized =
-            serde_json::to_string(&self).map_err(|e| format!("Serialization error: {}", e))?;
+        let serialized = serde_json::to_string(&self).map_err(|_| fmt::Error)?;
         write!(f, "{}", serialized)
     }
 }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -26,6 +26,10 @@ pub struct GasPoolRpcMetrics {
     pub num_authorized_execute_tx_requests: IntCounter,
     pub num_successful_execute_tx_requests: IntCounter,
     pub num_failed_execute_tx_requests: IntCounter,
+
+    /// Access controller metrics
+    pub num_allowed_execute_tx_requests: IntCounter,
+    pub num_blocked_execute_tx_requests: IntCounter,
 }
 
 impl GasPoolRpcMetrics {
@@ -86,6 +90,18 @@ impl GasPoolRpcMetrics {
             num_failed_execute_tx_requests: register_int_counter_with_registry!(
                 "num_failed_execute_tx_requests",
                 "Total number of execute_tx RPC requests that failed",
+                registry,
+            )
+            .unwrap(),
+            num_allowed_execute_tx_requests: register_int_counter_with_registry!(
+                "num_allowed_execute_tx_requests",
+                "Total number execute_tx RPC requests allowed by the Access Controller",
+                registry,
+            )
+            .unwrap(),
+            num_blocked_execute_tx_requests: register_int_counter_with_registry!(
+                "num_blocked_execute_tx_requests",
+                "Total number execute_tx RPC requests blocked by the Access Controller",
                 registry,
             )
             .unwrap(),

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -9,7 +9,10 @@ pub use server::GasPoolServer;
 
 #[cfg(test)]
 mod tests {
-    use crate::test_env::{create_test_transaction, start_rpc_server_for_testing};
+    use crate::test_env::{
+        create_test_transaction, start_rpc_server_for_testing,
+        start_rpc_server_for_testing_with_access_ctrl_deny_all,
+    };
     use crate::AUTH_ENV_NAME;
     use iota_json_rpc_types::IotaTransactionBlockEffectsAPI;
     use iota_types::gas_coin::NANOS_PER_IOTA;
@@ -50,6 +53,31 @@ mod tests {
         // Change the auth secret used in the client.
         std::env::set_var(AUTH_ENV_NAME, "b");
         assert!(client.reserve_gas(NANOS_PER_IOTA, 10).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_access_denied_from_controller() {
+        let (test_cluster, _container, server) =
+            start_rpc_server_for_testing_with_access_ctrl_deny_all(
+                vec![NANOS_PER_IOTA; 10],
+                NANOS_PER_IOTA,
+            )
+            .await;
+        let client = server.get_local_client();
+        client.health().await.unwrap();
+
+        let (sponsor, reservation_id, gas_coins) =
+            client.reserve_gas(NANOS_PER_IOTA, 10).await.unwrap();
+        assert_eq!(gas_coins.len(), 1);
+
+        // We can no longer request all balance given one is loaned out above.
+        assert!(client.reserve_gas(NANOS_PER_IOTA * 10, 10).await.is_err());
+
+        let (tx_data, user_sig) = create_test_transaction(&test_cluster, sponsor, gas_coins).await;
+        assert!(client
+            .execute_tx(reservation_id, &tx_data, &user_sig)
+            .await
+            .is_err());
     }
 
     #[tokio::test]

--- a/src/rpc/server.rs
+++ b/src/rpc/server.rs
@@ -4,6 +4,7 @@
 use crate::access_controller::rule::TransactionDescription;
 use crate::access_controller::AccessController;
 use crate::gas_pool::gas_pool_core::GasPool;
+use crate::logging::TxLogMessage;
 use crate::metrics::GasPoolRpcMetrics;
 use crate::read_auth_env;
 use crate::rpc::client::GasPoolRpcClient;
@@ -25,7 +26,7 @@ use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::task::JoinHandle;
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, trace};
 
 const GIT_REVISION: &str = {
     if let Some(revision) = option_env!("GIT_REVISION") {
@@ -296,6 +297,8 @@ async fn execute_tx_impl(
                 effects.transaction_digest(),
                 effects.status()
             );
+            trace!(target: "transactions", "{}", TxLogMessage::new(&effects));
+
             metrics.num_successful_execute_tx_requests.inc();
             (StatusCode::OK, Json(ExecuteTxResponse::new_ok(effects)))
         }

--- a/src/types.rs
+++ b/src/types.rs
@@ -2,11 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::bail;
+use iota_json_rpc_types::IotaObjectRef;
+use iota_types::base_types::{ObjectID, ObjectRef};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
-use iota_json_rpc_types::IotaObjectRef;
-use iota_types::base_types::{ObjectID, ObjectRef};
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct GasCoin {


### PR DESCRIPTION
Implementation of access controller.

As per the design from #10, the Access controller is implemented only  for `/execute_tx`

The Access Controller introduces the concept of the Access Rule, which is composed according to the Resource Description Framework (RDF). The rule is made from object, predicate, and subject. This construction allows super-flexible extensibility for filtering. 

Rules are processed in the order defined in the configuration file.
Rule specification:

|   object                 |   possible values                                                                                   | mandatory |
|------------------------ | -------------------------------------------------------------------------------------------| --------------- |
| `sender-address`  | `'0x0000000'`, `'[0x00000000, 0x11111111]`, `'*'`                                 | yes             |        
| `transaction-gas-budget`         |  `'=100'`, `'<100'`,  `'<=100'`, `'>100'`, `'>=100'`, `'!=100'` | no               |
| `action`                 | `'allow'`,  `'deny'`                                                                                  | yes              |

Examples of configuration access controller in `config.yaml`:

- deny all, but allow only the sender `0x11111111`

```yaml
access-controller:
   access-policy: deny-all
   rules:
       - sender-address:  0x1111111
         action: 'allow'
```

- allow all, but block only the sender  `0x11111111` 
```yaml
access-controller:
   access-policy: allow-all
   rules:
       - sender-address:  0x11111111
         action: 'deny'
```

- deny all, but allow only the sender `0x11111111` with max gas budget `1000000`

```yaml
access-controller:
   access-policy: deny-all
   rules:
       - sender-address:  0x1111111
          gas-budget: '<1000000'
         action: 'allow'
```

- disable access controller (default) 
```yaml
access-controller:
   access-policy: disabled
```

## Addons:
introduces the `TRANACTIONS_LOGGING` environmental variable. If set, the transaction effects are printed to the default output. This can be parsed by tools like  Elasticsearch or Datadog, to get more detailed insights


close #9 
close #8 
close #17 
close #16 