### PR TITLE
Add ptb command count rule option

### DIFF
--- a/docs/access-controller.md
+++ b/docs/access-controller.md
@@ -10,11 +10,11 @@ The **Gas Station Server** includes an **Access Controller** mechanism to manage
 
    ```yaml
    access-controller:
-   access-policy: deny-all
-   rules:
-      - sender-address: "0x0101010101010101010101010101010101010101010101010101010101010101"
-        move-call-package-address: "0x0202020202020202020202020202020202020202020202020202020202020202"
-        action: 'allow' # allowed actions: 'allow', 'deny'
+      access-policy: deny-all
+      rules:
+         - sender-address: "0x0101010101010101010101010101010101010101010101010101010101010101"
+           move-call-package-address: "0x0202020202020202020202020202020202020202020202020202020202020202"
+           action: 'allow' # allowed actions: 'allow', 'deny'
    ```
 
 ---
@@ -25,10 +25,10 @@ The **Gas Station Server** includes an **Access Controller** mechanism to manage
 
    ```yaml
    access-controller:
-   access-policy: deny-all
-   rules:
-      - sender-address: "0x0101010101010101010101010101010101010101010101010101010101010101"
-        action: 'deny'
+      access-policy: deny-all
+      rules:
+         - sender-address: "0x0101010101010101010101010101010101010101010101010101010101010101"
+           action: 'deny'
    ```
 
 ---
@@ -39,11 +39,11 @@ The **Gas Station Server** includes an **Access Controller** mechanism to manage
 
    ```yaml
    access-controller:
-   access-policy: deny-all
-   rules:
-      - sender-address: "0x0101010101010101010101010101010101010101010101010101010101010101"
-        transaction-gas-budget: '<1000000' # allowed operators: =, !=, <, >, <=, >=
-        action: 'allow'
+      access-policy: deny-all
+      rules:
+         - sender-address: "0x0101010101010101010101010101010101010101010101010101010101010101"
+           transaction-gas-budget: '<1000000' # allowed operators: =, !=, <, >, <=, >=
+           action: 'allow'
    ```
 
 ---
@@ -54,16 +54,30 @@ The **Gas Station Server** includes an **Access Controller** mechanism to manage
 
    ```yaml
    access-controller:
-   access-policy: deny-all
-   rules:
-      - sender-address: "0x0101010101010101010101010101010101010101010101010101010101010101"
-        transaction-gas-budget: '<=10000000'
-        action: 'allow'
+      access-policy: deny-all
+      rules:
+         - sender-address: "0x0101010101010101010101010101010101010101010101010101010101010101"
+           transaction-gas-budget: '<=10000000'
+           action: 'allow'
 
-      - sender-address: '*'
-        transaction-gas-budget: '<500000'
-        action: 'allow'
+         - sender-address: '*'
+           transaction-gas-budget: '<500000'
+           action: 'allow'
+   ```
 
+---
+
+- Programmable Transaction Command Count Limits
+
+   To avoid users submitting transactions blocks with a large number of transactions, a limit for the commands in the programmable transaction can be configured. In the following example, the sender may only submit one command in the programmable transaction.
+
+   ```yaml
+   access-controller:
+      access-policy: deny-all
+      rules:
+         - sender-address: "0x0101010101010101010101010101010101010101010101010101010101010101"
+           max-commands-per-ptb: 1
+           action: 'allow'
    ```
 
 ---
@@ -75,6 +89,7 @@ The **Gas Station Server** includes an **Access Controller** mechanism to manage
 | `sender-address`            |  yes       | `'0x0000...'`, `[0x0000.., 0x1111...]`, `'*'`                  |
 | `gas-budget`                |  no        | `'=100'`, `'<100'`,  `'<=100'`, `'>100'`, `'>=100'`, `'!=100'` |
 | `move-call-package-address` |  no        | `'0x0000...'`, `[0x0000..., 0x1111...]`, `'*'`                 |
+| `max-commands-per-ptb`      |  no        | `1`, `2`, ..., `usize:MAX`                                     |
 | `action`                    |  yes       | `'allow'`,  `'deny'`                                           |
 
 ## Learn More

--- a/docs/access-controller.md
+++ b/docs/access-controller.md
@@ -69,14 +69,16 @@ The **Gas Station Server** includes an **Access Controller** mechanism to manage
 
 - Programmable Transaction Command Count Limits
 
-   To avoid users submitting transactions blocks with a large number of transactions, a limit for the commands in the programmable transaction can be configured. In the following example, the sender may only submit one command in the programmable transaction.
+   To avoid users submitting transactions blocks with a large number of transactions, limits for the commands in the programmable transaction can be configured. In the following example, the sender may only submit up to one command in the programmable transaction.
+
+   Note that this rule condition is only applied to transactions, that include a programmable transaction and will be ignored for other transaction kinds.
 
    ```yaml
    access-controller:
       access-policy: deny-all
       rules:
          - sender-address: "0x0101010101010101010101010101010101010101010101010101010101010101"
-           max-commands-per-ptb: 1
+           ptb-command-count: <=1 # allowed operators: =, !=, <, >, <=, >=
            action: 'allow'
    ```
 
@@ -89,7 +91,7 @@ The **Gas Station Server** includes an **Access Controller** mechanism to manage
 | `sender-address`            |  yes       | `'0x0000...'`, `[0x0000.., 0x1111...]`, `'*'`                  |
 | `gas-budget`                |  no        | `'=100'`, `'<100'`,  `'<=100'`, `'>100'`, `'>=100'`, `'!=100'` |
 | `move-call-package-address` |  no        | `'0x0000...'`, `[0x0000..., 0x1111...]`, `'*'`                 |
-| `max-commands-per-ptb`      |  no        | `1`, `2`, ..., `usize:MAX`                                     |
+| `ptb-command-count`         |  no        | `'=10'`, `'<10'`,  `'<=10'`, `'>10'`, `'>=10'`, `'!=10'`       |
 | `action`                    |  yes       | `'allow'`,  `'deny'`                                           |
 
 ## Learn More

--- a/src/rpc/rpc_types.rs
+++ b/src/rpc/rpc_types.rs
@@ -3,10 +3,10 @@
 
 use crate::types::ReservationID;
 use fastcrypto::encoding::Base64;
+use iota_json_rpc_types::{IotaObjectRef, IotaTransactionBlockEffects};
+use iota_types::base_types::{IotaAddress, ObjectRef};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use iota_json_rpc_types::{IotaObjectRef, IotaTransactionBlockEffects};
-use iota_types::base_types::{ObjectRef, IotaAddress};
 
 // 2 IOTA.
 pub const MAX_BUDGET: u64 = 2_000_000_000;

--- a/utils/gas-station-tool.sh
+++ b/utils/gas-station-tool.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/bin/bash
 
 IMAGE_NAME="iotaledger/gas-station-tool:latest"
 

--- a/utils/gas-station.sh
+++ b/utils/gas-station.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/bin/bash
 
 IMAGE_NAME="iotaledger/gas-station:latest"
 


### PR DESCRIPTION
# Description of change

Adds `ptb-command-count` rule option to allow defining rules based on count of transaction in the programmable transaction of the to be funded transaction.

As not all supported transactions have a programmable transaction, this rule is only applicable to the ones with a programmable transaction and ignored for other transaction kinds.

Syntax follows the same style as the `gas-budget` option. The protocol should only allow up to 1024 commands, but kept the type of the option based on `usize` as this is the type, the SDK returns (`.len()`).

## Links to any relevant issues

Resolves #59.