### PR TITLE
Add flag to allow user to decide to wait for local tx execution

### DIFF
--- a/docs/hook-openapi.json
+++ b/docs/hook-openapi.json
@@ -165,7 +165,7 @@
                             },
                             {
                                 "$ref": "#/components/schemas/ExecuteTransactionRequestType",
-                                "description": "Request type used for transaction finality waiting, defaults to `waitForEffectsCert`."
+                                "description": "Request type used for transaction finality waiting."
                             }
                         ]
                     },

--- a/docs/hook-openapi.json
+++ b/docs/hook-openapi.json
@@ -85,6 +85,13 @@
                     }
                 }
             },
+            "ExecuteTransactionRequestType": {
+                "type": "string",
+                "enum": [
+                    "waitForEffectsCert",
+                    "waitForLocalExecution"
+                ]
+            },
             "ExecuteTxGasStationRequest": {
                 "type": "object",
                 "description": "Original request data and headers sent to Gas Stations `execute_tx` endpoint.",
@@ -151,6 +158,17 @@
                     "userSig"
                 ],
                 "properties": {
+                    "requestType": {
+                        "oneOf": [
+                            {
+                                "type": "null"
+                            },
+                            {
+                                "$ref": "#/components/schemas/ExecuteTransactionRequestType",
+                                "description": "Request type used for transaction finality waiting, defaults to `waitForEffectsCert`."
+                            }
+                        ]
+                    },
                     "reservationId": {
                         "type": "integer",
                         "format": "uint64",

--- a/examples/hook/src/endpoint_types.rs
+++ b/examples/hook/src/endpoint_types.rs
@@ -6,6 +6,7 @@ use std::collections::HashMap;
 use anyhow::Context as _;
 use axum::http::StatusCode;
 use base64::prelude::*;
+use iota_types::quorum_driver_types::ExecuteTransactionRequestType;
 use iota_types::transaction::TransactionData;
 use serde::Deserialize;
 use serde::Serialize;
@@ -43,6 +44,64 @@ pub struct ExecuteTxRequestPayload {
     /// Base64 encoded user signature.
     #[schema(content_encoding = "base64")]
     pub user_sig: String,
+    /// Request type used for transaction finality waiting, defaults to `waitForEffectsCert`.
+    #[serde(default, with = "option_execute_transaction_request_type")]
+    #[schema(value_type = Option<option_execute_transaction_request_type::ExecuteTransactionRequestType>)]
+    pub request_type: Option<ExecuteTransactionRequestType>,
+}
+
+/// Helper module, that allows to convert `iota`s `ExecuteTransactionRequestType` to a lowercase representation of it
+/// as a value in a REST request. `serde`s `remote` attribute does currently not support optional values, so added a helper
+/// module as [suggested](https://github.com/serde-rs/serde/issues/1301#issuecomment-394108486).
+mod option_execute_transaction_request_type {
+    use serde::Deserialize;
+    use serde::Deserializer;
+    use serde::Serialize;
+    use serde::Serializer;
+    use utoipa::ToSchema;
+
+    use super::ExecuteTransactionRequestType as ExternalExecuteTransactionRequestType;
+
+    #[derive(Serialize, Deserialize, Clone, Debug, ToSchema)]
+    #[serde(
+        remote = "ExternalExecuteTransactionRequestType",
+        rename_all = "camelCase"
+    )]
+    pub enum ExecuteTransactionRequestType {
+        WaitForEffectsCert,
+        WaitForLocalExecution,
+    }
+
+    pub fn serialize<S>(
+        value: &Option<ExternalExecuteTransactionRequestType>,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        #[derive(Serialize)]
+        struct Helper<'a>(
+            #[serde(with = "ExecuteTransactionRequestType")]
+            &'a ExternalExecuteTransactionRequestType,
+        );
+
+        value.as_ref().map(Helper).serialize(serializer)
+    }
+
+    pub fn deserialize<'de, D>(
+        deserializer: D,
+    ) -> Result<Option<ExternalExecuteTransactionRequestType>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct Helper(
+            #[serde(with = "ExecuteTransactionRequestType")] ExternalExecuteTransactionRequestType,
+        );
+
+        let helper = Option::deserialize(deserializer)?;
+        Ok(helper.map(|Helper(external)| external))
+    }
 }
 
 impl ExecuteTxHookRequest {

--- a/examples/rust/sponsored_transaction.rs
+++ b/examples/rust/sponsored_transaction.rs
@@ -78,7 +78,7 @@ async fn main() {
     // Send the TransactionData together with the signature to the Gas Station.
     // The Gas Station will execute the Transaction and returns the effects.
     let effects = gas_station_client
-        .execute_tx(reservation_id, &tx_data, &signature, None)
+        .execute_tx(reservation_id, &tx_data, &signature, None, None)
         .await
         .expect("transaction should be sent");
 

--- a/src/access_controller/hook/hook_action.rs
+++ b/src/access_controller/hook/hook_action.rs
@@ -31,6 +31,7 @@ fn build_execute_tx_hook_request_payload(ctx: &TransactionContext) -> ExecuteTxH
                 reservation_id: ctx.reservation_id,
                 tx_bytes: ctx.tx_bytes.encoded(),
                 user_sig: ctx.user_sig.encoded(),
+                request_type: ctx.request_type.clone(),
             },
             headers: convert_header_map_to_vec(ctx),
         },

--- a/src/access_controller/hook/hook_server_types.rs
+++ b/src/access_controller/hook/hook_server_types.rs
@@ -35,8 +35,7 @@ pub struct ExecuteTxRequestPayload {
     pub tx_bytes: String,
     /// Base64 encoded user signature.
     pub user_sig: String,
-    /// Request type used for transaction finality waiting, defaults to `WaitForEffectsCert`.
-    // #[serde(default, with = "option_execute_transaction_request_type")]
+    /// Request type used for transaction finality waiting.
     pub request_type: Option<ExecuteTransactionRequestType>,
 }
 

--- a/src/access_controller/hook/hook_server_types.rs
+++ b/src/access_controller/hook/hook_server_types.rs
@@ -5,7 +5,10 @@
 
 use std::collections::HashMap;
 
+use iota_types::quorum_driver_types::ExecuteTransactionRequestType;
 use serde::{Deserialize, Serialize};
+
+use crate::rpc::rpc_types::option_execute_transaction_request_type;
 
 /// Input for hook to check if transaction should be executed.
 /// Contains original request for Gas Stations `execute_tx` endpoint.
@@ -33,6 +36,9 @@ pub struct ExecuteTxRequestPayload {
     pub tx_bytes: String,
     /// Base64 encoded user signature.
     pub user_sig: String,
+    /// Request type used for transaction finality waiting, defaults to `WaitForEffectsCert`.
+    #[serde(default, with = "option_execute_transaction_request_type")]
+    pub request_type: Option<ExecuteTransactionRequestType>,
 }
 
 /// Result of checking if transaction should be executed.

--- a/src/access_controller/hook/hook_server_types.rs
+++ b/src/access_controller/hook/hook_server_types.rs
@@ -5,10 +5,9 @@
 
 use std::collections::HashMap;
 
-use iota_types::quorum_driver_types::ExecuteTransactionRequestType;
 use serde::{Deserialize, Serialize};
 
-use crate::rpc::rpc_types::option_execute_transaction_request_type;
+use crate::rpc::rpc_types::ExecuteTransactionRequestType;
 
 /// Input for hook to check if transaction should be executed.
 /// Contains original request for Gas Stations `execute_tx` endpoint.
@@ -37,7 +36,7 @@ pub struct ExecuteTxRequestPayload {
     /// Base64 encoded user signature.
     pub user_sig: String,
     /// Request type used for transaction finality waiting, defaults to `WaitForEffectsCert`.
-    #[serde(default, with = "option_execute_transaction_request_type")]
+    // #[serde(default, with = "option_execute_transaction_request_type")]
     pub request_type: Option<ExecuteTransactionRequestType>,
 }
 

--- a/src/access_controller/rule.rs
+++ b/src/access_controller/rule.rs
@@ -7,6 +7,7 @@ use fastcrypto::encoding::Base64;
 use iota_types::{
     base_types::IotaAddress,
     digests::TransactionDigest,
+    quorum_driver_types::ExecuteTransactionRequestType,
     signature::GenericSignature,
     transaction::{TransactionData, TransactionDataAPI, TransactionDataV1, TransactionKind},
 };
@@ -293,6 +294,7 @@ pub struct TransactionContext {
     pub reservation_id: u64,
     pub tx_bytes: Base64,
     pub user_sig: Base64,
+    pub request_type: Option<ExecuteTransactionRequestType>,
     pub headers: HeaderMap,
 }
 
@@ -312,6 +314,7 @@ impl Default for TransactionContext {
                 .expect("empty string should be valid base64"),
             user_sig: Base64::try_from(String::default())
                 .expect("empty string should be valid base64"),
+            request_type: None,
             headers: HeaderMap::default(),
         }
     }
@@ -325,6 +328,7 @@ impl TransactionContext {
         reservation_id: u64,
         tx_bytes: Base64,
         user_sig: Base64,
+        request_type: Option<ExecuteTransactionRequestType>,
         headers: HeaderMap,
     ) -> Self {
         let ptb_command_count = match transaction_data {
@@ -348,6 +352,7 @@ impl TransactionContext {
             reservation_id,
             tx_bytes,
             user_sig,
+            request_type,
             headers,
         }
     }
@@ -397,6 +402,11 @@ impl TransactionContext {
 
     pub fn with_user_sig(mut self, user_sig: Base64) -> Self {
         self.user_sig = user_sig;
+        self
+    }
+
+    pub fn with_request_type(mut self, request_type: ExecuteTransactionRequestType) -> Self {
+        self.request_type = Some(request_type);
         self
     }
 

--- a/src/access_controller/rule.rs
+++ b/src/access_controller/rule.rs
@@ -7,7 +7,6 @@ use fastcrypto::encoding::Base64;
 use iota_types::{
     base_types::IotaAddress,
     digests::TransactionDigest,
-    quorum_driver_types::ExecuteTransactionRequestType,
     signature::GenericSignature,
     transaction::{TransactionData, TransactionDataAPI, TransactionDataV1, TransactionKind},
 };
@@ -21,9 +20,12 @@ use super::{
     hook::HookAction,
     predicates::{Action, LimitBy, RegoExpression, ValueAggregate, ValueIotaAddress, ValueNumber},
 };
-use crate::tracker::{
-    stats_tracker_storage::{Aggregate, AggregateType},
-    StatsTracker,
+use crate::{
+    rpc::rpc_types::ExecuteTransactionRequestType,
+    tracker::{
+        stats_tracker_storage::{Aggregate, AggregateType},
+        StatsTracker,
+    },
 };
 
 /// The AccessRuleBuilder is used to build an AccessRule with fluent API.

--- a/src/benchmarks/mod.rs
+++ b/src/benchmarks/mod.rs
@@ -88,7 +88,7 @@ impl BenchmarkMode {
                     let intent_msg = IntentMessage::new(Intent::iota_transaction(), &tx_data);
                     let user_sig = Signature::new_secure(&intent_msg, &keypair).into();
                     let result = client
-                        .execute_tx(reservation_id, &tx_data, &user_sig, None)
+                        .execute_tx(reservation_id, &tx_data, &user_sig, None, None)
                         .await;
                     if let Err(err) = result {
                         stats.write().update_error();

--- a/src/gas_station/gas_station_core.rs
+++ b/src/gas_station/gas_station_core.rs
@@ -3,6 +3,7 @@
 
 use crate::iota_client::IotaClient;
 use crate::metrics::GasStationCoreMetrics;
+use crate::rpc::rpc_types::ExecuteTransactionRequestType;
 use crate::storage::Storage;
 use crate::tx_signer::TxSigner;
 use crate::types::{GasCoin, ReservationID};
@@ -12,7 +13,6 @@ use iota_json_rpc_types::{IotaTransactionBlockEffects, IotaTransactionBlockEffec
 use iota_types::base_types::{IotaAddress, ObjectID, ObjectRef};
 use iota_types::gas_coin::NANOS_PER_IOTA;
 use iota_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
-use iota_types::quorum_driver_types::ExecuteTransactionRequestType;
 use iota_types::signature::GenericSignature;
 use iota_types::transaction::{
     Argument, Command, Transaction, TransactionData, TransactionDataAPI, TransactionKind,

--- a/src/gas_station/gas_station_core.rs
+++ b/src/gas_station/gas_station_core.rs
@@ -12,6 +12,7 @@ use iota_json_rpc_types::{IotaTransactionBlockEffects, IotaTransactionBlockEffec
 use iota_types::base_types::{IotaAddress, ObjectID, ObjectRef};
 use iota_types::gas_coin::NANOS_PER_IOTA;
 use iota_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
+use iota_types::quorum_driver_types::ExecuteTransactionRequestType;
 use iota_types::signature::GenericSignature;
 use iota_types::transaction::{
     Argument, Command, Transaction, TransactionData, TransactionDataAPI, TransactionKind,
@@ -89,6 +90,7 @@ impl GasStation {
         reservation_id: ReservationID,
         tx_data: TransactionData,
         user_sig: GenericSignature,
+        request_type: Option<ExecuteTransactionRequestType>,
     ) -> anyhow::Result<IotaTransactionBlockEffects> {
         let sponsor = tx_data.gas_data().owner;
         if !self.signer.is_valid_address(&sponsor) {
@@ -121,7 +123,7 @@ impl GasStation {
             "Total gas coin balance prior to execution: {}", total_gas_coin_balance,
         );
         let response = self
-            .execute_transaction_impl(reservation_id, tx_data, user_sig)
+            .execute_transaction_impl(reservation_id, tx_data, user_sig, request_type)
             .await;
         let updated_coins = match &response {
             Ok(effects) => {
@@ -183,6 +185,7 @@ impl GasStation {
         reservation_id: ReservationID,
         tx_data: TransactionData,
         user_sig: GenericSignature,
+        request_type: Option<ExecuteTransactionRequestType>,
     ) -> anyhow::Result<IotaTransactionBlockEffects> {
         let sponsor = tx_data.gas_data().owner;
         let cur_time = std::time::Instant::now();
@@ -203,7 +206,10 @@ impl GasStation {
 
         let tx = Transaction::from_generic_sig_data(tx_data, vec![sponsor_sig, user_sig]);
         let cur_time = std::time::Instant::now();
-        let effects = self.iota_client.execute_transaction(tx, 3).await?;
+        let effects = self
+            .iota_client
+            .execute_transaction(tx, 3, request_type)
+            .await?;
         debug!(?reservation_id, "Transaction executed");
         let elapsed = cur_time.elapsed().as_millis();
         self.metrics

--- a/src/gas_station/mod.rs
+++ b/src/gas_station/mod.rs
@@ -64,7 +64,7 @@ mod tests {
 
         let (tx_data, user_sig) = create_test_transaction(&test_cluster, sponsor, gas_coins).await;
         let effects = station
-            .execute_transaction(reservation_id, tx_data, user_sig)
+            .execute_transaction(reservation_id, tx_data, user_sig, None)
             .await
             .unwrap();
         assert!(effects.status().is_ok());
@@ -91,7 +91,7 @@ mod tests {
             &keypair,
         );
         let result = station
-            .execute_transaction(reservation_id, tx_data, user_sig.into())
+            .execute_transaction(reservation_id, tx_data, user_sig.into(), None)
             .await;
         println!("{:?}", result);
         assert!(result.is_err());
@@ -119,7 +119,7 @@ mod tests {
         assert_eq!(station.query_pool_available_coin_count().await, 1);
         let (tx_data, user_sig) = create_test_transaction(&test_cluster, sponsor, gas_coins).await;
         assert!(station
-            .execute_transaction(reservation_id, tx_data, user_sig)
+            .execute_transaction(reservation_id, tx_data, user_sig, None)
             .await
             .is_err());
         station
@@ -147,13 +147,13 @@ mod tests {
             create_test_transaction(&test_cluster, sponsor, incomplete_gas_coins).await;
         // It should fail because it's inconsistent with the reservation.
         assert!(station
-            .execute_transaction(reservation_id, tx_data, user_sig)
+            .execute_transaction(reservation_id, tx_data, user_sig, None)
             .await
             .is_err());
 
         let (tx_data, user_sig) = create_test_transaction(&test_cluster, sponsor, gas_coins).await;
         let effects = station
-            .execute_transaction(reservation_id, tx_data, user_sig)
+            .execute_transaction(reservation_id, tx_data, user_sig, None)
             .await
             .unwrap();
         assert!(effects.status().is_ok());
@@ -182,13 +182,13 @@ mod tests {
         let (tx_data, user_sig) =
             create_test_transaction(&test_cluster, sponsor, mixed_up_gas_coins).await;
         assert!(station
-            .execute_transaction(reservation_id1, tx_data, user_sig)
+            .execute_transaction(reservation_id1, tx_data, user_sig, None)
             .await
             .is_err());
 
         let (tx_data, user_sig) = create_test_transaction(&test_cluster, sponsor, gas_coins1).await;
         let effects = station
-            .execute_transaction(reservation_id1, tx_data, user_sig)
+            .execute_transaction(reservation_id1, tx_data, user_sig, None)
             .await
             .unwrap();
         assert!(effects.status().is_ok());

--- a/src/gas_station_initializer.rs
+++ b/src/gas_station_initializer.rs
@@ -110,7 +110,10 @@ impl CoinSplitEnv {
                 "Sending transaction for execution. Tx digest: {:?}",
                 tx.digest()
             );
-            let result = self.iota_client.execute_transaction(tx.clone(), 10).await;
+            let result = self
+                .iota_client
+                .execute_transaction(tx.clone(), 10, None)
+                .await;
             match result {
                 Ok(effects) => {
                     assert!(

--- a/src/iota_client.rs
+++ b/src/iota_client.rs
@@ -202,6 +202,7 @@ impl IotaClient {
         &self,
         tx: Transaction,
         max_attempts: usize,
+        request_type: Option<ExecuteTransactionRequestType>,
     ) -> anyhow::Result<IotaTransactionBlockEffects> {
         let digest = *tx.digest();
         debug!(?digest, "Executing transaction: {:?}", tx);
@@ -212,7 +213,9 @@ impl IotaClient {
                     .execute_transaction_block(
                         tx.clone(),
                         IotaTransactionBlockResponseOptions::new().with_effects(),
-                        Some(ExecuteTransactionRequestType::WaitForEffectsCert),
+                        request_type
+                            .clone()
+                            .or(Some(ExecuteTransactionRequestType::WaitForEffectsCert)),
                     )
                     .await
                     .tap_err(|err| debug!(?digest, "execute_transaction error: {:?}", err))

--- a/src/rpc/client.rs
+++ b/src/rpc/client.rs
@@ -10,6 +10,7 @@ use anyhow::bail;
 use fastcrypto::encoding::Base64;
 use iota_json_rpc_types::IotaTransactionBlockEffects;
 use iota_types::base_types::{IotaAddress, ObjectRef};
+use iota_types::quorum_driver_types::ExecuteTransactionRequestType;
 use iota_types::signature::GenericSignature;
 use iota_types::transaction::TransactionData;
 use reqwest::header::{HeaderMap, AUTHORIZATION};
@@ -127,6 +128,7 @@ impl GasStationRpcClient {
         reservation_id: ReservationID,
         tx_data: &TransactionData,
         user_sig: &GenericSignature,
+        request_type: Option<ExecuteTransactionRequestType>,
         headers: Option<HeaderMap>,
     ) -> anyhow::Result<IotaTransactionBlockEffects> {
         let mut headers = headers.unwrap_or_default();
@@ -138,6 +140,7 @@ impl GasStationRpcClient {
             reservation_id,
             tx_bytes: Base64::from_bytes(&bcs::to_bytes(&tx_data).unwrap()),
             user_sig: Base64::from_bytes(user_sig.as_ref()),
+            request_type,
         };
         let response = self
             .client

--- a/src/rpc/client.rs
+++ b/src/rpc/client.rs
@@ -3,14 +3,14 @@
 
 use crate::read_auth_env;
 use crate::rpc::rpc_types::{
-    ExecuteTxRequest, ExecuteTxResponse, ReserveGasRequest, ReserveGasResponse,
+    ExecuteTransactionRequestType, ExecuteTxRequest, ExecuteTxResponse, ReserveGasRequest,
+    ReserveGasResponse,
 };
 use crate::types::ReservationID;
 use anyhow::bail;
 use fastcrypto::encoding::Base64;
 use iota_json_rpc_types::IotaTransactionBlockEffects;
 use iota_types::base_types::{IotaAddress, ObjectRef};
-use iota_types::quorum_driver_types::ExecuteTransactionRequestType;
 use iota_types::signature::GenericSignature;
 use iota_types::transaction::TransactionData;
 use reqwest::header::{HeaderMap, AUTHORIZATION};

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -5,6 +5,7 @@ pub mod client;
 pub(crate) mod rpc_types;
 mod server;
 
+pub use rpc_types::ExecuteTransactionRequestType;
 pub use server::GasStationServer;
 
 #[cfg(test)]

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -17,6 +17,7 @@ mod tests {
     use crate::access_controller::rule::AccessRuleBuilder;
     use crate::access_controller::AccessController;
     use crate::config::GasStationConfig;
+    use crate::rpc::ExecuteTransactionRequestType;
     use crate::test_env::{
         create_test_transaction, start_rpc_server_for_testing,
         start_rpc_server_for_testing_with_access_controller, DEFAULT_TEST_CONFIG_PATH,
@@ -25,7 +26,6 @@ mod tests {
     use iota_config::Config;
     use iota_json_rpc_types::IotaTransactionBlockEffectsAPI;
     use iota_types::gas_coin::NANOS_PER_IOTA;
-    use iota_types::quorum_driver_types::ExecuteTransactionRequestType;
 
     #[tokio::test]
     async fn test_basic_rpc_flow() {

--- a/src/rpc/rpc_types.rs
+++ b/src/rpc/rpc_types.rs
@@ -4,7 +4,10 @@
 use crate::types::ReservationID;
 use fastcrypto::encoding::Base64;
 use iota_json_rpc_types::{IotaObjectRef, IotaTransactionBlockEffects};
-use iota_types::base_types::{IotaAddress, ObjectRef};
+use iota_types::{
+    base_types::{IotaAddress, ObjectRef},
+    quorum_driver_types::ExecuteTransactionRequestType,
+};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -83,6 +86,64 @@ pub struct ExecuteTxRequest {
     pub reservation_id: ReservationID,
     pub tx_bytes: Base64,
     pub user_sig: Base64,
+    // use separate `..._with` attributes instead of just `with` to prevent
+    // [issue](https://github.com/GREsau/schemars/issues/89#issuecomment-933746151) with `JsonSchema` derive
+    #[serde(
+        default,
+        deserialize_with = "option_execute_transaction_request_type::deserialize",
+        serialize_with = "option_execute_transaction_request_type::serialize"
+    )]
+    pub request_type: Option<ExecuteTransactionRequestType>,
+}
+
+/// Helper module, that allows to convert `iota`s `ExecuteTransactionRequestType` to a lowercase representation of it
+/// as a value in a REST request. `serde`s `remote` attribute does currently not support optional values, so added a helper
+/// module as [suggested](https://github.com/serde-rs/serde/issues/1301#issuecomment-394108486).
+pub(crate) mod option_execute_transaction_request_type {
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    use super::ExecuteTransactionRequestType as ExternalExecuteTransactionRequestType;
+
+    #[derive(Serialize, Deserialize, Clone, Debug)]
+    #[serde(
+        remote = "ExternalExecuteTransactionRequestType",
+        rename_all = "camelCase"
+    )]
+    pub enum ExecuteTransactionRequestType {
+        WaitForEffectsCert,
+        WaitForLocalExecution,
+    }
+
+    pub fn serialize<S>(
+        value: &Option<ExternalExecuteTransactionRequestType>,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        #[derive(Serialize)]
+        struct Helper<'a>(
+            #[serde(with = "ExecuteTransactionRequestType")]
+            &'a ExternalExecuteTransactionRequestType,
+        );
+
+        value.as_ref().map(Helper).serialize(serializer)
+    }
+
+    pub fn deserialize<'de, D>(
+        deserializer: D,
+    ) -> Result<Option<ExternalExecuteTransactionRequestType>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct Helper(
+            #[serde(with = "ExecuteTransactionRequestType")] ExternalExecuteTransactionRequestType,
+        );
+
+        let helper = Option::deserialize(deserializer)?;
+        Ok(helper.map(|Helper(external)| external))
+    }
 }
 
 #[derive(Debug, JsonSchema, Serialize, Deserialize)]

--- a/src/rpc/rpc_types.rs
+++ b/src/rpc/rpc_types.rs
@@ -6,7 +6,7 @@ use fastcrypto::encoding::Base64;
 use iota_json_rpc_types::{IotaObjectRef, IotaTransactionBlockEffects};
 use iota_types::{
     base_types::{IotaAddress, ObjectRef},
-    quorum_driver_types::ExecuteTransactionRequestType,
+    quorum_driver_types::ExecuteTransactionRequestType as IotaExecuteTransactionRequestType,
 };
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -86,63 +86,26 @@ pub struct ExecuteTxRequest {
     pub reservation_id: ReservationID,
     pub tx_bytes: Base64,
     pub user_sig: Base64,
-    // use separate `..._with` attributes instead of just `with` to prevent
-    // [issue](https://github.com/GREsau/schemars/issues/89#issuecomment-933746151) with `JsonSchema` derive
-    #[serde(
-        default,
-        deserialize_with = "option_execute_transaction_request_type::deserialize",
-        serialize_with = "option_execute_transaction_request_type::serialize"
-    )]
     pub request_type: Option<ExecuteTransactionRequestType>,
 }
 
-/// Helper module, that allows to convert `iota`s `ExecuteTransactionRequestType` to a lowercase representation of it
-/// as a value in a REST request. `serde`s `remote` attribute does currently not support optional values, so added a helper
-/// module as [suggested](https://github.com/serde-rs/serde/issues/1301#issuecomment-394108486).
-pub(crate) mod option_execute_transaction_request_type {
-    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+#[derive(Serialize, Deserialize, JsonSchema, Clone, Debug)]
+#[serde(rename_all = "camelCase")]
+pub enum ExecuteTransactionRequestType {
+    WaitForEffectsCert,
+    WaitForLocalExecution,
+}
 
-    use super::ExecuteTransactionRequestType as ExternalExecuteTransactionRequestType;
-
-    #[derive(Serialize, Deserialize, Clone, Debug)]
-    #[serde(
-        remote = "ExternalExecuteTransactionRequestType",
-        rename_all = "camelCase"
-    )]
-    pub enum ExecuteTransactionRequestType {
-        WaitForEffectsCert,
-        WaitForLocalExecution,
-    }
-
-    pub fn serialize<S>(
-        value: &Option<ExternalExecuteTransactionRequestType>,
-        serializer: S,
-    ) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        #[derive(Serialize)]
-        struct Helper<'a>(
-            #[serde(with = "ExecuteTransactionRequestType")]
-            &'a ExternalExecuteTransactionRequestType,
-        );
-
-        value.as_ref().map(Helper).serialize(serializer)
-    }
-
-    pub fn deserialize<'de, D>(
-        deserializer: D,
-    ) -> Result<Option<ExternalExecuteTransactionRequestType>, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        #[derive(Deserialize)]
-        struct Helper(
-            #[serde(with = "ExecuteTransactionRequestType")] ExternalExecuteTransactionRequestType,
-        );
-
-        let helper = Option::deserialize(deserializer)?;
-        Ok(helper.map(|Helper(external)| external))
+impl Into<Option<IotaExecuteTransactionRequestType>> for ExecuteTransactionRequestType {
+    fn into(self) -> Option<IotaExecuteTransactionRequestType> {
+        match self {
+            ExecuteTransactionRequestType::WaitForEffectsCert => {
+                Some(IotaExecuteTransactionRequestType::WaitForEffectsCert)
+            }
+            ExecuteTransactionRequestType::WaitForLocalExecution => {
+                Some(IotaExecuteTransactionRequestType::WaitForLocalExecution)
+            }
+        }
     }
 }
 

--- a/src/rpc/server.rs
+++ b/src/rpc/server.rs
@@ -251,6 +251,7 @@ async fn execute_tx(
         reservation_id,
         tx_bytes,
         user_sig: user_sig_raw,
+        request_type,
     } = payload;
     let Ok((tx_data, user_sig)) = convert_tx_and_sig(tx_bytes.clone(), user_sig_raw.clone()) else {
         return (
@@ -269,6 +270,7 @@ async fn execute_tx(
         reservation_id,
         tx_bytes,
         user_sig_raw,
+        request_type,
         headers,
     );
 
@@ -283,7 +285,7 @@ async fn execute_tx(
     ))
     .await
     .unwrap_or_else(|err| {
-        error!("Failed to spawn reserve_gas task: {:?}", err);
+        error!("Failed to spawn execute_tx task: {:?}", err);
         (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(ExecuteTxResponse::new_err(anyhow::anyhow!(
@@ -332,7 +334,7 @@ async fn execute_tx_impl(
 
     let transaction_digest = tx_data.digest();
     match gas_station
-        .execute_transaction(ctx.reservation_id, tx_data, user_sig)
+        .execute_transaction(ctx.reservation_id, tx_data, user_sig, ctx.request_type)
         .await
     {
         Ok(effects) => {


### PR DESCRIPTION
PR adds the `request_type` field to `/v1/execute_tx` to allow callers to choose, if they want to execute a transaction with

- `waitForEffectsCert` (default, matches behavior before this PR)
- `waitForLocalExecution`

## Details

Field behavior matches `execute_transaction_block`s `request_type` argument.

Note, that the field is serialized as camel case to match hook's enum serialization instead of Pascal case (the default serialization of the `ExecuteTransactionRequestType` from `iota` crate).

The same value is forwarded to the hook as well, where it matches its field name convention and is added under the `executeTxRequest.payload.requestType` field.

Closes #94.