### PR TITLE
docs: fix inactive link to gas-station setup

### DIFF
--- a/examples/rust/README.md
+++ b/examples/rust/README.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-1. Ensure the IOTA Gas Station is up and running. To learn how to set up the Gas Station, please follow this [link](../../GETTING_STARTED.md).
+1. Ensure the IOTA Gas Station is up and running. To learn how to set up the Gas Station, please follow this [link](../../README.md#how-to-run-with-docker).
 2. The expected address of the Gas Station is `http://localhost:9527`. Modify this if necessary.
 
 ## How to run

--- a/examples/ts/README.md
+++ b/examples/ts/README.md
@@ -17,7 +17,7 @@ This system package is available on every IOTA network instance (devnet, testnet
 
 ## Prerequisites
 
-1. A running instance of the `IOTA Gas Station` is required. To learn how to set up the Gas Station, please follow this [link](../../GETTING_STARTED.md).
+1. A running instance of the `IOTA Gas Station` is required. To learn how to set up the Gas Station, please follow this [link](../../README.md#how-to-run-with-docker).
 
    You should have:
    - The URL of the gas station instance.


### PR DESCRIPTION
Fixes inactive links to the IOTA gas-station setup 
closes #130 