### PR TITLE
chore: bump up the iota sdk to 0.11.0-alpha

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -172,7 +172,7 @@ dependencies = [
  "tap",
  "thiserror 1.0.69",
  "tokio",
- "tokio-util 0.7.13",
+ "tokio-util 0.7.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower 0.4.13",
  "tracing",
  "x509-parser",
@@ -1066,8 +1066,8 @@ dependencies = [
 
 [[package]]
 name = "bin-version"
-version = "0.10.0-alpha"
-source = "git+https://github.com/iotaledger/iota#f95b361b0e662e9ea367aac9e0323769d0d786bc"
+version = "0.11.0-alpha"
+source = "git+https://github.com/iotaledger/iota#5d86d45197849842100c1b34245ace3268bc01f6"
 dependencies = [
  "const-str",
  "git-version",
@@ -1798,7 +1798,7 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "tokio",
- "tokio-util 0.7.13",
+ "tokio-util 0.7.13 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1813,7 +1813,7 @@ dependencies = [
 [[package]]
 name = "consensus-config"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#f95b361b0e662e9ea367aac9e0323769d0d786bc"
+source = "git+https://github.com/iotaledger/iota#5d86d45197849842100c1b34245ace3268bc01f6"
 dependencies = [
  "fastcrypto",
  "iota-network-stack",
@@ -1825,7 +1825,7 @@ dependencies = [
 [[package]]
 name = "consensus-core"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#f95b361b0e662e9ea367aac9e0323769d0d786bc"
+source = "git+https://github.com/iotaledger/iota#5d86d45197849842100c1b34245ace3268bc01f6"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1865,9 +1865,10 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.1",
  "tokio-stream",
- "tokio-util 0.7.13",
+ "tokio-util 0.7.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "tonic",
  "tonic-build",
+ "tonic-rustls",
  "tower 0.4.13",
  "tower-http",
  "tracing",
@@ -2390,12 +2391,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "difference"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
-
-[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2675,7 +2670,7 @@ dependencies = [
 [[package]]
 name = "enum-compat-util"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#f95b361b0e662e9ea367aac9e0323769d0d786bc"
+source = "git+https://github.com/iotaledger/iota#5d86d45197849842100c1b34245ace3268bc01f6"
 dependencies = [
  "serde_yaml 0.8.26",
 ]
@@ -3748,7 +3743,7 @@ dependencies = [
  "indexmap 2.7.1",
  "slab",
  "tokio",
- "tokio-util 0.7.13",
+ "tokio-util 0.7.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing",
 ]
 
@@ -3767,7 +3762,7 @@ dependencies = [
  "indexmap 2.7.1",
  "slab",
  "tokio",
- "tokio-util 0.7.13",
+ "tokio-util 0.7.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing",
 ]
 
@@ -4045,7 +4040,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.10",
+ "socket2 0.5.8",
  "tokio",
  "tower-service",
  "tracing",
@@ -4465,7 +4460,7 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 [[package]]
 name = "iota-adapter-latest"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#f95b361b0e662e9ea367aac9e0323769d0d786bc"
+source = "git+https://github.com/iotaledger/iota#5d86d45197849842100c1b34245ace3268bc01f6"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4492,8 +4487,8 @@ dependencies = [
 
 [[package]]
 name = "iota-archival"
-version = "0.10.0-alpha"
-source = "git+https://github.com/iotaledger/iota#f95b361b0e662e9ea367aac9e0323769d0d786bc"
+version = "0.11.0-alpha"
+source = "git+https://github.com/iotaledger/iota#5d86d45197849842100c1b34245ace3268bc01f6"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -4517,8 +4512,8 @@ dependencies = [
 
 [[package]]
 name = "iota-authority-aggregation"
-version = "0.10.0-alpha"
-source = "git+https://github.com/iotaledger/iota#f95b361b0e662e9ea367aac9e0323769d0d786bc"
+version = "0.11.0-alpha"
+source = "git+https://github.com/iotaledger/iota#5d86d45197849842100c1b34245ace3268bc01f6"
 dependencies = [
  "futures",
  "iota-metrics",
@@ -4529,8 +4524,8 @@ dependencies = [
 
 [[package]]
 name = "iota-bridge"
-version = "0.10.0-alpha"
-source = "git+https://github.com/iotaledger/iota#f95b361b0e662e9ea367aac9e0323769d0d786bc"
+version = "0.11.0-alpha"
+source = "git+https://github.com/iotaledger/iota#5d86d45197849842100c1b34245ace3268bc01f6"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4551,7 +4546,7 @@ dependencies = [
  "iota-json-rpc-types",
  "iota-keys",
  "iota-metrics",
- "iota-sdk 0.10.0-alpha",
+ "iota-sdk 0.11.0-alpha",
  "iota-test-transaction-builder",
  "iota-types",
  "lru",
@@ -4576,8 +4571,8 @@ dependencies = [
 
 [[package]]
 name = "iota-common"
-version = "0.10.0-alpha"
-source = "git+https://github.com/iotaledger/iota#f95b361b0e662e9ea367aac9e0323769d0d786bc"
+version = "0.11.0-alpha"
+source = "git+https://github.com/iotaledger/iota#5d86d45197849842100c1b34245ace3268bc01f6"
 dependencies = [
  "futures",
  "parking_lot 0.12.3",
@@ -4587,8 +4582,8 @@ dependencies = [
 
 [[package]]
 name = "iota-config"
-version = "0.10.0-alpha"
-source = "git+https://github.com/iotaledger/iota#f95b361b0e662e9ea367aac9e0323769d0d786bc"
+version = "0.11.0-alpha"
+source = "git+https://github.com/iotaledger/iota#5d86d45197849842100c1b34245ace3268bc01f6"
 dependencies = [
  "anemo",
  "anyhow",
@@ -4614,8 +4609,8 @@ dependencies = [
 
 [[package]]
 name = "iota-core"
-version = "0.10.0-alpha"
-source = "git+https://github.com/iotaledger/iota#f95b361b0e662e9ea367aac9e0323769d0d786bc"
+version = "0.11.0-alpha"
+source = "git+https://github.com/iotaledger/iota#5d86d45197849842100c1b34245ace3268bc01f6"
 dependencies = [
  "anemo",
  "anyhow",
@@ -4736,8 +4731,8 @@ dependencies = [
 
 [[package]]
 name = "iota-enum-compat-util"
-version = "0.10.0-alpha"
-source = "git+https://github.com/iotaledger/iota#f95b361b0e662e9ea367aac9e0323769d0d786bc"
+version = "0.11.0-alpha"
+source = "git+https://github.com/iotaledger/iota#5d86d45197849842100c1b34245ace3268bc01f6"
 dependencies = [
  "serde_yaml 0.8.26",
 ]
@@ -4745,7 +4740,7 @@ dependencies = [
 [[package]]
 name = "iota-execution"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#f95b361b0e662e9ea367aac9e0323769d0d786bc"
+source = "git+https://github.com/iotaledger/iota#5d86d45197849842100c1b34245ace3268bc01f6"
 dependencies = [
  "iota-adapter-latest",
  "iota-move-natives-latest",
@@ -4761,8 +4756,8 @@ dependencies = [
 
 [[package]]
 name = "iota-framework"
-version = "0.10.0-alpha"
-source = "git+https://github.com/iotaledger/iota#f95b361b0e662e9ea367aac9e0323769d0d786bc"
+version = "0.11.0-alpha"
+source = "git+https://github.com/iotaledger/iota#5d86d45197849842100c1b34245ace3268bc01f6"
 dependencies = [
  "bcs",
  "iota-types",
@@ -4775,8 +4770,8 @@ dependencies = [
 
 [[package]]
 name = "iota-framework-snapshot"
-version = "0.10.0-alpha"
-source = "git+https://github.com/iotaledger/iota#f95b361b0e662e9ea367aac9e0323769d0d786bc"
+version = "0.11.0-alpha"
+source = "git+https://github.com/iotaledger/iota#5d86d45197849842100c1b34245ace3268bc01f6"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4807,7 +4802,7 @@ dependencies = [
  "iota-config",
  "iota-json-rpc-types",
  "iota-metrics",
- "iota-sdk 0.10.0-alpha",
+ "iota-sdk 0.11.0-alpha",
  "iota-swarm-config",
  "iota-types",
  "itertools 0.14.0",
@@ -4835,8 +4830,8 @@ dependencies = [
 
 [[package]]
 name = "iota-genesis-builder"
-version = "0.10.0-alpha"
-source = "git+https://github.com/iotaledger/iota#f95b361b0e662e9ea367aac9e0323769d0d786bc"
+version = "0.11.0-alpha"
+source = "git+https://github.com/iotaledger/iota#5d86d45197849842100c1b34245ace3268bc01f6"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4846,7 +4841,6 @@ dependencies = [
  "csv",
  "fastcrypto",
  "flate2",
- "fs_extra",
  "iota-adapter-latest",
  "iota-config",
  "iota-execution",
@@ -4888,8 +4882,8 @@ dependencies = [
 
 [[package]]
 name = "iota-genesis-common"
-version = "0.10.0-alpha"
-source = "git+https://github.com/iotaledger/iota#f95b361b0e662e9ea367aac9e0323769d0d786bc"
+version = "0.11.0-alpha"
+source = "git+https://github.com/iotaledger/iota#5d86d45197849842100c1b34245ace3268bc01f6"
 dependencies = [
  "iota-execution",
  "iota-protocol-config",
@@ -4899,8 +4893,8 @@ dependencies = [
 
 [[package]]
 name = "iota-json"
-version = "0.10.0-alpha"
-source = "git+https://github.com/iotaledger/iota#f95b361b0e662e9ea367aac9e0323769d0d786bc"
+version = "0.11.0-alpha"
+source = "git+https://github.com/iotaledger/iota#5d86d45197849842100c1b34245ace3268bc01f6"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4916,8 +4910,8 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc"
-version = "0.10.0-alpha"
-source = "git+https://github.com/iotaledger/iota#f95b361b0e662e9ea367aac9e0323769d0d786bc"
+version = "0.11.0-alpha"
+source = "git+https://github.com/iotaledger/iota#5d86d45197849842100c1b34245ace3268bc01f6"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4960,7 +4954,7 @@ dependencies = [
  "tap",
  "thiserror 1.0.69",
  "tokio",
- "tokio-util 0.7.13",
+ "tokio-util 0.7.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower 0.4.13",
  "tower-http",
  "tracing",
@@ -4969,8 +4963,8 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc-api"
-version = "0.10.0-alpha"
-source = "git+https://github.com/iotaledger/iota#f95b361b0e662e9ea367aac9e0323769d0d786bc"
+version = "0.11.0-alpha"
+source = "git+https://github.com/iotaledger/iota#5d86d45197849842100c1b34245ace3268bc01f6"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -4989,8 +4983,8 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc-types"
-version = "0.10.0-alpha"
-source = "git+https://github.com/iotaledger/iota#f95b361b0e662e9ea367aac9e0323769d0d786bc"
+version = "0.11.0-alpha"
+source = "git+https://github.com/iotaledger/iota#5d86d45197849842100c1b34245ace3268bc01f6"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5019,8 +5013,8 @@ dependencies = [
 
 [[package]]
 name = "iota-keys"
-version = "0.10.0-alpha"
-source = "git+https://github.com/iotaledger/iota#f95b361b0e662e9ea367aac9e0323769d0d786bc"
+version = "0.11.0-alpha"
+source = "git+https://github.com/iotaledger/iota#5d86d45197849842100c1b34245ace3268bc01f6"
 dependencies = [
  "anyhow",
  "bip32",
@@ -5038,8 +5032,8 @@ dependencies = [
 
 [[package]]
 name = "iota-macros"
-version = "0.10.0-alpha"
-source = "git+https://github.com/iotaledger/iota#f95b361b0e662e9ea367aac9e0323769d0d786bc"
+version = "0.11.0-alpha"
+source = "git+https://github.com/iotaledger/iota#5d86d45197849842100c1b34245ace3268bc01f6"
 dependencies = [
  "futures",
  "iota-proc-macros",
@@ -5049,8 +5043,8 @@ dependencies = [
 
 [[package]]
 name = "iota-metrics"
-version = "0.10.0-alpha"
-source = "git+https://github.com/iotaledger/iota#f95b361b0e662e9ea367aac9e0323769d0d786bc"
+version = "0.11.0-alpha"
+source = "git+https://github.com/iotaledger/iota#5d86d45197849842100c1b34245ace3268bc01f6"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -5073,8 +5067,8 @@ dependencies = [
 
 [[package]]
 name = "iota-move-build"
-version = "0.10.0-alpha"
-source = "git+https://github.com/iotaledger/iota#f95b361b0e662e9ea367aac9e0323769d0d786bc"
+version = "0.11.0-alpha"
+source = "git+https://github.com/iotaledger/iota#5d86d45197849842100c1b34245ace3268bc01f6"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -5098,7 +5092,7 @@ dependencies = [
 [[package]]
 name = "iota-move-natives-latest"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#f95b361b0e662e9ea367aac9e0323769d0d786bc"
+source = "git+https://github.com/iotaledger/iota#5d86d45197849842100c1b34245ace3268bc01f6"
 dependencies = [
  "bcs",
  "better_any",
@@ -5120,8 +5114,8 @@ dependencies = [
 
 [[package]]
 name = "iota-network"
-version = "0.10.0-alpha"
-source = "git+https://github.com/iotaledger/iota#f95b361b0e662e9ea367aac9e0323769d0d786bc"
+version = "0.11.0-alpha"
+source = "git+https://github.com/iotaledger/iota#5d86d45197849842100c1b34245ace3268bc01f6"
 dependencies = [
  "anemo",
  "anemo-build",
@@ -5155,8 +5149,8 @@ dependencies = [
 
 [[package]]
 name = "iota-network-stack"
-version = "0.10.0-alpha"
-source = "git+https://github.com/iotaledger/iota#f95b361b0e662e9ea367aac9e0323769d0d786bc"
+version = "0.11.0-alpha"
+source = "git+https://github.com/iotaledger/iota#5d86d45197849842100c1b34245ace3268bc01f6"
 dependencies = [
  "anemo",
  "bcs",
@@ -5179,8 +5173,8 @@ dependencies = [
 
 [[package]]
 name = "iota-node"
-version = "0.10.0-alpha"
-source = "git+https://github.com/iotaledger/iota#f95b361b0e662e9ea367aac9e0323769d0d786bc"
+version = "0.11.0-alpha"
+source = "git+https://github.com/iotaledger/iota#5d86d45197849842100c1b34245ace3268bc01f6"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -5230,8 +5224,8 @@ dependencies = [
 
 [[package]]
 name = "iota-open-rpc"
-version = "0.10.0-alpha"
-source = "git+https://github.com/iotaledger/iota#f95b361b0e662e9ea367aac9e0323769d0d786bc"
+version = "0.11.0-alpha"
+source = "git+https://github.com/iotaledger/iota#5d86d45197849842100c1b34245ace3268bc01f6"
 dependencies = [
  "schemars",
  "serde",
@@ -5241,8 +5235,8 @@ dependencies = [
 
 [[package]]
 name = "iota-open-rpc-macros"
-version = "0.10.0-alpha"
-source = "git+https://github.com/iotaledger/iota#f95b361b0e662e9ea367aac9e0323769d0d786bc"
+version = "0.11.0-alpha"
+source = "git+https://github.com/iotaledger/iota#5d86d45197849842100c1b34245ace3268bc01f6"
 dependencies = [
  "derive-syn-parse",
  "itertools 0.13.0",
@@ -5254,12 +5248,12 @@ dependencies = [
 
 [[package]]
 name = "iota-package-management"
-version = "0.10.0-alpha"
-source = "git+https://github.com/iotaledger/iota#f95b361b0e662e9ea367aac9e0323769d0d786bc"
+version = "0.11.0-alpha"
+source = "git+https://github.com/iotaledger/iota#5d86d45197849842100c1b34245ace3268bc01f6"
 dependencies = [
  "anyhow",
  "iota-json-rpc-types",
- "iota-sdk 0.10.0-alpha",
+ "iota-sdk 0.11.0-alpha",
  "iota-types",
  "move-core-types",
  "move-package",
@@ -5270,8 +5264,8 @@ dependencies = [
 
 [[package]]
 name = "iota-package-resolver"
-version = "0.10.0-alpha"
-source = "git+https://github.com/iotaledger/iota#f95b361b0e662e9ea367aac9e0323769d0d786bc"
+version = "0.11.0-alpha"
+source = "git+https://github.com/iotaledger/iota#5d86d45197849842100c1b34245ace3268bc01f6"
 dependencies = [
  "async-trait",
  "bcs",
@@ -5288,8 +5282,8 @@ dependencies = [
 
 [[package]]
 name = "iota-proc-macros"
-version = "0.10.0-alpha"
-source = "git+https://github.com/iotaledger/iota#f95b361b0e662e9ea367aac9e0323769d0d786bc"
+version = "0.11.0-alpha"
+source = "git+https://github.com/iotaledger/iota#5d86d45197849842100c1b34245ace3268bc01f6"
 dependencies = [
  "msim-macros",
  "proc-macro2",
@@ -5299,8 +5293,8 @@ dependencies = [
 
 [[package]]
 name = "iota-protocol-config"
-version = "0.10.0-alpha"
-source = "git+https://github.com/iotaledger/iota#f95b361b0e662e9ea367aac9e0323769d0d786bc"
+version = "0.11.0-alpha"
+source = "git+https://github.com/iotaledger/iota#5d86d45197849842100c1b34245ace3268bc01f6"
 dependencies = [
  "clap",
  "iota-protocol-config-macros",
@@ -5313,8 +5307,8 @@ dependencies = [
 
 [[package]]
 name = "iota-protocol-config-macros"
-version = "0.10.0-alpha"
-source = "git+https://github.com/iotaledger/iota#f95b361b0e662e9ea367aac9e0323769d0d786bc"
+version = "0.11.0-alpha"
+source = "git+https://github.com/iotaledger/iota#5d86d45197849842100c1b34245ace3268bc01f6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5323,8 +5317,8 @@ dependencies = [
 
 [[package]]
 name = "iota-rest-api"
-version = "0.10.0-alpha"
-source = "git+https://github.com/iotaledger/iota#f95b361b0e662e9ea367aac9e0323769d0d786bc"
+version = "0.11.0-alpha"
+source = "git+https://github.com/iotaledger/iota#5d86d45197849842100c1b34245ace3268bc01f6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5355,7 +5349,7 @@ dependencies = [
 [[package]]
 name = "iota-rust-sdk"
 version = "0.0.0"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=2ba6b293bdede769a1d9b4d1aecaede2ff7682dd#2ba6b293bdede769a1d9b4d1aecaede2ff7682dd"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=3e4a47351cdd774dd2895a2552a038fe2f4b6da5#3e4a47351cdd774dd2895a2552a038fe2f4b6da5"
 dependencies = [
  "base64ct",
  "bcs",
@@ -5374,8 +5368,8 @@ dependencies = [
 
 [[package]]
 name = "iota-sdk"
-version = "0.10.0-alpha"
-source = "git+https://github.com/iotaledger/iota#f95b361b0e662e9ea367aac9e0323769d0d786bc"
+version = "0.11.0-alpha"
+source = "git+https://github.com/iotaledger/iota#5d86d45197849842100c1b34245ace3268bc01f6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5441,8 +5435,8 @@ dependencies = [
 
 [[package]]
 name = "iota-simulator"
-version = "0.10.0-alpha"
-source = "git+https://github.com/iotaledger/iota#f95b361b0e662e9ea367aac9e0323769d0d786bc"
+version = "0.11.0-alpha"
+source = "git+https://github.com/iotaledger/iota#5d86d45197849842100c1b34245ace3268bc01f6"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -5464,8 +5458,8 @@ dependencies = [
 
 [[package]]
 name = "iota-snapshot"
-version = "0.10.0-alpha"
-source = "git+https://github.com/iotaledger/iota#f95b361b0e662e9ea367aac9e0323769d0d786bc"
+version = "0.11.0-alpha"
+source = "git+https://github.com/iotaledger/iota#5d86d45197849842100c1b34245ace3268bc01f6"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5492,8 +5486,8 @@ dependencies = [
 
 [[package]]
 name = "iota-storage"
-version = "0.10.0-alpha"
-source = "git+https://github.com/iotaledger/iota#f95b361b0e662e9ea367aac9e0323769d0d786bc"
+version = "0.11.0-alpha"
+source = "git+https://github.com/iotaledger/iota#5d86d45197849842100c1b34245ace3268bc01f6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5532,6 +5526,7 @@ dependencies = [
  "rustls 0.23.21",
  "serde",
  "serde_json",
+ "strum 0.26.3",
  "tap",
  "telemetry-subscribers",
  "tempfile",
@@ -5544,8 +5539,8 @@ dependencies = [
 
 [[package]]
 name = "iota-swarm"
-version = "0.10.0-alpha"
-source = "git+https://github.com/iotaledger/iota#f95b361b0e662e9ea367aac9e0323769d0d786bc"
+version = "0.11.0-alpha"
+source = "git+https://github.com/iotaledger/iota#5d86d45197849842100c1b34245ace3268bc01f6"
 dependencies = [
  "anyhow",
  "futures",
@@ -5570,8 +5565,8 @@ dependencies = [
 
 [[package]]
 name = "iota-swarm-config"
-version = "0.10.0-alpha"
-source = "git+https://github.com/iotaledger/iota#f95b361b0e662e9ea367aac9e0323769d0d786bc"
+version = "0.11.0-alpha"
+source = "git+https://github.com/iotaledger/iota#5d86d45197849842100c1b34245ace3268bc01f6"
 dependencies = [
  "anemo",
  "anyhow",
@@ -5596,13 +5591,13 @@ dependencies = [
 
 [[package]]
 name = "iota-test-transaction-builder"
-version = "0.10.0-alpha"
-source = "git+https://github.com/iotaledger/iota#f95b361b0e662e9ea367aac9e0323769d0d786bc"
+version = "0.11.0-alpha"
+source = "git+https://github.com/iotaledger/iota#5d86d45197849842100c1b34245ace3268bc01f6"
 dependencies = [
  "bcs",
  "iota-genesis-builder",
  "iota-move-build",
- "iota-sdk 0.10.0-alpha",
+ "iota-sdk 0.11.0-alpha",
  "iota-types",
  "move-core-types",
  "shared-crypto",
@@ -5610,8 +5605,8 @@ dependencies = [
 
 [[package]]
 name = "iota-tls"
-version = "0.10.0-alpha"
-source = "git+https://github.com/iotaledger/iota#f95b361b0e662e9ea367aac9e0323769d0d786bc"
+version = "0.11.0-alpha"
+source = "git+https://github.com/iotaledger/iota#5d86d45197849842100c1b34245ace3268bc01f6"
 dependencies = [
  "anyhow",
  "axum 0.7.9",
@@ -5631,8 +5626,8 @@ dependencies = [
 
 [[package]]
 name = "iota-transaction-builder"
-version = "0.10.0-alpha"
-source = "git+https://github.com/iotaledger/iota#f95b361b0e662e9ea367aac9e0323769d0d786bc"
+version = "0.11.0-alpha"
+source = "git+https://github.com/iotaledger/iota#5d86d45197849842100c1b34245ace3268bc01f6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5648,8 +5643,8 @@ dependencies = [
 
 [[package]]
 name = "iota-transaction-checks"
-version = "0.10.0-alpha"
-source = "git+https://github.com/iotaledger/iota#f95b361b0e662e9ea367aac9e0323769d0d786bc"
+version = "0.11.0-alpha"
+source = "git+https://github.com/iotaledger/iota#5d86d45197849842100c1b34245ace3268bc01f6"
 dependencies = [
  "fastcrypto-zkp",
  "iota-config",
@@ -5663,8 +5658,8 @@ dependencies = [
 
 [[package]]
 name = "iota-types"
-version = "0.10.0-alpha"
-source = "git+https://github.com/iotaledger/iota#f95b361b0e662e9ea367aac9e0323769d0d786bc"
+version = "0.11.0-alpha"
+source = "git+https://github.com/iotaledger/iota#5d86d45197849842100c1b34245ace3268bc01f6"
 dependencies = [
  "anemo",
  "anyhow",
@@ -5734,7 +5729,7 @@ dependencies = [
 [[package]]
 name = "iota-verifier-latest"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#f95b361b0e662e9ea367aac9e0323769d0d786bc"
+source = "git+https://github.com/iotaledger/iota#5d86d45197849842100c1b34245ace3268bc01f6"
 dependencies = [
  "iota-protocol-config",
  "iota-types",
@@ -5936,7 +5931,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tokio-rustls 0.26.1",
- "tokio-util 0.7.13",
+ "tokio-util 0.7.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing",
  "url",
 ]
@@ -6028,7 +6023,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
- "tokio-util 0.7.13",
+ "tokio-util 0.7.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower 0.4.13",
  "tracing",
 ]
@@ -6522,7 +6517,7 @@ dependencies = [
 [[package]]
 name = "move-abstract-interpreter"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#f95b361b0e662e9ea367aac9e0323769d0d786bc"
+source = "git+https://github.com/iotaledger/iota#5d86d45197849842100c1b34245ace3268bc01f6"
 dependencies = [
  "move-binary-format",
  "move-bytecode-verifier-meter",
@@ -6531,12 +6526,12 @@ dependencies = [
 [[package]]
 name = "move-abstract-stack"
 version = "0.0.1"
-source = "git+https://github.com/iotaledger/iota#f95b361b0e662e9ea367aac9e0323769d0d786bc"
+source = "git+https://github.com/iotaledger/iota#5d86d45197849842100c1b34245ace3268bc01f6"
 
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/iotaledger/iota#f95b361b0e662e9ea367aac9e0323769d0d786bc"
+source = "git+https://github.com/iotaledger/iota#5d86d45197849842100c1b34245ace3268bc01f6"
 dependencies = [
  "anyhow",
  "enum-compat-util",
@@ -6550,12 +6545,12 @@ dependencies = [
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/iotaledger/iota#f95b361b0e662e9ea367aac9e0323769d0d786bc"
+source = "git+https://github.com/iotaledger/iota#5d86d45197849842100c1b34245ace3268bc01f6"
 
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#f95b361b0e662e9ea367aac9e0323769d0d786bc"
+source = "git+https://github.com/iotaledger/iota#5d86d45197849842100c1b34245ace3268bc01f6"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6571,7 +6566,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#f95b361b0e662e9ea367aac9e0323769d0d786bc"
+source = "git+https://github.com/iotaledger/iota#5d86d45197849842100c1b34245ace3268bc01f6"
 dependencies = [
  "anyhow",
  "indexmap 2.7.1",
@@ -6585,7 +6580,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#f95b361b0e662e9ea367aac9e0323769d0d786bc"
+source = "git+https://github.com/iotaledger/iota#5d86d45197849842100c1b34245ace3268bc01f6"
 dependencies = [
  "move-abstract-interpreter",
  "move-abstract-stack",
@@ -6600,7 +6595,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier-meter"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#f95b361b0e662e9ea367aac9e0323769d0d786bc"
+source = "git+https://github.com/iotaledger/iota#5d86d45197849842100c1b34245ace3268bc01f6"
 dependencies = [
  "move-binary-format",
  "move-core-types",
@@ -6610,11 +6605,11 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#f95b361b0e662e9ea367aac9e0323769d0d786bc"
+source = "git+https://github.com/iotaledger/iota#5d86d45197849842100c1b34245ace3268bc01f6"
 dependencies = [
  "anyhow",
  "bcs",
- "difference",
+ "colored",
  "dirs-next",
  "hex",
  "move-binary-format",
@@ -6623,6 +6618,7 @@ dependencies = [
  "once_cell",
  "serde",
  "sha2 0.9.9",
+ "similar",
  "vfs",
  "walkdir",
 ]
@@ -6630,7 +6626,7 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/iotaledger/iota#f95b361b0e662e9ea367aac9e0323769d0d786bc"
+source = "git+https://github.com/iotaledger/iota#5d86d45197849842100c1b34245ace3268bc01f6"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6664,7 +6660,7 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/iotaledger/iota#f95b361b0e662e9ea367aac9e0323769d0d786bc"
+source = "git+https://github.com/iotaledger/iota#5d86d45197849842100c1b34245ace3268bc01f6"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6687,7 +6683,7 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#f95b361b0e662e9ea367aac9e0323769d0d786bc"
+source = "git+https://github.com/iotaledger/iota#5d86d45197849842100c1b34245ace3268bc01f6"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6708,7 +6704,7 @@ dependencies = [
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#f95b361b0e662e9ea367aac9e0323769d0d786bc"
+source = "git+https://github.com/iotaledger/iota#5d86d45197849842100c1b34245ace3268bc01f6"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6728,7 +6724,7 @@ dependencies = [
 [[package]]
 name = "move-docgen"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#f95b361b0e662e9ea367aac9e0323769d0d786bc"
+source = "git+https://github.com/iotaledger/iota#5d86d45197849842100c1b34245ace3268bc01f6"
 dependencies = [
  "anyhow",
  "codespan",
@@ -6746,7 +6742,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#f95b361b0e662e9ea367aac9e0323769d0d786bc"
+source = "git+https://github.com/iotaledger/iota#5d86d45197849842100c1b34245ace3268bc01f6"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -6764,7 +6760,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#f95b361b0e662e9ea367aac9e0323769d0d786bc"
+source = "git+https://github.com/iotaledger/iota#5d86d45197849842100c1b34245ace3268bc01f6"
 dependencies = [
  "anyhow",
  "hex",
@@ -6777,7 +6773,7 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#f95b361b0e662e9ea367aac9e0323769d0d786bc"
+source = "git+https://github.com/iotaledger/iota#5d86d45197849842100c1b34245ace3268bc01f6"
 dependencies = [
  "hex",
  "move-command-line-common",
@@ -6790,7 +6786,7 @@ dependencies = [
 [[package]]
 name = "move-model"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#f95b361b0e662e9ea367aac9e0323769d0d786bc"
+source = "git+https://github.com/iotaledger/iota#5d86d45197849842100c1b34245ace3268bc01f6"
 dependencies = [
  "anyhow",
  "codespan",
@@ -6814,7 +6810,7 @@ dependencies = [
 [[package]]
 name = "move-package"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#f95b361b0e662e9ea367aac9e0323769d0d786bc"
+source = "git+https://github.com/iotaledger/iota#5d86d45197849842100c1b34245ace3268bc01f6"
 dependencies = [
  "anyhow",
  "clap",
@@ -6848,7 +6844,7 @@ dependencies = [
 [[package]]
 name = "move-proc-macros"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#f95b361b0e662e9ea367aac9e0323769d0d786bc"
+source = "git+https://github.com/iotaledger/iota#5d86d45197849842100c1b34245ace3268bc01f6"
 dependencies = [
  "quote",
  "syn 2.0.96",
@@ -6857,7 +6853,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib-natives"
 version = "0.1.1"
-source = "git+https://github.com/iotaledger/iota#f95b361b0e662e9ea367aac9e0323769d0d786bc"
+source = "git+https://github.com/iotaledger/iota#5d86d45197849842100c1b34245ace3268bc01f6"
 dependencies = [
  "hex",
  "move-binary-format",
@@ -6872,7 +6868,7 @@ dependencies = [
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#f95b361b0e662e9ea367aac9e0323769d0d786bc"
+source = "git+https://github.com/iotaledger/iota#5d86d45197849842100c1b34245ace3268bc01f6"
 dependencies = [
  "once_cell",
  "phf",
@@ -6882,7 +6878,7 @@ dependencies = [
 [[package]]
 name = "move-trace-format"
 version = "0.0.1"
-source = "git+https://github.com/iotaledger/iota#f95b361b0e662e9ea367aac9e0323769d0d786bc"
+source = "git+https://github.com/iotaledger/iota#5d86d45197849842100c1b34245ace3268bc01f6"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -6897,7 +6893,7 @@ dependencies = [
 [[package]]
 name = "move-vm-config"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#f95b361b0e662e9ea367aac9e0323769d0d786bc"
+source = "git+https://github.com/iotaledger/iota#5d86d45197849842100c1b34245ace3268bc01f6"
 dependencies = [
  "move-binary-format",
  "once_cell",
@@ -6906,7 +6902,7 @@ dependencies = [
 [[package]]
 name = "move-vm-profiler"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#f95b361b0e662e9ea367aac9e0323769d0d786bc"
+source = "git+https://github.com/iotaledger/iota#5d86d45197849842100c1b34245ace3268bc01f6"
 dependencies = [
  "move-vm-config",
  "once_cell",
@@ -6916,7 +6912,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#f95b361b0e662e9ea367aac9e0323769d0d786bc"
+source = "git+https://github.com/iotaledger/iota#5d86d45197849842100c1b34245ace3268bc01f6"
 dependencies = [
  "better_any",
  "fail",
@@ -6936,7 +6932,7 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#f95b361b0e662e9ea367aac9e0323769d0d786bc"
+source = "git+https://github.com/iotaledger/iota#5d86d45197849842100c1b34245ace3268bc01f6"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -6950,7 +6946,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#f95b361b0e662e9ea367aac9e0323769d0d786bc"
+source = "git+https://github.com/iotaledger/iota#5d86d45197849842100c1b34245ace3268bc01f6"
 dependencies = [
  "bcs",
  "move-binary-format",
@@ -6963,7 +6959,7 @@ dependencies = [
 [[package]]
 name = "msim"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota-sim.git?rev=f16ef50ba7d874fe1f0960f248f6c651a634d6a5#f16ef50ba7d874fe1f0960f248f6c651a634d6a5"
+source = "git+https://github.com/iotaledger/iota-sim.git?branch=tokio-1.43#d3ae9de63b7ebfbeea8fa5f9d111b9570be703f2"
 dependencies = [
  "ahash",
  "async-task",
@@ -6982,7 +6978,7 @@ dependencies = [
  "serde",
  "socket2 0.5.8",
  "tap",
- "tokio-util 0.7.11",
+ "tokio-util 0.7.13 (git+https://github.com/iotaledger/tokio-madsim-fork.git?branch=msim-1.43.0)",
  "toml 0.8.19",
  "tracing",
  "tracing-subscriber",
@@ -6991,7 +6987,7 @@ dependencies = [
 [[package]]
 name = "msim-macros"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota-sim.git?rev=f16ef50ba7d874fe1f0960f248f6c651a634d6a5#f16ef50ba7d874fe1f0960f248f6c651a634d6a5"
+source = "git+https://github.com/iotaledger/iota-sim.git?branch=tokio-1.43#d3ae9de63b7ebfbeea8fa5f9d111b9570be703f2"
 dependencies = [
  "darling 0.14.4",
  "proc-macro2",
@@ -8361,8 +8357,8 @@ dependencies = [
 
 [[package]]
 name = "prometheus-closure-metric"
-version = "0.10.0-alpha"
-source = "git+https://github.com/iotaledger/iota#f95b361b0e662e9ea367aac9e0323769d0d786bc"
+version = "0.11.0-alpha"
+source = "git+https://github.com/iotaledger/iota#5d86d45197849842100c1b34245ace3268bc01f6"
 dependencies = [
  "anyhow",
  "prometheus",
@@ -8732,8 +8728,8 @@ dependencies = [
 
 [[package]]
 name = "real_tokio"
-version = "1.39.2"
-source = "git+https://github.com/iotaledger/tokio-madsim-fork.git?branch=main#e34a35287024b341db16139a402508aaea8ec955"
+version = "1.43.0"
+source = "git+https://github.com/iotaledger/tokio-madsim-fork.git?branch=msim-1.43.0#9256cf957759096beb965a378bef71d0827d8cb3"
 dependencies = [
  "backtrace",
  "bytes",
@@ -8743,7 +8739,7 @@ dependencies = [
  "pin-project-lite",
  "signal-hook-registry",
  "socket2 0.5.8",
- "tokio-macros 2.4.0 (git+https://github.com/iotaledger/tokio-madsim-fork.git?branch=main)",
+ "tokio-macros 2.5.0 (git+https://github.com/iotaledger/tokio-madsim-fork.git?branch=msim-1.43.0)",
  "windows-sys 0.52.0",
 ]
 
@@ -8768,7 +8764,7 @@ dependencies = [
  "socket2 0.4.10",
  "tokio",
  "tokio-retry",
- "tokio-util 0.7.13",
+ "tokio-util 0.7.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "url",
 ]
 
@@ -8945,7 +8941,7 @@ dependencies = [
  "sync_wrapper 1.0.2",
  "tokio",
  "tokio-rustls 0.26.1",
- "tokio-util 0.7.13",
+ "tokio-util 0.7.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower 0.5.2",
  "tower-service",
  "url",
@@ -9767,8 +9763,8 @@ dependencies = [
 
 [[package]]
 name = "shared-crypto"
-version = "0.10.0-alpha"
-source = "git+https://github.com/iotaledger/iota#f95b361b0e662e9ea367aac9e0323769d0d786bc"
+version = "0.11.0-alpha"
+source = "git+https://github.com/iotaledger/iota#5d86d45197849842100c1b34245ace3268bc01f6"
 dependencies = [
  "bcs",
  "eyre",
@@ -10363,8 +10359,8 @@ dependencies = [
 
 [[package]]
 name = "telemetry-subscribers"
-version = "0.10.0-alpha"
-source = "git+https://github.com/iotaledger/iota#f95b361b0e662e9ea367aac9e0323769d0d786bc"
+version = "0.11.0-alpha"
+source = "git+https://github.com/iotaledger/iota#5d86d45197849842100c1b34245ace3268bc01f6"
 dependencies = [
  "atomic_float",
  "bytes",
@@ -10440,8 +10436,8 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "test-cluster"
-version = "0.10.0-alpha"
-source = "git+https://github.com/iotaledger/iota#f95b361b0e662e9ea367aac9e0323769d0d786bc"
+version = "0.11.0-alpha"
+source = "git+https://github.com/iotaledger/iota#5d86d45197849842100c1b34245ace3268bc01f6"
 dependencies = [
  "anyhow",
  "bcs",
@@ -10459,7 +10455,7 @@ dependencies = [
  "iota-keys",
  "iota-node",
  "iota-protocol-config",
- "iota-sdk 0.10.0-alpha",
+ "iota-sdk 0.11.0-alpha",
  "iota-simulator",
  "iota-swarm",
  "iota-swarm-config",
@@ -10618,9 +10614,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.39.2"
+version = "1.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daa4fb1bc778bd6f04cbfc4bb2d06a7396a8f299dc33ea1900cedaa316f467b1"
+checksum = "3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e"
 dependencies = [
  "backtrace",
  "bytes",
@@ -10630,16 +10626,16 @@ dependencies = [
  "pin-project-lite",
  "signal-hook-registry",
  "socket2 0.5.8",
- "tokio-macros 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-macros 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing",
  "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10648,8 +10644,8 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.4.0"
-source = "git+https://github.com/iotaledger/tokio-madsim-fork.git?branch=main#e34a35287024b341db16139a402508aaea8ec955"
+version = "2.5.0"
+source = "git+https://github.com/iotaledger/tokio-madsim-fork.git?branch=msim-1.43.0#9256cf957759096beb965a378bef71d0827d8cb3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10706,7 +10702,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
- "tokio-util 0.7.13",
+ "tokio-util 0.7.13 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -10738,22 +10734,6 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.11"
-source = "git+https://github.com/iotaledger/tokio-madsim-fork.git?branch=main#e34a35287024b341db16139a402508aaea8ec955"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-io",
- "futures-sink",
- "futures-util",
- "hashbrown 0.14.5",
- "pin-project-lite",
- "real_tokio",
- "slab",
-]
-
-[[package]]
-name = "tokio-util"
 version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7fcaa8d55a2bdd6b83ace262b016eca0d79ee02818c5c1bcdf0305114081078"
@@ -10766,6 +10746,22 @@ dependencies = [
  "hashbrown 0.14.5",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.13"
+source = "git+https://github.com/iotaledger/tokio-madsim-fork.git?branch=msim-1.43.0#9256cf957759096beb965a378bef71d0827d8cb3"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-util",
+ "hashbrown 0.14.5",
+ "pin-project-lite",
+ "real_tokio",
+ "slab",
 ]
 
 [[package]]
@@ -10892,6 +10888,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic-rustls"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "803689f99cfc6de9c3b27aa86bf98553754c72c53b715913f1c14dcd3c030f77"
+dependencies = [
+ "async-stream",
+ "bytes",
+ "h2 0.4.7",
+ "http 1.2.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.5.2",
+ "hyper-timeout",
+ "hyper-util",
+ "pin-project",
+ "socket2 0.5.8",
+ "tokio",
+ "tokio-rustls 0.26.1",
+ "tokio-stream",
+ "tonic",
+ "tower 0.5.2",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "tower"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10906,7 +10929,7 @@ dependencies = [
  "rand 0.8.5",
  "slab",
  "tokio",
- "tokio-util 0.7.13",
+ "tokio-util 0.7.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -10920,11 +10943,15 @@ checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap 2.7.1",
  "pin-project-lite",
+ "slab",
  "sync_wrapper 1.0.2",
  "tokio",
+ "tokio-util 0.7.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -10950,7 +10977,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "tokio",
- "tokio-util 0.7.13",
+ "tokio-util 0.7.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower 0.4.13",
  "tower-layer",
  "tower-service",
@@ -11160,8 +11187,8 @@ dependencies = [
 
 [[package]]
 name = "typed-store"
-version = "0.10.0-alpha"
-source = "git+https://github.com/iotaledger/iota#f95b361b0e662e9ea367aac9e0323769d0d786bc"
+version = "0.11.0-alpha"
+source = "git+https://github.com/iotaledger/iota#5d86d45197849842100c1b34245ace3268bc01f6"
 dependencies = [
  "async-trait",
  "bcs",
@@ -11189,8 +11216,8 @@ dependencies = [
 
 [[package]]
 name = "typed-store-derive"
-version = "0.10.0-alpha"
-source = "git+https://github.com/iotaledger/iota#f95b361b0e662e9ea367aac9e0323769d0d786bc"
+version = "0.11.0-alpha"
+source = "git+https://github.com/iotaledger/iota#5d86d45197849842100c1b34245ace3268bc01f6"
 dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
@@ -11200,8 +11227,8 @@ dependencies = [
 
 [[package]]
 name = "typed-store-error"
-version = "0.10.0-alpha"
-source = "git+https://github.com/iotaledger/iota#f95b361b0e662e9ea367aac9e0323769d0d786bc"
+version = "0.11.0-alpha"
+source = "git+https://github.com/iotaledger/iota#5d86d45197849842100c1b34245ace3268bc01f6"
 dependencies = [
  "serde",
  "thiserror 1.0.69",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,13 +10,13 @@ repository = "https://github.com/iotaledger/gas-station"
 
 fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "5f2c63266a065996d53f98156f0412782b468597" }
 
-iota-metrics = { git = "https://github.com/iotaledger/iota", version = "0.10.0-alpha", package = "iota-metrics" }
-iota-config = { git = "https://github.com/iotaledger/iota", version = "0.10.0-alpha", package = "iota-config" }
-iota-json-rpc-types = { git = "https://github.com/iotaledger/iota", version = "0.10.0-alpha", package = "iota-json-rpc-types" }
-iota-sdk = { git = "https://github.com/iotaledger/iota", version = "0.10.0-alpha", package = "iota-sdk" }
-iota-types = { git = "https://github.com/iotaledger/iota", version = "0.10.0-alpha", package = "iota-types" }
-shared-crypto = { git = "https://github.com/iotaledger/iota", version = "0.10.0-alpha", package = "shared-crypto" }
-telemetry-subscribers = { git = "https://github.com/iotaledger/iota", version = "0.10.0-alpha", package = "telemetry-subscribers" }
+iota-metrics = { git = "https://github.com/iotaledger/iota", version = "0.11.0-alpha", package = "iota-metrics" }
+iota-config = { git = "https://github.com/iotaledger/iota", version = "0.11.0-alpha", package = "iota-config" }
+iota-json-rpc-types = { git = "https://github.com/iotaledger/iota", version = "0.11.0-alpha", package = "iota-json-rpc-types" }
+iota-sdk = { git = "https://github.com/iotaledger/iota", version = "0.11.0-alpha", package = "iota-sdk" }
+iota-types = { git = "https://github.com/iotaledger/iota", version = "0.11.0-alpha", package = "iota-types" }
+shared-crypto = { git = "https://github.com/iotaledger/iota", version = "0.11.0-alpha", package = "shared-crypto" }
+telemetry-subscribers = { git = "https://github.com/iotaledger/iota", version = "0.11.0-alpha", package = "telemetry-subscribers" }
 
 
 anyhow = "1.0.75"
@@ -57,8 +57,8 @@ lazy_static = "1.5.0"
 [dev-dependencies]
 rand = "0.8.5"
 
-iota-swarm-config = { git = "https://github.com/iotaledger/iota", version = "0.10.0-alpha", package = "iota-swarm-config" }
-test-cluster = { git = "https://github.com/iotaledger/iota", version = "0.10.0-alpha", package = "test-cluster" }
+iota-swarm-config = { git = "https://github.com/iotaledger/iota", version = "0.11.0-alpha", package = "iota-swarm-config" }
+test-cluster = { git = "https://github.com/iotaledger/iota", version = "0.11.0-alpha", package = "test-cluster" }
 
 [profile.release]
 panic = "abort"


### PR DESCRIPTION
Bump up the iota SDK to the 0.11-alpha


https://github.com/iotaledger/gas-station/actions/runs/13829168981/job/38689510988

```
#19 24.99     iota-config = { version = "0.11.0-alpha" }
#19 ERROR: process "/bin/sh -c cargo build --release" did not complete successfully: exit code: 101
------
 > [builder 5/5] RUN cargo build --release:
0.088     Updating crates.io index
0.089     Updating git repository `[https://github.com/MystenLabs/fastcrypto`](https://github.com/MystenLabs/fastcrypto%60)
0.855     Updating git repository `[https://github.com/iotaledger/iota`](https://github.com/iotaledger/iota%60)
24.99 error: failed to select a version for the requirement `iota-config = "^0.10.0-alpha"`
24.99 candidate versions found which didn't match: 0.11.0-alpha
24.99 location searched: Git repository https://github.com/iotaledger/iota
24.99 required by package `iota-gas-station v0.1.0 (/iota)`
24.99 if you are looking for the prerelease package it needs to be specified explicitly
24.99     iota-config = { version = "0.11.0-alpha" }
------
Dockerfile:26
--------------------
  24 |     COPY src ./src
  25 |     
  26 | >>> RUN cargo build --release
  27 |     
  28 |     
--------------------
ERROR: failed to solve: process "/bin/sh -c cargo build --release" did not complete successfully: exit code: 101
Error: Process completed with exit code 1.
```
