### PR TITLE
chore: bump up rust version in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.83-bullseye AS chef
+FROM rust:1.84-bullseye AS chef
 WORKDIR iota
 ARG GIT_REVISION
 ENV GIT_REVISION=$GIT_REVISION


### PR DESCRIPTION
Bump up the version of rust  in DockerFile to `1.84` The version (`1.84`) should be aligned with the  https://github.com/iotaledger/iota 