### PR TITLE
chore: use multiple tags to publish the same docker image

### DIFF
--- a/.github/workflows/publish-to-dockerhub.yml
+++ b/.github/workflows/publish-to-dockerhub.yml
@@ -47,7 +47,9 @@ jobs:
           for tag in "${TAG_ARRAY[@]}"; do
             # trim leading/trailing whitespace
             tag_trimmed=$(echo "$tag" | xargs)
-            TAG_ARGS="$TAG_ARGS -t ${{ matrix.image.repo }}:$tag_trimmed"
+            if [ -n "$tag_trimmed" ]; then
+              TAG_ARGS="$TAG_ARGS -t ${{ matrix.image.repo }}:$tag_trimmed"
+            fi
           done
           echo "tag-args=$TAG_ARGS" >> $GITHUB_OUTPUT
           echo "Tags to be used: $TAG_ARGS"

--- a/.github/workflows/publish-to-dockerhub.yml
+++ b/.github/workflows/publish-to-dockerhub.yml
@@ -45,8 +45,9 @@ jobs:
           IFS=',' read -ra TAG_ARRAY <<< "${{ github.event.inputs.tags }}"
           TAG_ARGS=""
           for tag in "${TAG_ARRAY[@]}"; do
-            tag=$(echo "$tag" | xargs)
-            TAG_ARGS="$TAG_ARGS -t ${{ matrix.image.repo }}:$tag"
+            # trim leading/trailing whitespace
+            tag_trimmed=$(echo "$tag" | xargs)
+            TAG_ARGS="$TAG_ARGS -t ${{ matrix.image.repo }}:$tag_trimmed"
           done
           echo "tag-args=$TAG_ARGS" >> $GITHUB_OUTPUT
           echo "Tags to be used: $TAG_ARGS"

--- a/.github/workflows/publish-to-dockerhub.yml
+++ b/.github/workflows/publish-to-dockerhub.yml
@@ -24,8 +24,8 @@ jobs:
     strategy:
       matrix:
         image:
-          - { name: "iota-gas-station", repo: "iotaledger/gas-station" }
-          - { name: "tool", repo: "iotaledger/gas-station-tool" }
+          - { name: "iota-gas-station", repo: "atoicafe/gas-station" }
+          # - { name: "tool", repo: "iotaledger/gas-station-tool" }
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4

--- a/.github/workflows/publish-to-dockerhub.yml
+++ b/.github/workflows/publish-to-dockerhub.yml
@@ -3,8 +3,8 @@ name: publish to DockerHub
 on:
   workflow_dispatch:
     inputs:
-      tag:
-        description: "Tag to publish under, defaults to latest"
+      tags:
+        description: "Comma-separated list of tags to publish (e.g., '0.2,latest')"
         required: false
         default: latest
       branch:
@@ -38,14 +38,27 @@ jobs:
           username: ${{ secrets.IOTALEDGER_DOCKER_USERNAME }}
           password: ${{ secrets.IOTALEDGER_DOCKER_PASSWORD }}
 
+      - name: Parse tags
+        id: parse-tags
+        run: |
+          # Convert comma-separated tags to array and build tag arguments
+          IFS=',' read -ra TAG_ARRAY <<< "${{ github.event.inputs.tags }}"
+          TAG_ARGS=""
+          for tag in "${TAG_ARRAY[@]}"; do
+            tag=$(echo "$tag" | xargs)  # trim whitespace
+            TAG_ARGS="$TAG_ARGS -t ${{ matrix.image.repo }}:$tag"
+          done
+          echo "tag-args=$TAG_ARGS" >> $GITHUB_OUTPUT
+          echo "Tags to be used: $TAG_ARGS"
+
       - name: Build image with build.sh
         run: |
-          ENTRY_BINARY=${{ matrix.image.name }} docker/build.sh -t ${{ matrix.image.repo }}:${{ github.event.inputs.tag }}
+          ENTRY_BINARY=${{ matrix.image.name }} docker/build.sh ${{ steps.parse-tags.outputs.tag-args }}
 
-      - name: Push docker image
+      - name: Push docker images
         if: ${{ github.event.inputs.is-dry-run != 'true' }}
         run: |
-          docker push ${{ matrix.image.repo }}:${{ github.event.inputs.tag }}
+          docker push --all-tags ${{ matrix.image.repo }}
 
       # - name: Docker Hub Description for ${{ matrix.image.repo }}
       #   if: ${{ github.event.inputs.is-dry-run  == 'false'}}

--- a/.github/workflows/publish-to-dockerhub.yml
+++ b/.github/workflows/publish-to-dockerhub.yml
@@ -24,8 +24,8 @@ jobs:
     strategy:
       matrix:
         image:
-          - { name: "iota-gas-station", repo: "atoicafe/gas-station" }
-          # - { name: "tool", repo: "iotaledger/gas-station-tool" }
+          - { name: "iota-gas-station", repo: "iotaledger/gas-station" }
+          - { name: "tool", repo: "iotaledger/gas-station-tool" }
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4
@@ -45,7 +45,7 @@ jobs:
           IFS=',' read -ra TAG_ARRAY <<< "${{ github.event.inputs.tags }}"
           TAG_ARGS=""
           for tag in "${TAG_ARRAY[@]}"; do
-            tag=$(echo "$tag" | xargs)  # trim whitespace
+            tag=$(echo "$tag" | xargs)
             TAG_ARGS="$TAG_ARGS -t ${{ matrix.image.repo }}:$tag"
           done
           echo "tag-args=$TAG_ARGS" >> $GITHUB_OUTPUT


### PR DESCRIPTION
**Description:**
This PR enhances the GitHub workflow to support building and pushing Docker images with **multiple tags** specified in a **comma-separated list**.

* The list of tags is parsed and passed to the `docker build` command using multiple `-t` flags.
* After building, all tagged images are pushed using `docker push --all-tags`.

This makes it easier to publish the same image under different tags (e.g., `latest`, `v0.2`, `stable`) in a single workflow run.
