### PR TITLE
chore: multi-platform docker release

### DIFF
--- a/.github/workflows/publish-to-dockerhub.yml
+++ b/.github/workflows/publish-to-dockerhub.yml
@@ -23,9 +23,32 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        image:
-          - { name: "iota-gas-station", repo: "iotaledger/gas-station" }
-          - { name: "tool", repo: "iotaledger/gas-station-tool" }
+        config:
+          - {
+              binary_name: "iota-gas-station",
+              docker_repo: "atoicafe/gas-station",
+              runner: "ubuntu-latest",
+              platform: "linux/amd64",
+            }
+          - {
+              binary_name: "iota-gas-station",
+              docker_repo: "atoicafe/gas-station",
+              runner: "macos-latest",
+              platform: "linux/arm64/v8",
+            }
+
+          # - {
+          #     binary_name: "tool",
+          #     docker_repo: "atoicafe/gas-station-tool",
+          #     runner: "ubuntu-latest",
+          #     platform: "linux/amd64",
+          #   }
+          # - {
+          #     binary_name: "tool",
+          #     docker_repo: "atoicafe/gas-station-tool",
+          #     runner: "macos-latest",
+          #     platform: "linux/arm64/v8",
+          #   }
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4
@@ -38,22 +61,93 @@ jobs:
           username: ${{ secrets.IOTALEDGER_DOCKER_USERNAME }}
           password: ${{ secrets.IOTALEDGER_DOCKER_PASSWORD }}
 
-      - name: Build image with build.sh
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3.7.1
+
+      - name: Local Image Names
+        id: names
+        run: |
+          echo "local_image=${{ matrix.config.binary_name }}-${{ matrix.config.runner }}" >> $GITHUB_OUTPUT
+          echo "ext_image=${{ matrix.config.docker_repo }}:${{ github.event.inputs.tag }}" >> $GITHUB_OUTPUT
+
+      - name: Build docker image (DRY-RUN) ${{ matrix.config.docker_repo }} - ${{ matrix.config.platform }}
+        if: ${{ github.event.inputs.is-dry-run == 'true' }}
         run: |
           chmod +x docker/build.sh
-          ENTRY_BINARY=${{ matrix.image.name }} docker/build.sh -t ${{ matrix.image.repo }}:${{ github.event.inputs.tag }}
+          ENTRY_BINARY=${{ matrix.config.binary_name }} docker/build.sh \
+          -t ${{ steps.names.outputs.ext_image }}  \
+          --platform ${{ matrix.config.platform }}
 
-      - name: Push docker image
-        if: ${{ github.event.inputs.is-dry-run != 'true' }}
+      - name: Build & Push docker image Build docker image ${{ matrix.config.docker_repo }} - ${{ matrix.config.platform }}
+        if: ${{ github.event.inputs.is-dry-run == 'false' }}
+        id: build-push-image
         run: |
-          docker push ${{ matrix.image.repo }}:${{ github.event.inputs.tag }}
+          chmod +x docker/build.sh
+          ENTRY_BINARY=${{ matrix.config.binary_name }} docker/build.sh \
+          --platform ${{ matrix.config.platform }} \
+          --output type=image,"name=${{ matrix.config.docker_repo }}",push-by-digest=true,name-canonical=true,push=true \
+          --iidfile docker.id
 
-      # - name: Docker Hub Description for ${{ matrix.image.repo }}
-      #   if: ${{ github.event.inputs.is-dry-run  == 'false'}}
-      #   uses: peter-evans/dockerhub-description@e98e4d1628a5f3be2be7c231e50981aee98723ae
-      #   with:
-      #     username: ${{ secrets.IOTALEDGER_DOCKER_USERNAME }}
-      #     password: ${{ secrets.IOTALEDGER_DOCKER_PASSWORD }}
-      #     repository: ${{ matrix.image.repo }}
-      #     readme-filepath: ./README.md
-      #     short-description: ${{ github.event.repository.description }}
+          DOCKER_ID=$(cat docker.id)
+          DIGEST=$(docker manifest inspect ${{ matrix.config.docker_repo }}@${DOCKER_ID} | jq -r '.manifests[0].digest')
+          echo "Obtained the docker image $DIGEST"
+          echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
+
+      - name: Export digest
+        if: ${{ github.event.inputs.is-dry-run == 'false' }}
+        run: |
+          mkdir -p ${{ runner.temp }}/digests/${{ github.sha }}
+          digest="${{ steps.build-push-image.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${{ github.sha}}/${digest#sha256:}"
+
+      - name: Upload digest
+        if: ${{ steps.build-push-image.outputs.digest != '' }}
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        with:
+          name: digests-${{ github.sha }}-${{ matrix.config.binary_name }}-${{ matrix.config.runner }}
+          path: ${{ runner.temp }}/digests/${{ github.sha }}/*
+          if-no-files-found: error
+          retention-days: 1
+
+  push-index:
+    if: ${{ github.event.inputs.is-dry-run == 'false' }}
+    environment: release
+    needs: push_to_registry
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        config:
+          - {
+              binary_name: "iota-gas-station",
+              docker_repo: "atoicafe/gas-station",
+            }
+          # - { binary_name: "tool", docker_repo: "atoicafe/gas-station-tool" }
+
+    steps:
+      - name: Login to Docker Registry
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          username: ${{ secrets.IOTALEDGER_DOCKER_USERNAME }}
+          password: ${{ secrets.IOTALEDGER_DOCKER_PASSWORD }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3.7.1
+
+      - name: Download digests
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-${{ github.sha }}-${{ matrix.config.binary_name }}-*
+          merge-multiple: true
+
+      - name: Push multi-platform index
+        run: |
+          cmd="docker buildx imagetools create --tag ${{ matrix.config.docker_repo }}:${{ github.event.inputs.tag }}"
+          for file in ${{ runner.temp }}/digests/*; do
+            # Extract the filename (which is the hash).
+            hash=$(basename "$file")
+            # Append the amend option for the current hash.
+            cmd+="  ${{ matrix.config.docker_repo }}@sha256:$hash"
+          done
+          echo -e "$cmd"
+          eval "$cmd"

--- a/.github/workflows/publish-to-dockerhub.yml
+++ b/.github/workflows/publish-to-dockerhub.yml
@@ -73,7 +73,6 @@ jobs:
       - name: Build docker image (DRY-RUN) ${{ matrix.config.docker_repo }} - ${{ matrix.config.platform }}
         if: ${{ github.event.inputs.is-dry-run == 'true' }}
         run: |
-          chmod +x docker/build.sh
           ENTRY_BINARY=${{ matrix.config.binary_name }} docker/build.sh \
           -t ${{ steps.names.outputs.ext_image }}  \
           --platform ${{ matrix.config.platform }}
@@ -82,7 +81,6 @@ jobs:
         if: ${{ github.event.inputs.is-dry-run == 'false' }}
         id: build-push-image
         run: |
-          chmod +x docker/build.sh
           ENTRY_BINARY=${{ matrix.config.binary_name }} docker/build.sh \
           --platform ${{ matrix.config.platform }} \
           --output type=image,"name=${{ matrix.config.docker_repo }}",push-by-digest=true,name-canonical=true,push=true \

--- a/.github/workflows/publish-to-dockerhub.yml
+++ b/.github/workflows/publish-to-dockerhub.yml
@@ -26,29 +26,29 @@ jobs:
         config:
           - {
               binary_name: "iota-gas-station",
-              docker_repo: "atoicafe/gas-station",
+              docker_repo: "iotaledger/gas-station",
               runner: "ubuntu-latest",
               platform: "linux/amd64",
             }
           - {
               binary_name: "iota-gas-station",
-              docker_repo: "atoicafe/gas-station",
+              docker_repo: "iotaledger/gas-station",
               runner: "macos-latest",
               platform: "linux/arm64/v8",
             }
 
-          # - {
-          #     binary_name: "tool",
-          #     docker_repo: "atoicafe/gas-station-tool",
-          #     runner: "ubuntu-latest",
-          #     platform: "linux/amd64",
-          #   }
-          # - {
-          #     binary_name: "tool",
-          #     docker_repo: "atoicafe/gas-station-tool",
-          #     runner: "macos-latest",
-          #     platform: "linux/arm64/v8",
-          #   }
+          - {
+              binary_name: "tool",
+              docker_repo: "iotaledger/gas-station-tool",
+              runner: "ubuntu-latest",
+              platform: "linux/amd64",
+            }
+          - {
+              binary_name: "tool",
+              docker_repo: "iotaledger/gas-station-tool",
+              runner: "macos-latest",
+              platform: "linux/arm64/v8",
+            }
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4
@@ -119,9 +119,9 @@ jobs:
         config:
           - {
               binary_name: "iota-gas-station",
-              docker_repo: "atoicafe/gas-station",
+              docker_repo: "iotaledger/gas-station",
             }
-          # - { binary_name: "tool", docker_repo: "atoicafe/gas-station-tool" }
+          - { binary_name: "tool", docker_repo: "iotaledger/gas-station-tool" }
 
     steps:
       - name: Login to Docker Registry

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1815,7 +1815,7 @@ name = "consensus-config"
 version = "0.1.0"
 source = "git+https://github.com/iotaledger/iota#f95b361b0e662e9ea367aac9e0323769d0d786bc"
 dependencies = [
- "fastcrypto 0.1.8",
+ "fastcrypto",
  "iota-network-stack",
  "rand 0.8.5",
  "serde",
@@ -1837,7 +1837,7 @@ dependencies = [
  "consensus-config",
  "dashmap",
  "enum_dispatch",
- "fastcrypto 0.1.8",
+ "fastcrypto",
  "futures",
  "http 1.2.0",
  "hyper 1.5.2",
@@ -3116,57 +3116,7 @@ dependencies = [
  "ecdsa",
  "ed25519-consensus",
  "elliptic-curve",
- "fastcrypto-derive 0.1.3 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
- "generic-array",
- "hex",
- "hex-literal",
- "hkdf",
- "lazy_static",
- "num-bigint 0.4.6",
- "once_cell",
- "p256",
- "rand 0.8.5",
- "readonly",
- "rfc6979",
- "rsa",
- "schemars",
- "secp256k1",
- "serde",
- "serde_json",
- "serde_with",
- "sha2 0.10.8",
- "sha3 0.10.8",
- "signature 2.2.0",
- "static_assertions",
- "thiserror 1.0.69",
- "tokio",
- "typenum",
- "zeroize",
-]
-
-[[package]]
-name = "fastcrypto"
-version = "0.1.9"
-source = "git+https://github.com/MystenLabs/fastcrypto#0acf0ff1a163c60e0dec1e16e4fbad4a4cf853bd"
-dependencies = [
- "ark-ec",
- "ark-ff",
- "ark-secp256r1",
- "ark-serialize",
- "auto_ops",
- "base64ct",
- "bech32",
- "bincode",
- "blake2",
- "blst",
- "bs58 0.4.0",
- "curve25519-dalek-ng",
- "derive_more 0.99.18",
- "digest 0.10.7",
- "ecdsa",
- "ed25519-consensus",
- "elliptic-curve",
- "fastcrypto-derive 0.1.3 (git+https://github.com/MystenLabs/fastcrypto)",
+ "fastcrypto-derive",
  "generic-array",
  "hex",
  "hex-literal",
@@ -3198,15 +3148,6 @@ dependencies = [
 name = "fastcrypto-derive"
 version = "0.1.3"
 source = "git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597#5f2c63266a065996d53f98156f0412782b468597"
-dependencies = [
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "fastcrypto-derive"
-version = "0.1.3"
-source = "git+https://github.com/MystenLabs/fastcrypto#0acf0ff1a163c60e0dec1e16e4fbad4a4cf853bd"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -3219,7 +3160,7 @@ source = "git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f9
 dependencies = [
  "bcs",
  "digest 0.10.7",
- "fastcrypto 0.1.8",
+ "fastcrypto",
  "hex",
  "itertools 0.10.5",
  "rand 0.8.5",
@@ -3237,7 +3178,7 @@ version = "0.1.0"
 source = "git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597#5f2c63266a065996d53f98156f0412782b468597"
 dependencies = [
  "bcs",
- "fastcrypto 0.1.8",
+ "fastcrypto",
  "lazy_static",
  "num-bigint 0.4.6",
  "num-integer",
@@ -3264,7 +3205,7 @@ dependencies = [
  "blst",
  "byte-slice-cast",
  "derive_more 0.99.18",
- "fastcrypto 0.1.8",
+ "fastcrypto",
  "ff",
  "im",
  "itertools 0.12.1",
@@ -4557,7 +4498,7 @@ dependencies = [
  "anyhow",
  "byteorder",
  "bytes",
- "fastcrypto 0.1.8",
+ "fastcrypto",
  "futures",
  "indicatif",
  "iota-config",
@@ -4602,7 +4543,7 @@ dependencies = [
  "enum_dispatch",
  "ethers",
  "eyre",
- "fastcrypto 0.1.8",
+ "fastcrypto",
  "futures",
  "iota-authority-aggregation",
  "iota-config",
@@ -4656,7 +4597,7 @@ dependencies = [
  "consensus-config",
  "csv",
  "dirs 5.0.1",
- "fastcrypto 0.1.8",
+ "fastcrypto",
  "iota-genesis-common",
  "iota-keys",
  "iota-protocol-config",
@@ -4692,7 +4633,7 @@ dependencies = [
  "either",
  "enum_dispatch",
  "eyre",
- "fastcrypto 0.1.8",
+ "fastcrypto",
  "fastcrypto-tbls",
  "fastcrypto-zkp",
  "futures",
@@ -4849,7 +4790,7 @@ dependencies = [
 
 [[package]]
 name = "iota-gas-station"
-version = "0.4.0"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4859,7 +4800,7 @@ dependencies = [
  "clap",
  "const-str",
  "eyre",
- "fastcrypto 0.1.9",
+ "fastcrypto",
  "futures-util",
  "git-version",
  "hostname",
@@ -4903,7 +4844,7 @@ dependencies = [
  "camino",
  "clap",
  "csv",
- "fastcrypto 0.1.8",
+ "fastcrypto",
  "flate2",
  "fs_extra",
  "iota-adapter-latest",
@@ -4963,7 +4904,7 @@ source = "git+https://github.com/iotaledger/iota#f95b361b0e662e9ea367aac9e032376
 dependencies = [
  "anyhow",
  "bcs",
- "fastcrypto 0.1.8",
+ "fastcrypto",
  "iota-types",
  "move-binary-format",
  "move-bytecode-utils",
@@ -4986,7 +4927,7 @@ dependencies = [
  "bcs",
  "cached",
  "eyre",
- "fastcrypto 0.1.8",
+ "fastcrypto",
  "futures",
  "http-body 1.0.1",
  "hyper 1.5.2",
@@ -5032,7 +4973,7 @@ version = "0.10.0-alpha"
 source = "git+https://github.com/iotaledger/iota#f95b361b0e662e9ea367aac9e0323769d0d786bc"
 dependencies = [
  "anyhow",
- "fastcrypto 0.1.8",
+ "fastcrypto",
  "iota-json",
  "iota-json-rpc-types",
  "iota-metrics",
@@ -5055,7 +4996,7 @@ dependencies = [
  "bcs",
  "colored",
  "enum_dispatch",
- "fastcrypto 0.1.8",
+ "fastcrypto",
  "iota-enum-compat-util",
  "iota-json",
  "iota-macros",
@@ -5083,7 +5024,7 @@ source = "git+https://github.com/iotaledger/iota#f95b361b0e662e9ea367aac9e032376
 dependencies = [
  "anyhow",
  "bip32",
- "fastcrypto 0.1.8",
+ "fastcrypto",
  "iota-types",
  "rand 0.8.5",
  "regex",
@@ -5136,7 +5077,7 @@ version = "0.10.0-alpha"
 source = "git+https://github.com/iotaledger/iota#f95b361b0e662e9ea367aac9e0323769d0d786bc"
 dependencies = [
  "anyhow",
- "fastcrypto 0.1.8",
+ "fastcrypto",
  "iota-package-management",
  "iota-protocol-config",
  "iota-types",
@@ -5161,7 +5102,7 @@ source = "git+https://github.com/iotaledger/iota#f95b361b0e662e9ea367aac9e032376
 dependencies = [
  "bcs",
  "better_any",
- "fastcrypto 0.1.8",
+ "fastcrypto",
  "fastcrypto-vdf",
  "fastcrypto-zkp",
  "indexmap 2.7.1",
@@ -5190,7 +5131,7 @@ dependencies = [
  "bcs",
  "bytes",
  "dashmap",
- "fastcrypto 0.1.8",
+ "fastcrypto",
  "fastcrypto-tbls",
  "futures",
  "governor",
@@ -5251,7 +5192,7 @@ dependencies = [
  "bin-version",
  "clap",
  "const-str",
- "fastcrypto 0.1.8",
+ "fastcrypto",
  "fastcrypto-zkp",
  "futures",
  "git-version",
@@ -5389,7 +5330,7 @@ dependencies = [
  "async-trait",
  "axum 0.7.9",
  "bcs",
- "fastcrypto 0.1.8",
+ "fastcrypto",
  "iota-network-stack",
  "iota-protocol-config",
  "iota-rust-sdk",
@@ -5442,7 +5383,7 @@ dependencies = [
  "bcs",
  "clap",
  "colored",
- "fastcrypto 0.1.8",
+ "fastcrypto",
  "futures",
  "futures-core",
  "getset",
@@ -5506,7 +5447,7 @@ dependencies = [
  "anemo",
  "anemo-tower",
  "bcs",
- "fastcrypto 0.1.8",
+ "fastcrypto",
  "iota-framework",
  "iota-move-build",
  "iota-types",
@@ -5530,7 +5471,7 @@ dependencies = [
  "bcs",
  "byteorder",
  "bytes",
- "fastcrypto 0.1.8",
+ "fastcrypto",
  "futures",
  "indicatif",
  "integer-encoding",
@@ -5565,7 +5506,7 @@ dependencies = [
  "chrono",
  "clap",
  "eyre",
- "fastcrypto 0.1.8",
+ "fastcrypto",
  "futures",
  "hyper 1.5.2",
  "hyper-rustls 0.27.5",
@@ -5635,7 +5576,7 @@ dependencies = [
  "anemo",
  "anyhow",
  "bcs",
- "fastcrypto 0.1.8",
+ "fastcrypto",
  "iota-config",
  "iota-genesis-builder",
  "iota-macros",
@@ -5676,7 +5617,7 @@ dependencies = [
  "axum 0.7.9",
  "axum-server",
  "ed25519 2.2.3",
- "fastcrypto 0.1.8",
+ "fastcrypto",
  "pkcs8 0.10.2",
  "rcgen",
  "reqwest 0.12.12",
@@ -5737,7 +5678,7 @@ dependencies = [
  "derive_more 1.0.0",
  "enum_dispatch",
  "eyre",
- "fastcrypto 0.1.8",
+ "fastcrypto",
  "fastcrypto-tbls",
  "fastcrypto-zkp",
  "hex",
@@ -9831,7 +9772,7 @@ source = "git+https://github.com/iotaledger/iota#f95b361b0e662e9ea367aac9e032376
 dependencies = [
  "bcs",
  "eyre",
- "fastcrypto 0.1.8",
+ "fastcrypto",
  "serde",
  "serde_repr",
 ]
@@ -10504,7 +10445,7 @@ source = "git+https://github.com/iotaledger/iota#f95b361b0e662e9ea367aac9e032376
 dependencies = [
  "anyhow",
  "bcs",
- "fastcrypto 0.1.8",
+ "fastcrypto",
  "fastcrypto-zkp",
  "futures",
  "iota-bridge",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "iota-gas-station"
-version = "0.4.0"
+version = "0.1.0"
 edition = "2021"
-authors = ["Mysten Labs <build@mystenlabs.com>"]
+authors = ["Mysten Labs <build@mystenlabs.com>", "IOTA Stiftung"]
 license = "Apache-2.0"
-repository = "https://github.com/iotaledger/iota-gas-station"
+repository = "https://github.com/iotaledger/gas-station"
 
 [dependencies]
 
-fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto" }
+fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "5f2c63266a065996d53f98156f0412782b468597" }
 
 iota-metrics = { git = "https://github.com/iotaledger/iota", version = "0.10.0-alpha", package = "iota-metrics" }
 iota-config = { git = "https://github.com/iotaledger/iota", version = "0.10.0-alpha", package = "iota-config" }

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Your Gas Station instance should now be running and accessible via its [HTTP API
 
 ### Build prerequisites
 
-- [Rust 1.84](https://www.rust-lang.org/tools/install)
+- [Rust 1.85](https://www.rust-lang.org/tools/install)
 
 ### Build
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,17 +1,29 @@
-FROM rust:1.84-bullseye AS chef
-WORKDIR iota
+FROM --platform=$BUILDPLATFORM  rust:1.84-bullseye AS chef
+
+WORKDIR /iota
+
 ARG GIT_REVISION
 ENV GIT_REVISION=$GIT_REVISION
-RUN apt-get update && apt-get install -y cmake clang
+
+# This is a workaround for the following the issue related to the libc-bin package
+RUN rm /var/lib/dpkg/info/libc-bin.*
+
+RUN apt-get clean
+RUN apt-get update && apt-get install -y cmake clang lld
+
 
 # Build and cache all dependencies.
 FROM chef AS builder
-WORKDIR /
+WORKDIR /iota
+
+# Configure Rust to use clang and lld as the linker
+RUN mkdir -p ./.cargo && \
+  echo "[target.x86_64-unknown-linux-gnu]\nlinker = \"clang\"\nrustflags = [\"-C\", \"link-arg=-fuse-ld=lld\"]" > ./.cargo/config.toml
+
 COPY Cargo.toml ./
 COPY src ./src
-RUN cargo build --release
 
-ARG ENTRY_BINARY=iota-gas-station
+RUN cargo build --release
 
 
 # Production Image
@@ -19,7 +31,7 @@ FROM debian:bullseye-slim AS runtime
 RUN apt-get update && apt-get install -y libjemalloc-dev ca-certificates
 
 ARG ENTRY_BINARY=iota-gas-station
-COPY --from=builder /target/release/${ENTRY_BINARY} /usr/local/bin/entrypoint
+COPY --from=builder /iota/target/release/${ENTRY_BINARY} /usr/local/bin/entrypoint
 
 ARG BUILD_DATE
 ARG GIT_REVISION

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM  rust:1.84-bullseye AS chef
+FROM --platform=$BUILDPLATFORM  rust:1.85-bullseye AS chef
 
 WORKDIR /iota
 

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -22,7 +22,7 @@ echo "git revision: \t$GIT_REVISION"
 echo "binary: \t$ENTRY_BINARY"
 echo
 
-docker build -f "$DOCKERFILE" "$REPO_ROOT" \
+docker buildx build -f "$DOCKERFILE" "$REPO_ROOT" \
 	--build-arg GIT_REVISION="$GIT_REVISION" \
 	--build-arg BUILD_DATE="$BUILD_DATE" \
 	--build-arg ENTRY_BINARY="$ENTRY_BINARY" \

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.84"
+channel = "1.85"

--- a/utils/gas-station.sh
+++ b/utils/gas-station.sh
@@ -1,6 +1,7 @@
 #!/bin/env bash
 
-IMAGE_NAME="iotaledger/gas-station:latest"
+# IMAGE_NAME="iotaledger/gas-station:latest"
+IMAGE_NAME="atoicafe/gas-station:latest"
 
 docker run --init -it --rm \
       --name iota-gas-station \

--- a/utils/gas-station.sh
+++ b/utils/gas-station.sh
@@ -6,6 +6,7 @@ docker run --init -it --rm \
       --name iota-gas-station \
       --network host \
       -v $(pwd):/app \
-      -w /app -u $(id -u):$(id -g) \
+      -w /app \
+      -u $(id -u):$(id -g) \
       -e GAS_STATION_AUTH="$GAS_STATION_AUTH" \
       ${IMAGE_NAME} "$@"

--- a/utils/gas-station.sh
+++ b/utils/gas-station.sh
@@ -1,7 +1,6 @@
 #!/bin/env bash
 
-# IMAGE_NAME="iotaledger/gas-station:latest"
-IMAGE_NAME="atoicafe/gas-station:latest"
+IMAGE_NAME="iotaledger/gas-station:latest"
 
 docker run --init -it --rm \
       --name iota-gas-station \


### PR DESCRIPTION
##  Description
This pull request introduces multi-platform releases for Docker images. The workflow uses two separate runners—macOS and Ubuntu—to build each binary individually from the matrix. The resulting Docker images are pushed by their respective digests, which are ultimately combined into a single multi-platform index.

Validated on the other repo:

![image](https://github.com/user-attachments/assets/15b49cbb-f77a-4511-936f-cb59767ae7dc)


closes #53 