### PR TITLE
docs: access controller debug

### DIFF
--- a/docs/common-issues.md
+++ b/docs/common-issues.md
@@ -36,7 +36,8 @@ redis-cli FLUSHALL
 When executing a transaction, you get a 403 HTTP response with the message: `Access Denied by Access Controller`
 
 **Explanation:**
-The Access Controller in Gas Station is a robust tool designed to enable the creation of highly intricate filtering logic. However, with its complexity and flexibility, there is a chance that you might misunderstand or overlook certain behaviors of the rule-matching system. It is likely that you may have neglected some aspect of the access controller that is preventing your request from being processed.
+
+The Access Controller in Gas Station is a robust tool designed to enable the creation of highly intricate filtering logic. However, with its complexity and flexibility, it can become hard to pin down why a certain transaction was rejected or allowed. This might become even more likely in larger and/or more fine granular rule sets.
 
 **Solution:**
 

--- a/docs/common-issues.md
+++ b/docs/common-issues.md
@@ -28,3 +28,33 @@ If you have a local instance or an instance with persistent storage, you can use
 ```bash
 redis-cli FLUSHALL
 ```
+
+## Access Denied by Access Controller
+
+**Problem:**
+
+When executing a transaction, you get a 403 HTTP response with the message: `Access Denied by Access Controller`
+
+**Explanation:**
+The Access Controller in Gas Station is a robust tool designed to enable the creation of highly intricate filtering logic. However, with its complexity and flexibility, there is a chance that you might misunderstand or overlook certain behaviors of the rule-matching system. It is likely that you may have neglected some aspect of the access controller that is preventing your request from being processed.
+
+**Solution:**
+
+The IOTA Gas Station [PR](https://github.com/iotaledger/gas-station/pull/114) introduces the ability to inspect in detail the behavior of the Access Controller.
+
+To see a detailed report of the transaction, you must enable the `tracing` level for the access controller module. This can be done using the `RUST_LOG` environment variable.
+
+If you start the binary directly:
+
+```log
+   RUST_LOG=iota_gas_station::access_controller=trace ./iota-gas-station
+```
+
+In case you use Docker Compose, please edit the docker-compose file:
+
+```yaml
+  iota-gas-station:
+  ...
+    environment:
+    - RUST_LOG=iota_gas_station::access_controller=trace
+```

--- a/examples/rust/README.md
+++ b/examples/rust/README.md
@@ -13,4 +13,4 @@ GAS_STATION_AUTH='your-bearer-token' cargo run --example sponsored_transaction
 
 ## Common Issues
 
-If you encounter any problems please check [Common Issues](../../docs/troubleshooting.md) section.
+If you encounter any problems please check [Common Issues](../../docs/common-issues.md) section.

--- a/examples/ts/README.md
+++ b/examples/ts/README.md
@@ -54,4 +54,4 @@ npx ts-node gasStationTest.ts
 
 ## Common Issues
 
-If you encounter any problems please check [Common Issues](../../docs/troubleshooting.md) section.
+If you encounter any problems please check [Common Issues](../../docs/common-issues.md) section.


### PR DESCRIPTION
### Description

This commit adds comprehensive documentation for debugging Access Controller issues and fixes broken documentation links in example README files.


#### Changes:

1. **Added Access Controller Debug Documentation** (`docs/common-issues.md`):
    - Added a new section "Access Denied by Access Controller" explaining the 403 error scenario
2. **Fixed Documentation Links**:
   - Updated `examples/rust/README.md` to point to the correct `common-issues.md` file instead of the non-existent `troubleshooting.md`
   - Updated `examples/ts/README.md` to point to the correct `common-issues.md` file instead of the non-existent `troubleshooting.md`

part of #121 