### PR TITLE
Align KMS Sidecar example endpoint with defaults/examples/doc

### DIFF
--- a/sample_kms_sidecar/README.md
+++ b/sample_kms_sidecar/README.md
@@ -42,13 +42,13 @@ npm start
 ## API Endpoints
 
 - `GET /` - Health check endpoint
-- `GET /aws-kms/get-pubkey-address` - Get the IOTA address for the KMS public key
-- `POST /aws-kms/sign-transaction` - Sign a IOTA transaction using KMS
+- `GET /get-pubkey-address` - Get the IOTA address for the KMS public key
+- `POST /sign-transaction` - Sign a IOTA transaction using KMS
 
 ### Sign Transaction Example
 
 ```bash
-curl -X POST http://localhost:3000/aws-kms/sign-transaction \
+curl -X POST http://localhost:3000/sign-transaction \
   -H "Content-Type: application/json" \
   -d '{"txBytes": "base64-encoded-transaction-bytes"}'
 ```

--- a/sample_kms_sidecar/index.ts
+++ b/sample_kms_sidecar/index.ts
@@ -11,7 +11,7 @@ async function main() {
         res.send("KMS Signer Demo!");
     });
 
-    app.get("/aws-kms/get-pubkey-address", async (req, res) => {
+    app.get("/get-pubkey-address", async (req, res) => {
         try {
             const keyId = process.env.AWS_KMS_KEY_ID || "";
             const publicKey = await getPublicKey(keyId);
@@ -26,7 +26,7 @@ async function main() {
         }
     });
 
-    app.post("/aws-kms/sign-transaction", async (req, res) => {
+    app.post("/sign-transaction", async (req, res) => {
         try {
             const { txBytes } = req.body;
 


### PR DESCRIPTION
Removes `aws-kms` URL infix in example sidecar to align example with default URLs used in tests and docs.

Closes #127.