### PR TITLE
Fix Docker Issues on macOS

### DIFF
--- a/.github/workflows/publish-to-dockerhub.yml
+++ b/.github/workflows/publish-to-dockerhub.yml
@@ -23,32 +23,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        config:
-          - {
-              binary_name: "iota-gas-station",
-              docker_repo: "iotaledger/gas-station",
-              runner: "ubuntu-latest",
-              platform: "linux/amd64",
-            }
-          - {
-              binary_name: "iota-gas-station",
-              docker_repo: "iotaledger/gas-station",
-              runner: "macos-latest",
-              platform: "linux/arm64/v8",
-            }
-
-          - {
-              binary_name: "tool",
-              docker_repo: "iotaledger/gas-station-tool",
-              runner: "ubuntu-latest",
-              platform: "linux/amd64",
-            }
-          - {
-              binary_name: "tool",
-              docker_repo: "iotaledger/gas-station-tool",
-              runner: "macos-latest",
-              platform: "linux/arm64/v8",
-            }
+        image:
+          - { name: "iota-gas-station", repo: "iotaledger/gas-station" }
+          - { name: "tool", repo: "iotaledger/gas-station-tool" }
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4
@@ -61,91 +38,21 @@ jobs:
           username: ${{ secrets.IOTALEDGER_DOCKER_USERNAME }}
           password: ${{ secrets.IOTALEDGER_DOCKER_PASSWORD }}
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3.7.1
-
-      - name: Local Image Names
-        id: names
+      - name: Build image with build.sh
         run: |
-          echo "local_image=${{ matrix.config.binary_name }}-${{ matrix.config.runner }}" >> $GITHUB_OUTPUT
-          echo "ext_image=${{ matrix.config.docker_repo }}:${{ github.event.inputs.tag }}" >> $GITHUB_OUTPUT
+          ENTRY_BINARY=${{ matrix.image.name }} docker/build.sh -t ${{ matrix.image.repo }}:${{ github.event.inputs.tag }}
 
-      - name: Build docker image (DRY-RUN) ${{ matrix.config.docker_repo }} - ${{ matrix.config.platform }}
-        if: ${{ github.event.inputs.is-dry-run == 'true' }}
+      - name: Push docker image
+        if: ${{ github.event.inputs.is-dry-run != 'true' }}
         run: |
-          ENTRY_BINARY=${{ matrix.config.binary_name }} docker/build.sh \
-          -t ${{ steps.names.outputs.ext_image }}  \
-          --platform ${{ matrix.config.platform }}
+          docker push ${{ matrix.image.repo }}:${{ github.event.inputs.tag }}
 
-      - name: Build & Push docker image Build docker image ${{ matrix.config.docker_repo }} - ${{ matrix.config.platform }}
-        if: ${{ github.event.inputs.is-dry-run == 'false' }}
-        id: build-push-image
-        run: |
-          ENTRY_BINARY=${{ matrix.config.binary_name }} docker/build.sh \
-          --platform ${{ matrix.config.platform }} \
-          --output type=image,"name=${{ matrix.config.docker_repo }}",push-by-digest=true,name-canonical=true,push=true \
-          --iidfile docker.id
-
-          DOCKER_ID=$(cat docker.id)
-          DIGEST=$(docker manifest inspect ${{ matrix.config.docker_repo }}@${DOCKER_ID} | jq -r '.manifests[0].digest')
-          echo "Obtained the docker image $DIGEST"
-          echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
-
-      - name: Export digest
-        if: ${{ github.event.inputs.is-dry-run == 'false' }}
-        run: |
-          mkdir -p ${{ runner.temp }}/digests/${{ github.sha }}
-          digest="${{ steps.build-push-image.outputs.digest }}"
-          touch "${{ runner.temp }}/digests/${{ github.sha}}/${digest#sha256:}"
-
-      - name: Upload digest
-        if: ${{ steps.build-push-image.outputs.digest != '' }}
-        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
-        with:
-          name: digests-${{ github.sha }}-${{ matrix.config.binary_name }}-${{ matrix.config.runner }}
-          path: ${{ runner.temp }}/digests/${{ github.sha }}/*
-          if-no-files-found: error
-          retention-days: 1
-
-  push-index:
-    if: ${{ github.event.inputs.is-dry-run == 'false' }}
-    environment: release
-    needs: push_to_registry
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        config:
-          - {
-              binary_name: "iota-gas-station",
-              docker_repo: "iotaledger/gas-station",
-            }
-          - { binary_name: "tool", docker_repo: "iotaledger/gas-station-tool" }
-
-    steps:
-      - name: Login to Docker Registry
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
-        with:
-          username: ${{ secrets.IOTALEDGER_DOCKER_USERNAME }}
-          password: ${{ secrets.IOTALEDGER_DOCKER_PASSWORD }}
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3.7.1
-
-      - name: Download digests
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
-        with:
-          path: ${{ runner.temp }}/digests
-          pattern: digests-${{ github.sha }}-${{ matrix.config.binary_name }}-*
-          merge-multiple: true
-
-      - name: Push multi-platform index
-        run: |
-          cmd="docker buildx imagetools create --tag ${{ matrix.config.docker_repo }}:${{ github.event.inputs.tag }}"
-          for file in ${{ runner.temp }}/digests/*; do
-            # Extract the filename (which is the hash).
-            hash=$(basename "$file")
-            # Append the amend option for the current hash.
-            cmd+="  ${{ matrix.config.docker_repo }}@sha256:$hash"
-          done
-          echo -e "$cmd"
-          eval "$cmd"
+      # - name: Docker Hub Description for ${{ matrix.image.repo }}
+      #   if: ${{ github.event.inputs.is-dry-run  == 'false'}}
+      #   uses: peter-evans/dockerhub-description@e98e4d1628a5f3be2be7c231e50981aee98723ae
+      #   with:
+      #     username: ${{ secrets.IOTALEDGER_DOCKER_USERNAME }}
+      #     password: ${{ secrets.IOTALEDGER_DOCKER_PASSWORD }}
+      #     repository: ${{ matrix.image.repo }}
+      #     readme-filepath: ./README.md
+      #     short-description: ${{ github.event.repository.description }}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,14 @@
+FROM --platform=$BUILDPLATFORM tonistiigi/xx AS xx
+
 FROM --platform=$BUILDPLATFORM  rust:1.85-bullseye AS chef
+
+# setup xx
+# copy xx scripts to your build stage
+COPY --from=xx / /
+# export TARGETPLATFORM (or other TARGET*)
+ARG TARGETPLATFORM
+# you can now call xx-* commands
+RUN xx-info env
 
 WORKDIR /iota
 
@@ -8,30 +18,27 @@ ENV GIT_REVISION=$GIT_REVISION
 # This is a workaround for the following the issue related to the libc-bin package
 RUN rm /var/lib/dpkg/info/libc-bin.*
 
-RUN apt-get clean
-RUN apt-get update && apt-get install -y cmake clang lld
-
+RUN apt-get update && apt-get install -y clang lld
 
 # Build and cache all dependencies.
 FROM chef AS builder
 WORKDIR /iota
 
-# Configure Rust to use clang and lld as the linker
-RUN mkdir -p ./.cargo && \
-  echo "[target.x86_64-unknown-linux-gnu]\nlinker = \"clang\"\nrustflags = [\"-C\", \"link-arg=-fuse-ld=lld\"]" > ./.cargo/config.toml
-
 COPY Cargo.toml ./
 COPY src ./src
+ARG ENTRY_BINARY=iota-gas-station
 
-RUN cargo build --release
+RUN xx-cargo build --release --target-dir ./build
+RUN xx-verify "./build/$(xx-cargo --print-target-triple)/release/${ENTRY_BINARY}"
 
+# move binary to a location we can access it more easily in `FROM` command
+RUN mv "./build/$(xx-cargo --print-target-triple)/release/${ENTRY_BINARY}" ./build/entrypoint
 
 # Production Image
 FROM debian:bullseye-slim AS runtime
 RUN apt-get update && apt-get install -y libjemalloc-dev ca-certificates
 
-ARG ENTRY_BINARY=iota-gas-station
-COPY --from=builder /iota/target/release/${ENTRY_BINARY} /usr/local/bin/entrypoint
+COPY --from=builder "/iota/build/entrypoint" /usr/local/bin/entrypoint
 
 ARG BUILD_DATE
 ARG GIT_REVISION


### PR DESCRIPTION
Fixes issues with running built images on macOS.

`Dockerfile` has been updated to use `xx` for multi-platform support, docker CI workflow has been reverted to the slightly simpler variant from before #56, as we now can run with one image per component (gas-station, gas-station-tool).