### PR TITLE
Update `iota-sdk` version to `v1.7.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1080,8 +1080,8 @@ dependencies = [
 
 [[package]]
 name = "bin-version"
-version = "1.5.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.5.0#e8adad33aa8bf5d4463c084a2a93a3802bc0b122"
+version = "1.7.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "const-str",
  "git-version",
@@ -1766,7 +1766,7 @@ dependencies = [
 [[package]]
 name = "consensus-config"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.5.0#e8adad33aa8bf5d4463c084a2a93a3802bc0b122"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "fastcrypto",
  "iota-network-stack",
@@ -1778,7 +1778,7 @@ dependencies = [
 [[package]]
 name = "consensus-core"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.5.0#e8adad33aa8bf5d4463c084a2a93a3802bc0b122"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "async-trait",
  "base64 0.21.7",
@@ -2657,7 +2657,7 @@ dependencies = [
 [[package]]
 name = "enum-compat-util"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.5.0#e8adad33aa8bf5d4463c084a2a93a3802bc0b122"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "serde_yaml 0.8.26",
 ]
@@ -2985,6 +2985,12 @@ name = "fixedbitset"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "fixedbitset"
@@ -3422,7 +3428,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.8.0",
+ "indexmap 2.11.4",
  "slab",
  "tokio",
  "tokio-util 0.7.14",
@@ -3441,7 +3447,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.3.1",
- "indexmap 2.8.0",
+ "indexmap 2.11.4",
  "slab",
  "tokio",
  "tokio-util 0.7.14",
@@ -4054,13 +4060,14 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.8.0"
+version = "2.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3954d50fe15b02142bf25d3b8bdadb634ec3948f103d04ffe3031bc8fe9d7058"
+checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.2",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -4139,7 +4146,7 @@ dependencies = [
 [[package]]
 name = "iota-adapter-latest"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.5.0#e8adad33aa8bf5d4463c084a2a93a3802bc0b122"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4166,8 +4173,8 @@ dependencies = [
 
 [[package]]
 name = "iota-archival"
-version = "1.5.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.5.0#e8adad33aa8bf5d4463c084a2a93a3802bc0b122"
+version = "1.7.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -4191,8 +4198,8 @@ dependencies = [
 
 [[package]]
 name = "iota-authority-aggregation"
-version = "1.5.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.5.0#e8adad33aa8bf5d4463c084a2a93a3802bc0b122"
+version = "1.7.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "futures",
  "iota-metrics",
@@ -4203,8 +4210,8 @@ dependencies = [
 
 [[package]]
 name = "iota-common"
-version = "1.5.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.5.0#e8adad33aa8bf5d4463c084a2a93a3802bc0b122"
+version = "1.7.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -4222,8 +4229,8 @@ dependencies = [
 
 [[package]]
 name = "iota-config"
-version = "1.5.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.5.0#e8adad33aa8bf5d4463c084a2a93a3802bc0b122"
+version = "1.7.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "anemo",
  "anyhow",
@@ -4251,12 +4258,13 @@ dependencies = [
 
 [[package]]
 name = "iota-core"
-version = "1.5.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.5.0#e8adad33aa8bf5d4463c084a2a93a3802bc0b122"
+version = "1.7.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "anemo",
  "anyhow",
  "arc-swap",
+ "async-stream",
  "async-trait",
  "axum 0.8.4",
  "bcs",
@@ -4319,6 +4327,8 @@ dependencies = [
  "serde_json",
  "serde_with",
  "shared-crypto",
+ "starfish-config",
+ "starfish-core",
  "static_assertions",
  "tap",
  "telemetry-subscribers",
@@ -4368,8 +4378,8 @@ dependencies = [
 
 [[package]]
 name = "iota-enum-compat-util"
-version = "1.5.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.5.0#e8adad33aa8bf5d4463c084a2a93a3802bc0b122"
+version = "1.7.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "serde_yaml 0.8.26",
 ]
@@ -4377,7 +4387,7 @@ dependencies = [
 [[package]]
 name = "iota-execution"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.5.0#e8adad33aa8bf5d4463c084a2a93a3802bc0b122"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "iota-adapter-latest",
  "iota-move-natives-latest",
@@ -4394,8 +4404,8 @@ dependencies = [
 
 [[package]]
 name = "iota-framework"
-version = "1.5.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.5.0#e8adad33aa8bf5d4463c084a2a93a3802bc0b122"
+version = "1.7.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "bcs",
  "iota-types",
@@ -4407,8 +4417,8 @@ dependencies = [
 
 [[package]]
 name = "iota-framework-snapshot"
-version = "1.5.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.5.0#e8adad33aa8bf5d4463c084a2a93a3802bc0b122"
+version = "1.7.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4443,7 +4453,7 @@ dependencies = [
  "iota-config",
  "iota-json-rpc-types",
  "iota-metrics",
- "iota-sdk 1.5.0",
+ "iota-sdk 1.7.0",
  "iota-swarm-config",
  "iota-types",
  "itertools 0.14.0",
@@ -4476,8 +4486,8 @@ dependencies = [
 
 [[package]]
 name = "iota-genesis-builder"
-version = "1.5.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.5.0#e8adad33aa8bf5d4463c084a2a93a3802bc0b122"
+version = "1.7.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4526,8 +4536,8 @@ dependencies = [
 
 [[package]]
 name = "iota-genesis-common"
-version = "1.5.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.5.0#e8adad33aa8bf5d4463c084a2a93a3802bc0b122"
+version = "1.7.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "iota-execution",
  "iota-protocol-config",
@@ -4537,8 +4547,8 @@ dependencies = [
 
 [[package]]
 name = "iota-http"
-version = "1.5.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.5.0#e8adad33aa8bf5d4463c084a2a93a3802bc0b122"
+version = "1.7.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "bytes",
  "http 1.3.1",
@@ -4557,8 +4567,8 @@ dependencies = [
 
 [[package]]
 name = "iota-json"
-version = "1.5.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.5.0#e8adad33aa8bf5d4463c084a2a93a3802bc0b122"
+version = "1.7.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4574,8 +4584,8 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc"
-version = "1.5.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.5.0#e8adad33aa8bf5d4463c084a2a93a3802bc0b122"
+version = "1.7.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4590,7 +4600,7 @@ dependencies = [
  "futures",
  "http-body 1.0.1",
  "hyper 1.6.0",
- "indexmap 2.8.0",
+ "indexmap 2.11.4",
  "iota-config",
  "iota-core",
  "iota-json",
@@ -4627,8 +4637,8 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc-api"
-version = "1.5.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.5.0#e8adad33aa8bf5d4463c084a2a93a3802bc0b122"
+version = "1.7.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -4647,8 +4657,8 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc-types"
-version = "1.5.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.5.0#e8adad33aa8bf5d4463c084a2a93a3802bc0b122"
+version = "1.7.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4681,8 +4691,8 @@ dependencies = [
 
 [[package]]
 name = "iota-keys"
-version = "1.5.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.5.0#e8adad33aa8bf5d4463c084a2a93a3802bc0b122"
+version = "1.7.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "anyhow",
  "bip32",
@@ -4702,8 +4712,8 @@ dependencies = [
 
 [[package]]
 name = "iota-macros"
-version = "1.5.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.5.0#e8adad33aa8bf5d4463c084a2a93a3802bc0b122"
+version = "1.7.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "futures",
  "iota-proc-macros",
@@ -4713,8 +4723,8 @@ dependencies = [
 
 [[package]]
 name = "iota-mainnet-unlocks"
-version = "1.5.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.5.0#e8adad33aa8bf5d4463c084a2a93a3802bc0b122"
+version = "1.7.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4726,8 +4736,8 @@ dependencies = [
 
 [[package]]
 name = "iota-metrics"
-version = "1.5.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.5.0#e8adad33aa8bf5d4463c084a2a93a3802bc0b122"
+version = "1.7.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -4752,8 +4762,8 @@ dependencies = [
 
 [[package]]
 name = "iota-move-build"
-version = "1.5.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.5.0#e8adad33aa8bf5d4463c084a2a93a3802bc0b122"
+version = "1.7.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -4775,14 +4785,14 @@ dependencies = [
 [[package]]
 name = "iota-move-natives-latest"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.5.0#e8adad33aa8bf5d4463c084a2a93a3802bc0b122"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "bcs",
  "better_any",
  "fastcrypto",
  "fastcrypto-vdf",
  "fastcrypto-zkp",
- "indexmap 2.8.0",
+ "indexmap 2.11.4",
  "iota-protocol-config",
  "iota-types",
  "move-binary-format",
@@ -4797,8 +4807,8 @@ dependencies = [
 
 [[package]]
 name = "iota-names"
-version = "1.5.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.5.0#e8adad33aa8bf5d4463c084a2a93a3802bc0b122"
+version = "1.7.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4810,8 +4820,8 @@ dependencies = [
 
 [[package]]
 name = "iota-network"
-version = "1.5.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.5.0#e8adad33aa8bf5d4463c084a2a93a3802bc0b122"
+version = "1.7.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "anemo",
  "anemo-build",
@@ -4847,8 +4857,8 @@ dependencies = [
 
 [[package]]
 name = "iota-network-stack"
-version = "1.5.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.5.0#e8adad33aa8bf5d4463c084a2a93a3802bc0b122"
+version = "1.7.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "anemo",
  "bcs",
@@ -4876,8 +4886,8 @@ dependencies = [
 
 [[package]]
 name = "iota-node"
-version = "1.5.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.5.0#e8adad33aa8bf5d4463c084a2a93a3802bc0b122"
+version = "1.7.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -4925,8 +4935,8 @@ dependencies = [
 
 [[package]]
 name = "iota-open-rpc"
-version = "1.5.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.5.0#e8adad33aa8bf5d4463c084a2a93a3802bc0b122"
+version = "1.7.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "schemars",
  "serde",
@@ -4936,8 +4946,8 @@ dependencies = [
 
 [[package]]
 name = "iota-open-rpc-macros"
-version = "1.5.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.5.0#e8adad33aa8bf5d4463c084a2a93a3802bc0b122"
+version = "1.7.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "derive-syn-parse",
  "itertools 0.13.0",
@@ -4949,14 +4959,14 @@ dependencies = [
 
 [[package]]
 name = "iota-package-management"
-version = "1.5.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.5.0#e8adad33aa8bf5d4463c084a2a93a3802bc0b122"
+version = "1.7.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "anyhow",
  "iota-framework-snapshot",
  "iota-json-rpc-types",
  "iota-protocol-config",
- "iota-sdk 1.5.0",
+ "iota-sdk 1.7.0",
  "iota-types",
  "move-core-types",
  "move-package",
@@ -4966,8 +4976,8 @@ dependencies = [
 
 [[package]]
 name = "iota-package-resolver"
-version = "1.5.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.5.0#e8adad33aa8bf5d4463c084a2a93a3802bc0b122"
+version = "1.7.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "async-trait",
  "bcs",
@@ -4982,8 +4992,8 @@ dependencies = [
 
 [[package]]
 name = "iota-proc-macros"
-version = "1.5.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.5.0#e8adad33aa8bf5d4463c084a2a93a3802bc0b122"
+version = "1.7.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "msim-macros",
  "proc-macro2",
@@ -4993,8 +5003,8 @@ dependencies = [
 
 [[package]]
 name = "iota-protocol-config"
-version = "1.5.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.5.0#e8adad33aa8bf5d4463c084a2a93a3802bc0b122"
+version = "1.7.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "clap",
  "iota-protocol-config-macros",
@@ -5008,8 +5018,8 @@ dependencies = [
 
 [[package]]
 name = "iota-protocol-config-macros"
-version = "1.5.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.5.0#e8adad33aa8bf5d4463c084a2a93a3802bc0b122"
+version = "1.7.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5018,8 +5028,8 @@ dependencies = [
 
 [[package]]
 name = "iota-rest-api"
-version = "1.5.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.5.0#e8adad33aa8bf5d4463c084a2a93a3802bc0b122"
+version = "1.7.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "anyhow",
  "axum 0.8.4",
@@ -5048,7 +5058,7 @@ dependencies = [
 [[package]]
 name = "iota-rust-sdk"
 version = "0.0.0"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=93580286f3714248398d17e4481daf608508856a#93580286f3714248398d17e4481daf608508856a"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=d7084eaf0564f4e2381b2e8408ee1f7d51468450#d7084eaf0564f4e2381b2e8408ee1f7d51468450"
 dependencies = [
  "base64ct",
  "bcs",
@@ -5099,8 +5109,8 @@ dependencies = [
 
 [[package]]
 name = "iota-sdk"
-version = "1.5.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.5.0#e8adad33aa8bf5d4463c084a2a93a3802bc0b122"
+version = "1.7.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5133,8 +5143,8 @@ dependencies = [
 
 [[package]]
 name = "iota-simulator"
-version = "1.5.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.5.0#e8adad33aa8bf5d4463c084a2a93a3802bc0b122"
+version = "1.7.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -5156,8 +5166,8 @@ dependencies = [
 
 [[package]]
 name = "iota-snapshot"
-version = "1.5.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.5.0#e8adad33aa8bf5d4463c084a2a93a3802bc0b122"
+version = "1.7.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5183,8 +5193,8 @@ dependencies = [
 
 [[package]]
 name = "iota-storage"
-version = "1.5.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.5.0#e8adad33aa8bf5d4463c084a2a93a3802bc0b122"
+version = "1.7.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5232,8 +5242,8 @@ dependencies = [
 
 [[package]]
 name = "iota-swarm"
-version = "1.5.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.5.0#e8adad33aa8bf5d4463c084a2a93a3802bc0b122"
+version = "1.7.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "anyhow",
  "futures",
@@ -5260,8 +5270,8 @@ dependencies = [
 
 [[package]]
 name = "iota-swarm-config"
-version = "1.5.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.5.0#e8adad33aa8bf5d4463c084a2a93a3802bc0b122"
+version = "1.7.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "anemo",
  "anyhow",
@@ -5287,13 +5297,13 @@ dependencies = [
 
 [[package]]
 name = "iota-test-transaction-builder"
-version = "1.5.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.5.0#e8adad33aa8bf5d4463c084a2a93a3802bc0b122"
+version = "1.7.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "bcs",
  "iota-genesis-builder",
  "iota-move-build",
- "iota-sdk 1.5.0",
+ "iota-sdk 1.7.0",
  "iota-types",
  "move-core-types",
  "shared-crypto",
@@ -5301,8 +5311,8 @@ dependencies = [
 
 [[package]]
 name = "iota-tls"
-version = "1.5.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.5.0#e8adad33aa8bf5d4463c084a2a93a3802bc0b122"
+version = "1.7.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -5323,8 +5333,8 @@ dependencies = [
 
 [[package]]
 name = "iota-transaction-builder"
-version = "1.5.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.5.0#e8adad33aa8bf5d4463c084a2a93a3802bc0b122"
+version = "1.7.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5340,8 +5350,8 @@ dependencies = [
 
 [[package]]
 name = "iota-transaction-checks"
-version = "1.5.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.5.0#e8adad33aa8bf5d4463c084a2a93a3802bc0b122"
+version = "1.7.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "fastcrypto-zkp",
  "iota-config",
@@ -5354,8 +5364,8 @@ dependencies = [
 
 [[package]]
 name = "iota-types"
-version = "1.5.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.5.0#e8adad33aa8bf5d4463c084a2a93a3802bc0b122"
+version = "1.7.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "anemo",
  "anyhow",
@@ -5374,7 +5384,7 @@ dependencies = [
  "fastcrypto-zkp",
  "hex",
  "im",
- "indexmap 2.8.0",
+ "indexmap 2.11.4",
  "iota-enum-compat-util",
  "iota-macros",
  "iota-network-stack",
@@ -5406,6 +5416,7 @@ dependencies = [
  "serde_with",
  "shared-crypto",
  "signature 1.6.4",
+ "starfish-config",
  "static_assertions",
  "strum 0.26.3",
  "strum_macros 0.26.4",
@@ -5419,7 +5430,7 @@ dependencies = [
 [[package]]
 name = "iota-verifier-latest"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.5.0#e8adad33aa8bf5d4463c084a2a93a3802bc0b122"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "iota-types",
  "move-abstract-interpreter",
@@ -6197,7 +6208,7 @@ dependencies = [
 [[package]]
 name = "move-abstract-interpreter"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.5.0#e8adad33aa8bf5d4463c084a2a93a3802bc0b122"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "move-binary-format",
  "move-bytecode-verifier-meter",
@@ -6206,12 +6217,12 @@ dependencies = [
 [[package]]
 name = "move-abstract-stack"
 version = "0.0.1"
-source = "git+https://github.com/iotaledger/iota?tag=v1.5.0#e8adad33aa8bf5d4463c084a2a93a3802bc0b122"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/iotaledger/iota?tag=v1.5.0#e8adad33aa8bf5d4463c084a2a93a3802bc0b122"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "anyhow",
  "enum-compat-util",
@@ -6225,12 +6236,12 @@ dependencies = [
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/iotaledger/iota?tag=v1.5.0#e8adad33aa8bf5d4463c084a2a93a3802bc0b122"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.5.0#e8adad33aa8bf5d4463c084a2a93a3802bc0b122"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6246,10 +6257,10 @@ dependencies = [
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.5.0#e8adad33aa8bf5d4463c084a2a93a3802bc0b122"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "anyhow",
- "indexmap 2.8.0",
+ "indexmap 2.11.4",
  "move-binary-format",
  "move-core-types",
  "petgraph 0.5.1",
@@ -6260,7 +6271,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.5.0#e8adad33aa8bf5d4463c084a2a93a3802bc0b122"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "move-abstract-interpreter",
  "move-abstract-stack",
@@ -6275,7 +6286,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier-meter"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.5.0#e8adad33aa8bf5d4463c084a2a93a3802bc0b122"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "move-binary-format",
  "move-core-types",
@@ -6285,7 +6296,7 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.5.0#e8adad33aa8bf5d4463c084a2a93a3802bc0b122"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6295,6 +6306,7 @@ dependencies = [
  "move-binary-format",
  "move-core-types",
  "once_cell",
+ "packed_struct",
  "serde",
  "sha2 0.9.9",
  "vfs",
@@ -6304,7 +6316,7 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/iotaledger/iota?tag=v1.5.0#e8adad33aa8bf5d4463c084a2a93a3802bc0b122"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6339,7 +6351,7 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/iotaledger/iota?tag=v1.5.0#e8adad33aa8bf5d4463c084a2a93a3802bc0b122"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6363,14 +6375,14 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.5.0#e8adad33aa8bf5d4463c084a2a93a3802bc0b122"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "anyhow",
  "bcs",
  "clap",
  "codespan",
  "colored",
- "indexmap 2.8.0",
+ "indexmap 2.11.4",
  "move-abstract-interpreter",
  "move-binary-format",
  "move-bytecode-source-map",
@@ -6384,7 +6396,7 @@ dependencies = [
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.5.0#e8adad33aa8bf5d4463c084a2a93a3802bc0b122"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6405,7 +6417,7 @@ dependencies = [
 [[package]]
 name = "move-docgen"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.5.0#e8adad33aa8bf5d4463c084a2a93a3802bc0b122"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "anyhow",
  "clap",
@@ -6428,7 +6440,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.5.0#e8adad33aa8bf5d4463c084a2a93a3802bc0b122"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -6446,7 +6458,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.5.0#e8adad33aa8bf5d4463c084a2a93a3802bc0b122"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "anyhow",
  "hex",
@@ -6459,7 +6471,7 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.5.0#e8adad33aa8bf5d4463c084a2a93a3802bc0b122"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "hex",
  "move-command-line-common",
@@ -6472,11 +6484,12 @@ dependencies = [
 [[package]]
 name = "move-model-2"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.5.0#e8adad33aa8bf5d4463c084a2a93a3802bc0b122"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "anyhow",
  "bcs",
  "codespan-reporting",
+ "indexmap 2.11.4",
  "move-binary-format",
  "move-bytecode-source-map",
  "move-command-line-common",
@@ -6492,11 +6505,12 @@ dependencies = [
 [[package]]
 name = "move-package"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.5.0#e8adad33aa8bf5d4463c084a2a93a3802bc0b122"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "anyhow",
  "clap",
  "colored",
+ "dunce",
  "itertools 0.10.5",
  "move-binary-format",
  "move-bytecode-source-map",
@@ -6527,7 +6541,7 @@ dependencies = [
 [[package]]
 name = "move-proc-macros"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.5.0#e8adad33aa8bf5d4463c084a2a93a3802bc0b122"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "quote",
  "syn 2.0.100",
@@ -6536,7 +6550,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib-natives"
 version = "0.1.1"
-source = "git+https://github.com/iotaledger/iota?tag=v1.5.0#e8adad33aa8bf5d4463c084a2a93a3802bc0b122"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "hex",
  "move-binary-format",
@@ -6551,7 +6565,7 @@ dependencies = [
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.5.0#e8adad33aa8bf5d4463c084a2a93a3802bc0b122"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "once_cell",
  "phf",
@@ -6561,7 +6575,7 @@ dependencies = [
 [[package]]
 name = "move-trace-format"
 version = "0.0.1"
-source = "git+https://github.com/iotaledger/iota?tag=v1.5.0#e8adad33aa8bf5d4463c084a2a93a3802bc0b122"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "move-binary-format",
  "move-core-types",
@@ -6572,7 +6586,7 @@ dependencies = [
 [[package]]
 name = "move-vm-config"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.5.0#e8adad33aa8bf5d4463c084a2a93a3802bc0b122"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "move-binary-format",
  "once_cell",
@@ -6581,7 +6595,7 @@ dependencies = [
 [[package]]
 name = "move-vm-profiler"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.5.0#e8adad33aa8bf5d4463c084a2a93a3802bc0b122"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "move-vm-config",
  "once_cell",
@@ -6591,7 +6605,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.5.0#e8adad33aa8bf5d4463c084a2a93a3802bc0b122"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "better_any",
  "fail",
@@ -6611,7 +6625,7 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.5.0#e8adad33aa8bf5d4463c084a2a93a3802bc0b122"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -6625,7 +6639,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.5.0#e8adad33aa8bf5d4463c084a2a93a3802bc0b122"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "bcs",
  "move-binary-format",
@@ -7131,7 +7145,7 @@ name = "openapiv3"
 version = "2.0.0"
 source = "git+https://github.com/bmwill/openapiv3.git?rev=ca4b4845b7c159a39f5c68ad8f7f76cb6f4d6963#ca4b4845b7c159a39f5c68ad8f7f76cb6f4d6963"
 dependencies = [
- "indexmap 2.8.0",
+ "indexmap 2.11.4",
  "schemars",
  "serde",
  "serde_json",
@@ -7353,6 +7367,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "packed_struct"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36b29691432cc9eff8b282278473b63df73bea49bc3ec5e67f31a3ae9c3ec190"
+dependencies = [
+ "bitvec 1.0.1",
+ "packed_struct_codegen",
+ "serde",
+]
+
+[[package]]
+name = "packed_struct_codegen"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cd6706dfe50d53e0f6aa09e12c034c44faacd23e966ae5a209e8bdb8f179f98"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "pairing"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7501,7 +7537,7 @@ dependencies = [
  "data-encoding",
  "getrandom 0.2.15",
  "hmac",
- "indexmap 2.8.0",
+ "indexmap 2.11.4",
  "rand 0.8.5",
  "serde",
  "serde_json",
@@ -7610,7 +7646,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
  "fixedbitset 0.5.7",
- "indexmap 2.8.0",
+ "indexmap 2.11.4",
 ]
 
 [[package]]
@@ -8002,8 +8038,8 @@ dependencies = [
 
 [[package]]
 name = "prometheus-closure-metric"
-version = "1.5.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.5.0#e8adad33aa8bf5d4463c084a2a93a3802bc0b122"
+version = "1.7.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "anyhow",
  "prometheus",
@@ -8385,6 +8421,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "readme-rustdocifier"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08ad765b21a08b1a8e5cdce052719188a23772bcbefb3c439f0baaf62c56ceac"
+
+[[package]]
 name = "readonly"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8464,6 +8506,16 @@ dependencies = [
  "getrandom 0.2.15",
  "libredox",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "reed-solomon-simd"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab6badd4f4b9c93832eb3707431e8e7bea282fae96801312f0990d48b030f8c5"
+dependencies = [
+ "fixedbitset 0.4.2",
+ "readme-rustdocifier",
 ]
 
 [[package]]
@@ -9154,10 +9206,11 @@ checksum = "f638d531eccd6e23b980caf34876660d38e265409d8e99b397ab71eb3612fad0"
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.226"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "0dca6411025b24b60bfa7ec1fe1f8e710ac09782dca409ee8237ba74b51295fd"
 dependencies = [
+ "serde_core",
  "serde_derive",
 ]
 
@@ -9202,10 +9255,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_derive"
-version = "1.0.219"
+name = "serde_core"
+version = "1.0.226"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "ba2ba63999edb9dac981fb34b3e5c0d111a69b0924e253ed29d83f7c99e966a4"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.226"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8db53ae22f34573731bafa1db20f04027b2d25e02d8205921b569171699cdb33"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9225,15 +9287,16 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
 dependencies = [
- "indexmap 2.8.0",
+ "indexmap 2.11.4",
  "itoa",
  "memchr",
  "ryu",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -9299,7 +9362,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.8.0",
+ "indexmap 2.11.4",
  "serde",
  "serde_derive",
  "serde_json",
@@ -9337,7 +9400,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.8.0",
+ "indexmap 2.11.4",
  "itoa",
  "ryu",
  "serde",
@@ -9428,8 +9491,8 @@ dependencies = [
 
 [[package]]
 name = "shared-crypto"
-version = "1.5.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.5.0#e8adad33aa8bf5d4463c084a2a93a3802bc0b122"
+version = "1.7.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "bcs",
  "eyre",
@@ -9687,6 +9750,70 @@ dependencies = [
  "libc",
  "psm",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "starfish-config"
+version = "0.1.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
+dependencies = [
+ "fastcrypto",
+ "iota-network-stack",
+ "rand 0.8.5",
+ "serde",
+ "shared-crypto",
+]
+
+[[package]]
+name = "starfish-core"
+version = "0.1.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
+dependencies = [
+ "anyhow",
+ "arc-swap",
+ "async-trait",
+ "base64 0.21.7",
+ "bcs",
+ "bytes",
+ "cfg-if",
+ "dashmap",
+ "enum_dispatch",
+ "fastcrypto",
+ "futures",
+ "http 1.3.1",
+ "iota-common",
+ "iota-http",
+ "iota-macros",
+ "iota-metrics",
+ "iota-network-stack",
+ "iota-protocol-config",
+ "iota-tls",
+ "itertools 0.13.0",
+ "nom",
+ "parking_lot 0.12.3",
+ "prometheus",
+ "prost",
+ "quinn-proto",
+ "rand 0.8.5",
+ "reed-solomon-simd",
+ "rustls",
+ "serde",
+ "shared-crypto",
+ "starfish-config",
+ "strum_macros 0.26.4",
+ "tap",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-rustls",
+ "tokio-stream",
+ "tokio-util 0.7.14",
+ "tonic 0.13.1",
+ "tonic-build",
+ "tonic-rustls",
+ "tower 0.4.13",
+ "tower-http",
+ "tracing",
+ "typed-store",
 ]
 
 [[package]]
@@ -9977,8 +10104,8 @@ dependencies = [
 
 [[package]]
 name = "telemetry-subscribers"
-version = "1.5.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.5.0#e8adad33aa8bf5d4463c084a2a93a3802bc0b122"
+version = "1.7.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "atomic_float",
  "bytes",
@@ -10043,12 +10170,13 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "test-cluster"
-version = "1.5.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.5.0#e8adad33aa8bf5d4463c084a2a93a3802bc0b122"
+version = "1.7.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "anyhow",
  "fastcrypto-zkp",
  "futures",
+ "iota-common",
  "iota-config",
  "iota-core",
  "iota-framework",
@@ -10058,7 +10186,7 @@ dependencies = [
  "iota-keys",
  "iota-node",
  "iota-protocol-config",
- "iota-sdk 1.5.0",
+ "iota-sdk 1.7.0",
  "iota-simulator",
  "iota-swarm",
  "iota-swarm-config",
@@ -10392,7 +10520,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.8.0",
+ "indexmap 2.11.4",
  "toml_datetime",
  "winnow 0.5.40",
 ]
@@ -10403,7 +10531,7 @@ version = "0.22.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
 dependencies = [
- "indexmap 2.8.0",
+ "indexmap 2.11.4",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -10552,7 +10680,7 @@ checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap 2.8.0",
+ "indexmap 2.11.4",
  "pin-project-lite",
  "slab",
  "sync_wrapper 1.0.2",
@@ -10765,10 +10893,9 @@ dependencies = [
 
 [[package]]
 name = "typed-store"
-version = "1.5.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.5.0#e8adad33aa8bf5d4463c084a2a93a3802bc0b122"
+version = "1.7.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
- "async-trait",
  "bcs",
  "bincode",
  "collectable",
@@ -10776,7 +10903,6 @@ dependencies = [
  "fdlimit",
  "hdrhistogram",
  "iota-macros",
- "itertools 0.13.0",
  "msim",
  "once_cell",
  "ouroboros 0.18.5",
@@ -10794,8 +10920,8 @@ dependencies = [
 
 [[package]]
 name = "typed-store-derive"
-version = "1.5.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.5.0#e8adad33aa8bf5d4463c084a2a93a3802bc0b122"
+version = "1.7.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
@@ -10805,8 +10931,8 @@ dependencies = [
 
 [[package]]
 name = "typed-store-error"
-version = "1.5.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.5.0#e8adad33aa8bf5d4463c084a2a93a3802bc0b122"
+version = "1.7.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "serde",
  "thiserror 1.0.69",
@@ -12009,7 +12135,7 @@ dependencies = [
  "crossbeam-utils",
  "displaydoc",
  "flate2",
- "indexmap 2.8.0",
+ "indexmap 2.11.4",
  "memchr",
  "thiserror 2.0.12",
  "zopfli",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,13 +10,13 @@ repository = "https://github.com/iotaledger/gas-station"
 
 fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "69d496c71fb37e3d22fe85e5bbfd4256d61422b9" }
 
-iota-metrics = { git = "https://github.com/iotaledger/iota", tag = "v1.5.0", package = "iota-metrics" }
-iota-config = { git = "https://github.com/iotaledger/iota", tag = "v1.5.0", package = "iota-config" }
-iota-json-rpc-types = { git = "https://github.com/iotaledger/iota", tag = "v1.5.0", package = "iota-json-rpc-types" }
-iota-sdk = { git = "https://github.com/iotaledger/iota", tag = "v1.5.0", package = "iota-sdk" }
-iota-types = { git = "https://github.com/iotaledger/iota", tag = "v1.5.0", package = "iota-types" }
-shared-crypto = { git = "https://github.com/iotaledger/iota", tag = "v1.5.0", package = "shared-crypto" }
-telemetry-subscribers = { git = "https://github.com/iotaledger/iota", tag = "v1.5.0", package = "telemetry-subscribers" }
+iota-metrics = { git = "https://github.com/iotaledger/iota", tag = "v1.7.0", package = "iota-metrics" }
+iota-config = { git = "https://github.com/iotaledger/iota", tag = "v1.7.0", package = "iota-config" }
+iota-json-rpc-types = { git = "https://github.com/iotaledger/iota", tag = "v1.7.0", package = "iota-json-rpc-types" }
+iota-sdk = { git = "https://github.com/iotaledger/iota", tag = "v1.7.0", package = "iota-sdk" }
+iota-types = { git = "https://github.com/iotaledger/iota", tag = "v1.7.0", package = "iota-types" }
+shared-crypto = { git = "https://github.com/iotaledger/iota", tag = "v1.7.0", package = "shared-crypto" }
+telemetry-subscribers = { git = "https://github.com/iotaledger/iota", tag = "v1.7.0", package = "telemetry-subscribers" }
 
 
 anyhow = "1.0.75"
@@ -50,7 +50,7 @@ tempfile = "3.2.0"
 tracing = "0.1.40"
 tokio = { version = "1.46", features = ["full"] }
 tokio-retry = "0.3.0"
-serde_json = "1.0.108"
+serde_json = "1.0.95"
 serde_json_canonicalizer = { version = "0.3.0" }
 serde_yaml = "0.8.26"
 lazy_static = "1.5.0"
@@ -64,8 +64,8 @@ url = { version = "2.5.4", features = ["serde"] }
 indoc = "2"
 rand = "0.8.5"
 wiremock = "0.6.3"
-iota-swarm-config = { git = "https://github.com/iotaledger/iota", tag = "v1.5.0", package = "iota-swarm-config" }
-test-cluster = { git = "https://github.com/iotaledger/iota", tag = "v1.5.0", package = "test-cluster" }
+iota-swarm-config = { git = "https://github.com/iotaledger/iota", tag = "v1.7.0", package = "iota-swarm-config" }
+test-cluster = { git = "https://github.com/iotaledger/iota", tag = "v1.7.0", package = "test-cluster" }
 
 [profile.release]
 panic = "abort"

--- a/examples/hook/Cargo.lock
+++ b/examples/hook/Cargo.lock
@@ -91,12 +91,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "aliasable"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd"
-
-[[package]]
 name = "alloc-no-stdlib"
 version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -135,29 +129,29 @@ dependencies = [
 [[package]]
 name = "anemo"
 version = "0.0.0"
-source = "git+https://github.com/mystenlabs/anemo.git?rev=e609f7697ed6169bf0760882a0b6c032a57e4f3b#e609f7697ed6169bf0760882a0b6c032a57e4f3b"
+source = "git+https://github.com/mystenlabs/anemo.git?rev=c4e7e4cb4b624d7738c2016d7b7885c6774ff9c2#c4e7e4cb4b624d7738c2016d7b7885c6774ff9c2"
 dependencies = [
  "anyhow",
  "async-trait",
  "bincode",
  "bytes",
- "ed25519 1.5.3",
+ "ed25519",
  "futures",
  "hex",
  "http",
  "matchit 0.5.0",
  "pin-project-lite",
- "pkcs8 0.9.0",
+ "pkcs8 0.10.2",
  "quinn",
  "quinn-proto",
  "rand 0.8.5",
  "rcgen",
  "ring",
  "rustls",
- "rustls-webpki 0.102.8",
+ "rustls-webpki",
  "serde",
  "serde_json",
- "socket2",
+ "socket2 0.5.9",
  "tap",
  "thiserror 1.0.69",
  "tokio",
@@ -165,24 +159,6 @@ dependencies = [
  "tower 0.4.13",
  "tracing",
  "x509-parser",
-]
-
-[[package]]
-name = "anemo-tower"
-version = "0.0.0"
-source = "git+https://github.com/mystenlabs/anemo.git?rev=e609f7697ed6169bf0760882a0b6c032a57e4f3b#e609f7697ed6169bf0760882a0b6c032a57e4f3b"
-dependencies = [
- "anemo",
- "bytes",
- "dashmap",
- "futures",
- "governor",
- "nonzero_ext",
- "pin-project-lite",
- "tokio",
- "tower 0.4.13",
- "tracing",
- "uuid",
 ]
 
 [[package]]
@@ -248,18 +224,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
 dependencies = [
  "derive_arbitrary",
-]
-
-[[package]]
-name = "ark-bls12-381"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c775f0d12169cba7aae4caeb547bb6a50781c7449a8aa53793827c9ec4abf488"
-dependencies = [
- "ark-ec",
- "ark-ff",
- "ark-serialize",
- "ark-std",
 ]
 
 [[package]]
@@ -460,9 +424,9 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "asn1-rs"
-version = "0.5.2"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f6fd5ddaf0351dff5b8da21b2fb4ff8e08ddd02857f0bf69c47639106c0fff0"
+checksum = "56624a96882bb8c26d61312ae18cb45868e5a9992ea73c58e45c3101e56a1e60"
 dependencies = [
  "asn1-rs-derive",
  "asn1-rs-impl",
@@ -470,31 +434,31 @@ dependencies = [
  "nom",
  "num-traits",
  "rusticata-macros",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "time",
 ]
 
 [[package]]
 name = "asn1-rs-derive"
-version = "0.4.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "726535892e8eae7e70657b4c8ea93d26b8553afb1ce617caee529ef96d7dee6c"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
- "synstructure 0.12.6",
+ "syn 2.0.101",
+ "synstructure 0.13.2",
 ]
 
 [[package]]
 name = "asn1-rs-impl"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2777730b2039ac0f95f093556e61b6d26cebed5393ca6f152717777cec3a42ed"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -511,28 +475,6 @@ dependencies = [
  "tokio",
  "zstd",
  "zstd-safe",
-]
-
-[[package]]
-name = "async-stream"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
-dependencies = [
- "async-stream-impl",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-stream-impl"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
 ]
 
 [[package]]
@@ -566,47 +508,11 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "axum"
-version = "0.7.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
-dependencies = [
- "async-trait",
- "axum-core 0.4.5",
- "base64 0.22.1",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-util",
- "itoa",
- "matchit 0.7.3",
- "memchr",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "rustversion",
- "serde",
- "serde_json",
- "serde_path_to_error",
- "serde_urlencoded",
- "sha1",
- "sync_wrapper",
- "tokio",
- "tokio-tungstenite",
- "tower 0.5.2",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "axum"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de45108900e1f9b9242f7f2e254aa3e2c029c921c258fe9e6b4217eeebd54288"
 dependencies = [
- "axum-core 0.5.2",
+ "axum-core",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -632,26 +538,6 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "axum-core"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
-dependencies = [
- "async-trait",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "mime",
- "pin-project-lite",
- "rustversion",
- "sync_wrapper",
- "tower-layer",
- "tower-service",
 ]
 
 [[package]]
@@ -1166,46 +1052,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
-name = "codespan"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3362992a0d9f1dd7c3d0e89e0ab2bb540b7a95fea8cd798090e758fda2899b5e"
-dependencies = [
- "codespan-reporting",
- "serde",
-]
-
-[[package]]
-name = "codespan-reporting"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
-dependencies = [
- "serde",
- "termcolor",
- "unicode-width",
-]
-
-[[package]]
 name = "colorchoice"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
-name = "colored"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
-dependencies = [
- "lazy_static",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "consensus-config"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v0.10.3-rc#21768a84e4fe2815ea7f674db645269ae8546d07"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "fastcrypto",
  "iota-network-stack",
@@ -1299,25 +1154,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "crossbeam-deque"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
-dependencies = [
- "crossbeam-utils",
 ]
 
 [[package]]
@@ -1481,19 +1317,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04d2cd9c18b9f454ed67da600630b021a8a80bf33f8c95896ab33aaf1c26b728"
 
 [[package]]
-name = "dashmap"
-version = "5.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
-dependencies = [
- "cfg-if",
- "hashbrown 0.14.5",
- "lock_api",
- "once_cell",
- "parking_lot_core",
-]
-
-[[package]]
 name = "data-encoding"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1543,9 +1366,9 @@ dependencies = [
 
 [[package]]
 name = "der-parser"
-version = "8.2.0"
+version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbd676fbbab537128ef0278adb5576cf363cff6aa22a7b24effe97347cfab61e"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
 dependencies = [
  "asn1-rs",
  "displaydoc",
@@ -1622,12 +1445,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "difference"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
-
-[[package]]
 name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1701,12 +1518,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dunce"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
-
-[[package]]
 name = "dyn-clone"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1729,23 +1540,14 @@ dependencies = [
 
 [[package]]
 name = "ed25519"
-version = "1.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91cff35c70bba8a626e3185d8cd48cc11b5437e1a5bcd15b9b5fa3c64b6dfee7"
-dependencies = [
- "pkcs8 0.9.0",
- "signature 1.6.4",
- "zeroize",
-]
-
-[[package]]
-name = "ed25519"
 version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
+ "pkcs8 0.10.2",
  "serde",
  "signature 2.2.0",
+ "zeroize",
 ]
 
 [[package]]
@@ -1770,7 +1572,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d9ce6874da5d4415896cd45ffbc4d1cfc0c4f9c079427bd870742c30f2f65a9"
 dependencies = [
  "curve25519-dalek",
- "ed25519 2.2.3",
+ "ed25519",
  "hashbrown 0.14.5",
  "hex",
  "rand_core 0.6.4",
@@ -1809,7 +1611,7 @@ dependencies = [
 [[package]]
 name = "enum-compat-util"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v0.10.3-rc#21768a84e4fe2815ea7f674db645269ae8546d07"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "serde_yaml",
 ]
@@ -1861,7 +1663,7 @@ dependencies = [
 [[package]]
 name = "fastcrypto"
 version = "0.1.8"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597#5f2c63266a065996d53f98156f0412782b468597"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=69d496c71fb37e3d22fe85e5bbfd4256d61422b9#69d496c71fb37e3d22fe85e5bbfd4256d61422b9"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -1915,7 +1717,7 @@ dependencies = [
 [[package]]
 name = "fastcrypto-derive"
 version = "0.1.3"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597#5f2c63266a065996d53f98156f0412782b468597"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=69d496c71fb37e3d22fe85e5bbfd4256d61422b9#69d496c71fb37e3d22fe85e5bbfd4256d61422b9"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -1924,7 +1726,7 @@ dependencies = [
 [[package]]
 name = "fastcrypto-tbls"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597#5f2c63266a065996d53f98156f0412782b468597"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=69d496c71fb37e3d22fe85e5bbfd4256d61422b9#69d496c71fb37e3d22fe85e5bbfd4256d61422b9"
 dependencies = [
  "bcs",
  "digest 0.10.7",
@@ -1943,9 +1745,8 @@ dependencies = [
 [[package]]
 name = "fastcrypto-zkp"
 version = "0.1.3"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597#5f2c63266a065996d53f98156f0412782b468597"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=69d496c71fb37e3d22fe85e5bbfd4256d61422b9#69d496c71fb37e3d22fe85e5bbfd4256d61422b9"
 dependencies = [
- "ark-bls12-381",
  "ark-bn254",
  "ark-ec",
  "ark-ff",
@@ -1953,7 +1754,7 @@ dependencies = [
  "ark-relations",
  "ark-serialize",
  "ark-snark",
- "blst",
+ "bcs",
  "byte-slice-cast",
  "derive_more 0.99.20",
  "fastcrypto",
@@ -1971,12 +1772,6 @@ dependencies = [
  "serde_json",
  "typenum",
 ]
-
-[[package]]
-name = "fastrand"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ff"
@@ -2169,12 +1964,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
-name = "futures-timer"
-version = "3.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
-
-[[package]]
 name = "futures-util"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2278,26 +2067,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "governor"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68a7f542ee6b35af73b06abc0dad1c1bae89964e4e253bc4b587b91c9637867b"
-dependencies = [
- "cfg-if",
- "dashmap",
- "futures",
- "futures-timer",
- "no-std-compat",
- "nonzero_ext",
- "parking_lot",
- "portable-atomic",
- "quanta",
- "rand 0.8.5",
- "smallvec",
- "spinning_top",
-]
-
-[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2322,7 +2091,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.9.0",
+ "indexmap 2.11.4",
  "slab",
  "tokio",
  "tokio-util",
@@ -2442,7 +2211,7 @@ name = "hook"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "axum 0.8.3",
+ "axum",
  "base64 0.22.1",
  "bcs",
  "iota-types",
@@ -2573,7 +2342,7 @@ dependencies = [
  "hyper",
  "libc",
  "pin-project-lite",
- "socket2",
+ "socket2 0.5.9",
  "tokio",
  "tower-service",
  "tracing",
@@ -2828,20 +2597,15 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.3",
  "serde",
+ "serde_core",
 ]
-
-[[package]]
-name = "inline_colorization"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1804bdb6a9784758b200007273a8b84e2b0b0b97a8f1e18e763eceb3e9f98a"
 
 [[package]]
 name = "inout"
@@ -2851,6 +2615,17 @@ checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "block-padding",
  "generic-array",
+]
+
+[[package]]
+name = "io-uring"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "046fa2d4d00aea763528b4950358d0ead425372445dc8ff86312b3c69ff7727b"
+dependencies = [
+ "bitflags 2.9.0",
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -2890,16 +2665,36 @@ dependencies = [
 
 [[package]]
 name = "iota-enum-compat-util"
-version = "0.10.3-rc"
-source = "git+https://github.com/iotaledger/iota?tag=v0.10.3-rc#21768a84e4fe2815ea7f674db645269ae8546d07"
+version = "1.7.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "serde_yaml",
 ]
 
 [[package]]
+name = "iota-http"
+version = "1.7.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
+dependencies = [
+ "bytes",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "socket2 0.5.9",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tower 0.4.13",
+ "tracing",
+]
+
+[[package]]
 name = "iota-macros"
-version = "0.10.3-rc"
-source = "git+https://github.com/iotaledger/iota?tag=v0.10.3-rc#21768a84e4fe2815ea7f674db645269ae8546d07"
+version = "1.7.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "futures",
  "iota-proc-macros",
@@ -2908,33 +2703,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "iota-metrics"
-version = "0.10.3-rc"
-source = "git+https://github.com/iotaledger/iota?tag=v0.10.3-rc#21768a84e4fe2815ea7f674db645269ae8546d07"
-dependencies = [
- "anemo",
- "anemo-tower",
- "async-trait",
- "axum 0.7.9",
- "bytes",
- "dashmap",
- "futures",
- "once_cell",
- "parking_lot",
- "prometheus",
- "prometheus-closure-metric",
- "scopeguard",
- "simple-server-timing-header",
- "tap",
- "tokio",
- "tracing",
- "uuid",
-]
-
-[[package]]
 name = "iota-network-stack"
-version = "0.10.3-rc"
-source = "git+https://github.com/iotaledger/iota?tag=v0.10.3-rc#21768a84e4fe2815ea7f674db645269ae8546d07"
+version = "1.7.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "anemo",
  "bcs",
@@ -2942,12 +2713,17 @@ dependencies = [
  "eyre",
  "futures",
  "http",
+ "http-body",
+ "hyper-rustls",
+ "hyper-util",
+ "iota-http",
  "multiaddr",
+ "once_cell",
  "pin-project-lite",
  "serde",
  "snap",
  "tokio",
- "tokio-stream",
+ "tokio-rustls",
  "tonic",
  "tonic-health",
  "tower 0.4.13",
@@ -2957,8 +2733,8 @@ dependencies = [
 
 [[package]]
 name = "iota-proc-macros"
-version = "0.10.3-rc"
-source = "git+https://github.com/iotaledger/iota?tag=v0.10.3-rc#21768a84e4fe2815ea7f674db645269ae8546d07"
+version = "1.7.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "msim-macros",
  "proc-macro2",
@@ -2968,22 +2744,23 @@ dependencies = [
 
 [[package]]
 name = "iota-protocol-config"
-version = "0.10.3-rc"
-source = "git+https://github.com/iotaledger/iota?tag=v0.10.3-rc#21768a84e4fe2815ea7f674db645269ae8546d07"
+version = "1.7.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "clap",
  "iota-protocol-config-macros",
  "move-vm-config",
  "schemars",
  "serde",
+ "serde-env",
  "serde_with",
  "tracing",
 ]
 
 [[package]]
 name = "iota-protocol-config-macros"
-version = "0.10.3-rc"
-source = "git+https://github.com/iotaledger/iota?tag=v0.10.3-rc#21768a84e4fe2815ea7f674db645269ae8546d07"
+version = "1.7.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2993,7 +2770,7 @@ dependencies = [
 [[package]]
 name = "iota-rust-sdk"
 version = "0.0.0"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=2ba6b293bdede769a1d9b4d1aecaede2ff7682dd#2ba6b293bdede769a1d9b4d1aecaede2ff7682dd"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=d7084eaf0564f4e2381b2e8408ee1f7d51468450#d7084eaf0564f4e2381b2e8408ee1f7d51468450"
 dependencies = [
  "base64ct",
  "bcs",
@@ -3044,8 +2821,8 @@ dependencies = [
 
 [[package]]
 name = "iota-types"
-version = "0.10.3-rc"
-source = "git+https://github.com/iotaledger/iota?tag=v0.10.3-rc#21768a84e4fe2815ea7f674db645269ae8546d07"
+version = "1.7.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "anemo",
  "anyhow",
@@ -3054,9 +2831,9 @@ dependencies = [
  "better_any",
  "bincode",
  "byteorder",
- "chrono",
  "consensus-config",
  "derive_more 1.0.0",
+ "either",
  "enum_dispatch",
  "eyre",
  "fastcrypto",
@@ -3064,10 +2841,9 @@ dependencies = [
  "fastcrypto-zkp",
  "hex",
  "im",
- "indexmap 2.9.0",
+ "indexmap 2.11.4",
  "iota-enum-compat-util",
  "iota-macros",
- "iota-metrics",
  "iota-network-stack",
  "iota-protocol-config",
  "iota-rust-sdk",
@@ -3076,18 +2852,13 @@ dependencies = [
  "lru",
  "move-binary-format",
  "move-bytecode-utils",
- "move-command-line-common",
  "move-core-types",
- "move-disassembler",
- "move-ir-types",
  "move-vm-profiler",
  "move-vm-test-utils",
- "move-vm-types",
  "nonempty",
  "num-bigint 0.4.6",
  "num-rational",
  "num-traits",
- "num_enum",
  "once_cell",
  "packable",
  "parking_lot",
@@ -3102,6 +2873,7 @@ dependencies = [
  "serde_with",
  "shared-crypto",
  "signature 1.6.4",
+ "starfish-config",
  "static_assertions",
  "strum 0.26.3",
  "strum_macros 0.26.4",
@@ -3361,9 +3133,6 @@ name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "lru"
@@ -3375,29 +3144,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "lsp-types"
-version = "0.95.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e34d33a8e9b006cd3fc4fe69a921affa097bae4bb65f76271f4644f9a334365"
-dependencies = [
- "bitflags 1.3.2",
- "serde",
- "serde_json",
- "serde_repr",
- "url",
-]
-
-[[package]]
 name = "matchit"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73cbba799671b762df5a175adf59ce145165747bb891505c43d09aefbbf38beb"
-
-[[package]]
-name = "matchit"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "matchit"
@@ -3469,23 +3219,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "move-abstract-interpreter"
-version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v0.10.3-rc#21768a84e4fe2815ea7f674db645269ae8546d07"
-dependencies = [
- "move-binary-format",
- "move-bytecode-verifier-meter",
-]
-
-[[package]]
-name = "move-abstract-stack"
-version = "0.0.1"
-source = "git+https://github.com/iotaledger/iota?tag=v0.10.3-rc#21768a84e4fe2815ea7f674db645269ae8546d07"
-
-[[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/iotaledger/iota?tag=v0.10.3-rc#21768a84e4fe2815ea7f674db645269ae8546d07"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "anyhow",
  "enum-compat-util",
@@ -3497,33 +3233,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "move-borrow-graph"
-version = "0.0.1"
-source = "git+https://github.com/iotaledger/iota?tag=v0.10.3-rc#21768a84e4fe2815ea7f674db645269ae8546d07"
-
-[[package]]
-name = "move-bytecode-source-map"
-version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v0.10.3-rc#21768a84e4fe2815ea7f674db645269ae8546d07"
-dependencies = [
- "anyhow",
- "bcs",
- "move-binary-format",
- "move-command-line-common",
- "move-core-types",
- "move-ir-types",
- "move-symbol-pool",
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v0.10.3-rc#21768a84e4fe2815ea7f674db645269ae8546d07"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "anyhow",
- "indexmap 2.9.0",
+ "indexmap 2.11.4",
  "move-binary-format",
  "move-core-types",
  "petgraph",
@@ -3532,88 +3247,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "move-bytecode-verifier"
-version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v0.10.3-rc#21768a84e4fe2815ea7f674db645269ae8546d07"
-dependencies = [
- "move-abstract-interpreter",
- "move-abstract-stack",
- "move-binary-format",
- "move-borrow-graph",
- "move-bytecode-verifier-meter",
- "move-core-types",
- "move-vm-config",
- "petgraph",
-]
-
-[[package]]
-name = "move-bytecode-verifier-meter"
-version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v0.10.3-rc#21768a84e4fe2815ea7f674db645269ae8546d07"
-dependencies = [
- "move-binary-format",
- "move-core-types",
- "move-vm-config",
-]
-
-[[package]]
-name = "move-command-line-common"
-version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v0.10.3-rc#21768a84e4fe2815ea7f674db645269ae8546d07"
-dependencies = [
- "anyhow",
- "bcs",
- "difference",
- "dirs-next",
- "hex",
- "move-binary-format",
- "move-core-types",
- "num-bigint 0.4.6",
- "once_cell",
- "serde",
- "sha2 0.9.9",
- "vfs",
- "walkdir",
-]
-
-[[package]]
-name = "move-compiler"
-version = "0.0.1"
-source = "git+https://github.com/iotaledger/iota?tag=v0.10.3-rc#21768a84e4fe2815ea7f674db645269ae8546d07"
-dependencies = [
- "anyhow",
- "bcs",
- "clap",
- "codespan-reporting",
- "dunce",
- "hex",
- "lsp-types",
- "move-binary-format",
- "move-borrow-graph",
- "move-bytecode-source-map",
- "move-bytecode-verifier",
- "move-command-line-common",
- "move-core-types",
- "move-ir-to-bytecode",
- "move-ir-types",
- "move-proc-macros",
- "move-symbol-pool",
- "once_cell",
- "petgraph",
- "rayon",
- "regex",
- "serde",
- "serde_json",
- "similar",
- "stacker",
- "tempfile",
- "vfs",
-]
-
-[[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/iotaledger/iota?tag=v0.10.3-rc#21768a84e4fe2815ea7f674db645269ae8546d07"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3629,118 +3265,24 @@ dependencies = [
  "ref-cast",
  "serde",
  "serde_bytes",
+ "serde_with",
  "thiserror 1.0.69",
  "uint",
 ]
 
 [[package]]
-name = "move-coverage"
-version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v0.10.3-rc#21768a84e4fe2815ea7f674db645269ae8546d07"
-dependencies = [
- "anyhow",
- "bcs",
- "clap",
- "codespan",
- "colored",
- "indexmap 2.9.0",
- "move-abstract-interpreter",
- "move-binary-format",
- "move-bytecode-source-map",
- "move-command-line-common",
- "move-core-types",
- "move-ir-types",
- "petgraph",
- "serde",
-]
-
-[[package]]
-name = "move-disassembler"
-version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v0.10.3-rc#21768a84e4fe2815ea7f674db645269ae8546d07"
-dependencies = [
- "anyhow",
- "bcs",
- "clap",
- "hex",
- "inline_colorization",
- "move-abstract-interpreter",
- "move-binary-format",
- "move-bytecode-source-map",
- "move-command-line-common",
- "move-compiler",
- "move-core-types",
- "move-coverage",
- "move-ir-types",
-]
-
-[[package]]
-name = "move-ir-to-bytecode"
-version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v0.10.3-rc#21768a84e4fe2815ea7f674db645269ae8546d07"
-dependencies = [
- "anyhow",
- "codespan-reporting",
- "log",
- "move-binary-format",
- "move-bytecode-source-map",
- "move-command-line-common",
- "move-core-types",
- "move-ir-to-bytecode-syntax",
- "move-ir-types",
- "move-symbol-pool",
- "ouroboros",
-]
-
-[[package]]
-name = "move-ir-to-bytecode-syntax"
-version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v0.10.3-rc#21768a84e4fe2815ea7f674db645269ae8546d07"
-dependencies = [
- "anyhow",
- "hex",
- "move-command-line-common",
- "move-core-types",
- "move-ir-types",
- "move-symbol-pool",
-]
-
-[[package]]
-name = "move-ir-types"
-version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v0.10.3-rc#21768a84e4fe2815ea7f674db645269ae8546d07"
-dependencies = [
- "hex",
- "move-command-line-common",
- "move-core-types",
- "move-symbol-pool",
- "once_cell",
- "serde",
-]
-
-[[package]]
 name = "move-proc-macros"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v0.10.3-rc#21768a84e4fe2815ea7f674db645269ae8546d07"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "quote",
  "syn 2.0.101",
 ]
 
 [[package]]
-name = "move-symbol-pool"
-version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v0.10.3-rc#21768a84e4fe2815ea7f674db645269ae8546d07"
-dependencies = [
- "once_cell",
- "phf",
- "serde",
-]
-
-[[package]]
 name = "move-vm-config"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v0.10.3-rc#21768a84e4fe2815ea7f674db645269ae8546d07"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "move-binary-format",
  "once_cell",
@@ -3749,7 +3291,7 @@ dependencies = [
 [[package]]
 name = "move-vm-profiler"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v0.10.3-rc#21768a84e4fe2815ea7f674db645269ae8546d07"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "move-vm-config",
  "once_cell",
@@ -3759,7 +3301,7 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v0.10.3-rc#21768a84e4fe2815ea7f674db645269ae8546d07"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -3773,7 +3315,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v0.10.3-rc#21768a84e4fe2815ea7f674db645269ae8546d07"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "bcs",
  "move-binary-format",
@@ -3786,7 +3328,7 @@ dependencies = [
 [[package]]
 name = "msim-macros"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota-sim.git?branch=tokio-1.43#d3ae9de63b7ebfbeea8fa5f9d111b9570be703f2"
+source = "git+https://github.com/iotaledger/iota-sim.git?branch=tokio-1.46.1#20adc0b089bf9072268eea0f059fb8ea2461702f"
 dependencies = [
  "darling 0.14.4",
  "proc-macro2",
@@ -3881,12 +3423,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "no-std-compat"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b93853da6d84c2e3c7d730d6473e8817692dd89be387eb01b94d7f108ecb5b8c"
-
-[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3901,12 +3437,6 @@ name = "nonempty"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "995defdca0a589acfdd1bd2e8e3b896b4d4f7675a31fd14c32611440c7f608e6"
-
-[[package]]
-name = "nonzero_ext"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
 
 [[package]]
 name = "num"
@@ -4028,27 +3558,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_enum"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e613fc340b2220f734a8595782c551f1250e969d87d3be1ae0579e8d4065179"
-dependencies = [
- "num_enum_derive",
-]
-
-[[package]]
-name = "num_enum_derive"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
-dependencies = [
- "proc-macro-crate 3.3.0",
- "proc-macro2",
- "quote",
- "syn 2.0.101",
-]
-
-[[package]]
 name = "object"
 version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4059,9 +3568,9 @@ dependencies = [
 
 [[package]]
 name = "oid-registry"
-version = "0.6.1"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bedf36ffb6ba96c2eb7144ef6270557b52e54b20c0a8e1eb2ff99a6c6959bff"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
 dependencies = [
  "asn1-rs",
 ]
@@ -4077,30 +3586,6 @@ name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
-
-[[package]]
-name = "ouroboros"
-version = "0.17.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2ba07320d39dfea882faa70554b4bd342a5f273ed59ba7c1c6b4c840492c954"
-dependencies = [
- "aliasable",
- "ouroboros_macro",
- "static_assertions",
-]
-
-[[package]]
-name = "ouroboros_macro"
-version = "0.17.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec4c6225c69b4ca778c0aea097321a64c421cf4577b331c61b229267edabb6f8"
-dependencies = [
- "heck 0.4.1",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 2.0.101",
-]
 
 [[package]]
 name = "p256"
@@ -4237,7 +3722,7 @@ dependencies = [
  "data-encoding",
  "getrandom 0.2.16",
  "hmac",
- "indexmap 2.9.0",
+ "indexmap 2.11.4",
  "rand 0.8.5",
  "serde",
  "serde_json",
@@ -4322,48 +3807,6 @@ checksum = "467d164a6de56270bd7c4d070df81d07beace25012d5103ced4e9ff08d6afdb7"
 dependencies = [
  "fixedbitset",
  "indexmap 1.9.3",
-]
-
-[[package]]
-name = "phf"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
-dependencies = [
- "phf_macros",
- "phf_shared",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
-dependencies = [
- "phf_shared",
- "rand 0.8.5",
-]
-
-[[package]]
-name = "phf_macros"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
-dependencies = [
- "phf_generator",
- "phf_shared",
- "proc-macro2",
- "quote",
- "syn 2.0.101",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
-dependencies = [
- "siphasher",
 ]
 
 [[package]]
@@ -4458,12 +3901,6 @@ dependencies = [
  "opaque-debug",
  "universal-hash",
 ]
-
-[[package]]
-name = "portable-atomic"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
 
 [[package]]
 name = "powerfmt"
@@ -4600,9 +4037,9 @@ dependencies = [
 
 [[package]]
 name = "prometheus"
-version = "0.13.4"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d33c28a30771f7f96db69893f78b857f7450d7e0237e9c8fc6427a81bae7ed1"
+checksum = "3ca5326d8d0b950a9acd87e6a3f94745394f62e4dae1b1ee22b2bc0c394af43a"
 dependencies = [
  "cfg-if",
  "fnv",
@@ -4610,17 +4047,7 @@ dependencies = [
  "memchr",
  "parking_lot",
  "protobuf",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "prometheus-closure-metric"
-version = "0.10.3-rc"
-source = "git+https://github.com/iotaledger/iota?tag=v0.10.3-rc#21768a84e4fe2815ea7f674db645269ae8546d07"
-dependencies = [
- "anyhow",
- "prometheus",
- "protobuf",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -4648,35 +4075,22 @@ dependencies = [
 
 [[package]]
 name = "protobuf"
-version = "2.28.0"
+version = "3.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
+checksum = "d65a1d4ddae7d8b5de68153b48f6aa3bba8cb002b243dbdbc55a5afbc98f99f4"
 dependencies = [
- "bytes",
-]
-
-[[package]]
-name = "psm"
-version = "0.1.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e944464ec8536cd1beb0bbfd96987eb5e3b72f2ecdafdc5c769a37f1fa2ae1f"
-dependencies = [
- "cc",
-]
-
-[[package]]
-name = "quanta"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bd1fe6824cea6538803de3ff1bc0cf3949024db3d43c9643024bfb33a807c0e"
-dependencies = [
- "crossbeam-utils",
- "libc",
  "once_cell",
- "raw-cpuid",
- "wasi 0.11.0+wasi-snapshot-preview1",
- "web-sys",
- "winapi",
+ "protobuf-support",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "protobuf-support"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e36c2f31e0a47f9280fb347ef5e461ffcd2c52dd520d8e216b52f93b0b0d7d6"
+dependencies = [
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -4693,7 +4107,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2",
+ "socket2 0.5.9",
  "thiserror 2.0.12",
  "tokio",
  "tracing",
@@ -4729,7 +4143,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.5.9",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -4836,35 +4250,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
 dependencies = [
  "rand_core 0.6.4",
-]
-
-[[package]]
-name = "raw-cpuid"
-version = "11.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6df7ab838ed27997ba19a4664507e6f82b41fe6e20be42929332156e5e85146"
-dependencies = [
- "bitflags 2.9.0",
-]
-
-[[package]]
-name = "rayon"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
-dependencies = [
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
-dependencies = [
- "crossbeam-deque",
- "crossbeam-utils",
 ]
 
 [[package]]
@@ -5169,7 +4554,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.2",
+ "rustls-webpki",
  "subtle",
  "zeroize",
 ]
@@ -5190,17 +4575,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
 dependencies = [
  "web-time",
-]
-
-[[package]]
-name = "rustls-webpki"
-version = "0.102.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
-dependencies = [
- "ring",
- "rustls-pki-types",
- "untrusted",
 ]
 
 [[package]]
@@ -5329,11 +4703,22 @@ checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.226"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "0dca6411025b24b60bfa7ec1fe1f8e710ac09782dca409ee8237ba74b51295fd"
 dependencies = [
+ "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde-env"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d13536c0c431652192b75c7d5afa83dedae98f91d7e687ff30a009e9d15284fb"
+dependencies = [
+ "anyhow",
+ "serde",
 ]
 
 [[package]]
@@ -5367,10 +4752,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_derive"
-version = "1.0.219"
+name = "serde_core"
+version = "1.0.226"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "ba2ba63999edb9dac981fb34b3e5c0d111a69b0924e253ed29d83f7c99e966a4"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.226"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8db53ae22f34573731bafa1db20f04027b2d25e02d8205921b569171699cdb33"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5394,7 +4788,7 @@ version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
- "indexmap 2.9.0",
+ "indexmap 2.11.4",
  "itoa",
  "memchr",
  "ryu",
@@ -5444,7 +4838,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.9.0",
+ "indexmap 2.11.4",
  "serde",
  "serde_derive",
  "serde_json",
@@ -5487,17 +4881,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha1"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest 0.10.7",
-]
-
-[[package]]
 name = "sha2"
 version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5533,8 +4916,8 @@ dependencies = [
 
 [[package]]
 name = "shared-crypto"
-version = "0.10.3-rc"
-source = "git+https://github.com/iotaledger/iota?tag=v0.10.3-rc#21768a84e4fe2815ea7f674db645269ae8546d07"
+version = "1.7.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "bcs",
  "eyre",
@@ -5581,24 +4964,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
-name = "similar"
-version = "2.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
-
-[[package]]
-name = "simple-server-timing-header"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16e78919e05c9b8e123d435a4ad104b488ad1585631830e413830985c214086e"
-
-[[package]]
-name = "siphasher"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
-
-[[package]]
 name = "sized-chunks"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5640,19 +5005,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-
-[[package]]
-name = "spinning_top"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d96d2d1d716fb500937168cc09353ffdc7a012be8475ac7308e1bdf0e3923300"
-dependencies = [
- "lock_api",
-]
 
 [[package]]
 name = "spki"
@@ -5681,16 +5047,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
-name = "stacker"
-version = "0.1.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cddb07e32ddb770749da91081d8d0ac3a16f1a569a18b20348cd371f5dead06b"
+name = "starfish-config"
+version = "0.1.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
- "cc",
- "cfg-if",
- "libc",
- "psm",
- "windows-sys 0.59.0",
+ "fastcrypto",
+ "iota-network-stack",
+ "rand 0.8.5",
+ "serde",
+ "shared-crypto",
 ]
 
 [[package]]
@@ -5897,28 +5262,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tempfile"
-version = "3.19.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7437ac7763b9b123ccf33c338a5cc1bac6f69b45a136c19bdd8a65e3916435bf"
-dependencies = [
- "fastrand",
- "getrandom 0.3.2",
- "once_cell",
- "rustix",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "termcolor"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
 name = "terminal_size"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6044,20 +5387,22 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.43.0"
+version = "1.47.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e"
+checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
 dependencies = [
  "backtrace",
  "bytes",
+ "io-uring",
  "libc",
  "mio",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "slab",
+ "socket2 0.6.0",
  "tokio-macros",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6094,18 +5439,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-tungstenite"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
-dependencies = [
- "futures-util",
- "log",
- "tokio",
- "tungstenite",
-]
-
-[[package]]
 name = "tokio-util"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6130,7 +5463,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.9.0",
+ "indexmap 2.11.4",
  "toml_datetime",
  "winnow 0.5.40",
 ]
@@ -6141,20 +5474,19 @@ version = "0.22.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e"
 dependencies = [
- "indexmap 2.9.0",
+ "indexmap 2.11.4",
  "toml_datetime",
  "winnow 0.7.9",
 ]
 
 [[package]]
 name = "tonic"
-version = "0.12.3"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
+checksum = "7e581ba15a835f4d9ea06c55ab1bd4dce26fc53752c69a04aac00703bfb49ba9"
 dependencies = [
- "async-stream",
  "async-trait",
- "axum 0.7.9",
+ "axum",
  "base64 0.22.1",
  "bytes",
  "h2",
@@ -6167,22 +5499,22 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "prost",
- "socket2",
+ "socket2 0.5.9",
  "tokio",
  "tokio-stream",
- "tower 0.4.13",
+ "tower 0.5.2",
  "tower-layer",
  "tower-service",
  "tracing",
+ "zstd",
 ]
 
 [[package]]
 name = "tonic-health"
-version = "0.12.3"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1eaf34ddb812120f5c601162d5429933c9b527d901ab0e7f930d3147e33a09b2"
+checksum = "cb87334d340313fefa513b6e60794d44a86d5f039b523229c99c323e4e19ca4b"
 dependencies = [
- "async-stream",
  "prost",
  "tokio",
  "tokio-stream",
@@ -6218,9 +5550,12 @@ checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap 2.11.4",
  "pin-project-lite",
+ "slab",
  "sync_wrapper",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -6319,27 +5654,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
-name = "tungstenite"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
-dependencies = [
- "byteorder",
- "bytes",
- "data-encoding",
- "http",
- "httparse",
- "log",
- "rand 0.8.5",
- "sha1",
- "thiserror 1.0.69",
- "utf-8",
-]
-
-[[package]]
 name = "typed-store-error"
-version = "0.10.3-rc"
-source = "git+https://github.com/iotaledger/iota?tag=v0.10.3-rc#21768a84e4fe2815ea7f674db645269ae8546d07"
+version = "1.7.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "serde",
  "thiserror 1.0.69",
@@ -6407,12 +5724,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-width"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
-
-[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6465,12 +5776,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "utf-8"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
-
-[[package]]
 name = "utf16_iter"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6494,7 +5799,7 @@ version = "5.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "435c6f69ef38c9017b4b4eea965dfb91e71e53d869e896db40d1cf2441dd75c0"
 dependencies = [
- "indexmap 2.9.0",
+ "indexmap 2.11.4",
  "serde",
  "serde_json",
  "utoipa-gen",
@@ -6506,7 +5811,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c25bae5bccc842449ec0c5ddc5cbb6a3a1eaeac4503895dc105a1138f8234a0"
 dependencies = [
- "axum 0.8.3",
+ "axum",
  "paste",
  "tower-layer",
  "tower-service",
@@ -6531,7 +5836,7 @@ version = "9.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29519b3c485df6b13f4478ac909a491387e9ef70204487c3b64b53749aec0be"
 dependencies = [
- "axum 0.8.3",
+ "axum",
  "base64 0.22.1",
  "mime_guess",
  "regex",
@@ -6550,7 +5855,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
 dependencies = [
  "getrandom 0.3.2",
- "rand 0.9.1",
 ]
 
 [[package]]
@@ -6574,12 +5878,6 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
-name = "vfs"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e4fe92cfc1bad19c19925d5eee4b30584dbbdee4ff10183b261acccbef74e2d"
 
 [[package]]
 name = "walkdir"
@@ -7090,19 +6388,18 @@ dependencies = [
 
 [[package]]
 name = "x509-parser"
-version = "0.14.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0ecbeb7b67ce215e40e3cc7f2ff902f94a223acf44995934763467e7b1febc8"
+checksum = "4569f339c0c402346d4a75a9e39cf8dad310e287eef1ff56d4c68e5067f53460"
 dependencies = [
  "asn1-rs",
- "base64 0.13.1",
  "data-encoding",
  "der-parser",
  "lazy_static",
  "nom",
  "oid-registry",
  "rusticata-macros",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "time",
 ]
 
@@ -7272,7 +6569,7 @@ dependencies = [
  "crc32fast",
  "crossbeam-utils",
  "flate2",
- "indexmap 2.9.0",
+ "indexmap 2.11.4",
  "memchr",
  "zopfli",
 ]

--- a/examples/hook/Cargo.toml
+++ b/examples/hook/Cargo.toml
@@ -10,7 +10,7 @@ anyhow = "1.0.98"
 axum = "0.8.0"
 base64 = "0.22.1"
 bcs = "0.1.4"
-iota-types = { git = "https://github.com/iotaledger/iota", tag = "v0.10.3-rc", package = "iota-types" }
+iota-types = { git = "https://github.com/iotaledger/iota", tag = "v1.7.0", package = "iota-types" }
 serde = "1"
 serde_json = "1.0.140"
 thiserror = "2.0.12"

--- a/examples/ts/.env.example
+++ b/examples/ts/.env.example
@@ -5,7 +5,7 @@
 #
 # HINT: To obtain the private key in bech32 format, you can use the following commands:
 #  iota keytool list
-#  iota keytool export --key-identity <key-alias>
+#  iota keytool export <key-alias>
 SENDER_PRIVATE_KEY="<SENDER_PRIVATE_KEY>"
 
 # The bearer token for the Gas Station. It must match GAS_STATION_AUTH in the Gas Station configuration.

--- a/examples/ts/package-lock.json
+++ b/examples/ts/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@iota/iota-sdk": "0.4.0",
+        "@iota/iota-sdk": "1.6.1",
         "axios": "^1.7.9",
         "bech32": "^2.0.0",
         "dotenv": "^16.4.5"
@@ -130,27 +130,29 @@
       }
     },
     "node_modules/@iota/bcs": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@iota/bcs/-/bcs-0.2.1.tgz",
-      "integrity": "sha512-T+iv5gZhUZP7BiDY7+Ir4MA2rYmyGNZA2b+nxjv219Fp8klFt+l38OWA+1RgJXrCmzuZ+M4hbMAeHhHziURX6Q==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@iota/bcs/-/bcs-1.2.0.tgz",
+      "integrity": "sha512-QdRSR0KpJ87tdjVNmM/j0+0DvE0aTxHIa02337iluaOsMqtJ8OdgUCfSyLduC/3qS+8tJE+UB1KOw55tF+sN2w==",
+      "license": "Apache-2.0",
       "dependencies": {
         "bs58": "^6.0.0"
       }
     },
     "node_modules/@iota/iota-sdk": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@iota/iota-sdk/-/iota-sdk-0.4.0.tgz",
-      "integrity": "sha512-uhHcQGN3G/gJi62aOKmvgiloaNAC61fEsV4GKAKVVv5kUP60p6Q3S5xQL3OoYf6kiAUUhaFoAr4keiEQDZp5aw==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@iota/iota-sdk/-/iota-sdk-1.6.1.tgz",
+      "integrity": "sha512-V7rx7m9erCn9lr4hNZVMtwmka2NsoTZ9EFSE4ZqEDO44cWdheM61+i/y5HJhvvmYAb/kkDfSmfdmzLaGTbVVYg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.2.0",
-        "@iota/bcs": "0.2.1",
+        "@iota/bcs": "1.2.0",
         "@noble/curves": "^1.4.2",
         "@noble/hashes": "^1.4.0",
         "@scure/bip32": "^1.4.0",
         "@scure/bip39": "^1.3.0",
         "@suchipi/femver": "^1.0.0",
         "bech32": "^2.0.0",
+        "bignumber.js": "^9.1.1",
         "gql.tada": "^1.8.2",
         "graphql": "^16.9.0",
         "tweetnacl": "^1.0.3",
@@ -435,14 +437,24 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "node_modules/base-x": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-5.0.0.tgz",
-      "integrity": "sha512-sMW3VGSX1QWVFA6l8U62MLKz29rRfpTlYdCqLdpLo1/Yd4zZwSbnUaDfciIAowAqvq7YFnWq9hrhdg1KYgc1lQ=="
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-5.0.1.tgz",
+      "integrity": "sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg==",
+      "license": "MIT"
     },
     "node_modules/bech32": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
       "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg=="
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/brace-expansion": {
       "version": "2.0.1",
@@ -456,6 +468,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/bs58/-/bs58-6.0.0.tgz",
       "integrity": "sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw==",
+      "license": "MIT",
       "dependencies": {
         "base-x": "^5.0.0"
       }
@@ -1013,26 +1026,27 @@
       "requires": {}
     },
     "@iota/bcs": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@iota/bcs/-/bcs-0.2.1.tgz",
-      "integrity": "sha512-T+iv5gZhUZP7BiDY7+Ir4MA2rYmyGNZA2b+nxjv219Fp8klFt+l38OWA+1RgJXrCmzuZ+M4hbMAeHhHziURX6Q==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@iota/bcs/-/bcs-1.2.0.tgz",
+      "integrity": "sha512-QdRSR0KpJ87tdjVNmM/j0+0DvE0aTxHIa02337iluaOsMqtJ8OdgUCfSyLduC/3qS+8tJE+UB1KOw55tF+sN2w==",
       "requires": {
         "bs58": "^6.0.0"
       }
     },
     "@iota/iota-sdk": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@iota/iota-sdk/-/iota-sdk-0.4.0.tgz",
-      "integrity": "sha512-uhHcQGN3G/gJi62aOKmvgiloaNAC61fEsV4GKAKVVv5kUP60p6Q3S5xQL3OoYf6kiAUUhaFoAr4keiEQDZp5aw==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@iota/iota-sdk/-/iota-sdk-1.6.1.tgz",
+      "integrity": "sha512-V7rx7m9erCn9lr4hNZVMtwmka2NsoTZ9EFSE4ZqEDO44cWdheM61+i/y5HJhvvmYAb/kkDfSmfdmzLaGTbVVYg==",
       "requires": {
         "@graphql-typed-document-node/core": "^3.2.0",
-        "@iota/bcs": "0.2.1",
+        "@iota/bcs": "1.2.0",
         "@noble/curves": "^1.4.2",
         "@noble/hashes": "^1.4.0",
         "@scure/bip32": "^1.4.0",
         "@scure/bip39": "^1.3.0",
         "@suchipi/femver": "^1.0.0",
         "bech32": "^2.0.0",
+        "bignumber.js": "^9.1.1",
         "gql.tada": "^1.8.2",
         "graphql": "^16.9.0",
         "tweetnacl": "^1.0.3",
@@ -1270,14 +1284,19 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "base-x": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-5.0.0.tgz",
-      "integrity": "sha512-sMW3VGSX1QWVFA6l8U62MLKz29rRfpTlYdCqLdpLo1/Yd4zZwSbnUaDfciIAowAqvq7YFnWq9hrhdg1KYgc1lQ=="
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-5.0.1.tgz",
+      "integrity": "sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg=="
     },
     "bech32": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
       "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg=="
+    },
+    "bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ=="
     },
     "brace-expansion": {
       "version": "2.0.1",

--- a/examples/ts/package-lock.json
+++ b/examples/ts/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@iota/iota-sdk": "1.6.1",
+        "@iota/iota-sdk": "^1.6.1",
         "axios": "^1.7.9",
         "bech32": "^2.0.0",
         "dotenv": "^16.4.5"

--- a/examples/ts/package.json
+++ b/examples/ts/package.json
@@ -9,7 +9,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@iota/iota-sdk": "0.4.0",
+    "@iota/iota-sdk": "1.6.1",
     "axios": "^1.7.9",
     "bech32": "^2.0.0",
     "dotenv": "^16.4.5"

--- a/examples/ts/package.json
+++ b/examples/ts/package.json
@@ -9,7 +9,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@iota/iota-sdk": "1.6.1",
+    "@iota/iota-sdk": "^1.6.1",
     "axios": "^1.7.9",
     "bech32": "^2.0.0",
     "dotenv": "^16.4.5"


### PR DESCRIPTION
Bumps

- `iota-gas-station`s `iota-sdk` and related dependencies' version to `v1.7.0`
- hook examples `iota-types` to `v1.7.0`
- TS examples (Node.js) `@iota/iota-sdk` dependency to `^1.6.1` (latest)