### PR TITLE
fix:  empty `GAS_STATION_AUTH` handling 

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -27,7 +27,7 @@ services:
     environment:
       - CONFIG_PATH=/app/config.yaml
       - RUST_BACKTRACE=1
-      - GAS_STATION_AUTH=${GAS_STATION_AUTH}
+      - GAS_STATION_AUTH=${GAS_STATION_AUTH:-}
     volumes:
       - ${LOCAL_CONFIG_PATH:-./config.yaml}:/app/config.yaml
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,5 +42,12 @@ pub const GIT_REVISION: &str = {
 pub const VERSION: &str = const_str::concat!(env!("CARGO_PKG_VERSION"), "-", GIT_REVISION);
 
 pub fn read_auth_env() -> Option<String> {
-    std::env::var(AUTH_ENV_NAME).ok()
+    if let Ok(auth) = std::env::var(AUTH_ENV_NAME) {
+        if auth.is_empty() {
+            return None;
+        }
+        Some(auth)
+    } else {
+        None
+    }
 }

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -20,8 +20,8 @@ mod tests {
     use crate::rpc::ExecuteTransactionRequestType;
     use crate::test_env::{
         create_test_transaction, start_rpc_server_for_testing,
-        start_rpc_server_for_testing_no_auth, start_rpc_server_for_testing_with_access_controller,
-        DEFAULT_TEST_CONFIG_PATH,
+        start_rpc_server_for_testing_empty_auth, start_rpc_server_for_testing_no_auth,
+        start_rpc_server_for_testing_with_access_controller, DEFAULT_TEST_CONFIG_PATH,
     };
     use crate::AUTH_ENV_NAME;
     use iota_config::Config;
@@ -70,6 +70,19 @@ mod tests {
     async fn test_no_auth() {
         let (_test_cluster, _container, server) =
             start_rpc_server_for_testing_no_auth(vec![NANOS_PER_IOTA; 10], NANOS_PER_IOTA).await;
+
+        let client = server.get_local_client();
+        client.health().await.unwrap();
+
+        let (_sponsor, _res_id, gas_coins) = client.reserve_gas(NANOS_PER_IOTA, 10).await.unwrap();
+        assert_eq!(gas_coins.len(), 1);
+        assert!(client.reserve_gas(NANOS_PER_IOTA, 10).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_empty_auth() {
+        let (_test_cluster, _container, server) =
+            start_rpc_server_for_testing_empty_auth(vec![NANOS_PER_IOTA; 10], NANOS_PER_IOTA).await;
 
         let client = server.get_local_client();
         client.health().await.unwrap();

--- a/src/test_env.rs
+++ b/src/test_env.rs
@@ -126,6 +126,28 @@ pub async fn start_rpc_server_for_testing_no_auth(
     (test_cluster, container, server)
 }
 
+pub async fn start_rpc_server_for_testing_empty_auth(
+    init_gas_amounts: Vec<u64>,
+    target_init_balance: u64,
+) -> (TestCluster, GasStationContainer, GasStationServer) {
+    let (test_cluster, container) = start_gas_station(init_gas_amounts, target_init_balance).await;
+    let localhost = localhost_for_testing();
+    let signer_address = container.get_signer_address();
+    std::env::set_var(AUTH_ENV_NAME, "");
+
+    let server = GasStationServer::new(
+        container.get_gas_station_arc(),
+        localhost.parse().unwrap(),
+        get_available_port(&localhost),
+        GasStationRpcMetrics::new_for_testing(),
+        Arc::new(ArcSwap::new(Arc::new(AccessController::default()))),
+        new_stats_tracker_for_testing(signer_address).await,
+        PathBuf::from_str(DEFAULT_TEST_CONFIG_PATH).unwrap(),
+    )
+    .await;
+    (test_cluster, container, server)
+}
+
 pub async fn start_rpc_server_for_testing_with_access_controller(
     init_gas_amounts: Vec<u64>,
     target_init_balance: u64,


### PR DESCRIPTION
### Description
This PR fixes how the `GAS_STATION_AUTH` environment variable is handled.

- **Interpret empty `GAS_STATION_AUTH` as unset**: If the variable is set but empty, treat it as not set.
- **Make `GAS_STATION_AUTH` optional in docker-compose**.

This avoids issues where docker-compose defines the variable with an empty string, which previously was treated as “set” and caused unintended authentication behavior.

### Behavior
- **Missing or empty `GAS_STATION_AUTH`**: authentication is disabled.
- **Non-empty `GAS_STATION_AUTH`**: authentication is enabled and required.

closes #108 