### PR TITLE
docs: rule syntax word delimiter

### DIFF
--- a/docs/access-controller.md
+++ b/docs/access-controller.md
@@ -11,8 +11,8 @@ The **Gas Station Server** includes an **Access Controller** mechanism to manage
 | `move-call-package-address` |  no        | `"0x0000..."`, `["0x0000...", "0x1111..."]`, `"*"`             |
 | `ptb-command-count`         |  no        | `"=10"`, `"<10"`,  `"<=10"`, `">10"`, `">=10"`, `"!=10"`       |
 | `action`                    |  yes       | `allow`, `deny`, [Hook Server URL](#hook-server)               |
-| `gas_usage`                 |  no        | See [Gas Usage Filter](#gas-usage-filter)                      |
-| `rego_expression`           |  no        | See [Gas Rego Expression](#rego-expression-filter)             |
+| `gas-usage`                 |  no        | See [Gas Usage Filter](#gas-usage-filter)                      |
+| `rego-expression`           |  no        | See [Gas Rego Expression](#rego-expression-filter)             |
 
 ## Access Controller Examples
 


### PR DESCRIPTION
### Description
This is a minor documentation fix of the invalid naming convention for rule parameters in the access controller documentation.