### PR TITLE
chore: disable test start when PR is in draft mode

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,6 +38,7 @@ env:
 
 jobs:
   test:
+    if: ${{ !github.event.pull_request.draft }}
     name: CI tests
     runs-on: [ubuntu-latest]
     steps:


### PR DESCRIPTION
To reduce resource usage, the PR that is in draft mode won't trigger a test 