### PR TITLE
 Add Optional HTTP Authentication for Gas Station Endpoints

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.85"
+channel = "1.86"

--- a/src/rpc/client.rs
+++ b/src/rpc/client.rs
@@ -58,10 +58,9 @@ impl GasStationRpcClient {
 
     pub async fn debug_health_check(&self) -> anyhow::Result<()> {
         let mut headers = HeaderMap::new();
-        headers.insert(
-            AUTHORIZATION,
-            format!("Bearer {}", read_auth_env()).parse().unwrap(),
-        );
+        if let Some(auth) = read_auth_env() {
+            headers.insert(AUTHORIZATION, format!("Bearer {}", auth).parse().unwrap());
+        }
         let response = self
             .client
             .post(format!("{}/debug_health_check", self.server_address))
@@ -89,10 +88,9 @@ impl GasStationRpcClient {
             reserve_duration_secs,
         };
         let mut headers = HeaderMap::new();
-        headers.insert(
-            AUTHORIZATION,
-            format!("Bearer {}", read_auth_env()).parse().unwrap(),
-        );
+        if let Some(auth) = read_auth_env() {
+            headers.insert(AUTHORIZATION, format!("Bearer {}", auth).parse().unwrap());
+        }
         let response = self
             .client
             .post(format!("{}/v1/reserve_gas", self.server_address))
@@ -130,10 +128,9 @@ impl GasStationRpcClient {
         headers: Option<HeaderMap>,
     ) -> anyhow::Result<IotaTransactionBlockEffects> {
         let mut headers = headers.unwrap_or_default();
-        headers.insert(
-            AUTHORIZATION,
-            format!("Bearer {}", read_auth_env()).parse().unwrap(),
-        );
+        if let Some(auth) = read_auth_env() {
+            headers.insert(AUTHORIZATION, format!("Bearer {}", auth).parse().unwrap());
+        }
         let request = ExecuteTxRequest {
             reservation_id,
             tx_bytes: Base64::from_bytes(&bcs::to_bytes(&tx_data).unwrap()),
@@ -157,10 +154,9 @@ impl GasStationRpcClient {
 
     pub async fn reload_access_controller(&self) -> anyhow::Result<()> {
         let mut headers = HeaderMap::new();
-        headers.insert(
-            AUTHORIZATION,
-            format!("Bearer {}", read_auth_env()).parse().unwrap(),
-        );
+        if let Some(auth) = read_auth_env() {
+            headers.insert(AUTHORIZATION, format!("Bearer {}", auth).parse().unwrap());
+        }
         let response = self
             .client
             .get(format!(


### PR DESCRIPTION
**Description:**
This PR introduces **optional HTTP authentication** for the gas station API endpoints. Authentication is controlled by the `GAS_STATION_AUTH` environment variable.

* If `GAS_STATION_AUTH` is **provided**, all HTTP requests must include the correct authentication header to access the protected endpoints.
* If `GAS_STATION_AUTH` is **not set**, the gas station runs without authentication, and a **warning message is printed at startup** to inform the operator that the API is publicly accessible.

