### PR TITLE
fix: collection of `gas_usage`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+test:
+	cargo nextest run -j 1
+
 redis-start:
 	docker run -d --name gas-station-redis -p 6379:6379 redis:7.2.5
 

--- a/src/access_controller/mod.rs
+++ b/src/access_controller/mod.rs
@@ -150,7 +150,7 @@ impl AccessController {
             for req in requests {
                 let diff = if let Some(real_gas_usage) = result.gas_usage {
                     let reserved_gas_usage = req.gas_usage;
-                    let diff = reserved_gas_usage - real_gas_usage;
+                    let diff = reserved_gas_usage.saturating_sub(real_gas_usage);
                     debug!("Transaction with id: {transaction_digest} confirmed, reserved gas usage: {reserved_gas_usage}, real gas usage: {real_gas_usage}, diff: {diff}");
                     diff
                 } else {

--- a/src/access_controller/predicates/source.rs
+++ b/src/access_controller/predicates/source.rs
@@ -23,8 +23,9 @@ impl SourceWithData {
     }
     // Fetch the data from the location.
     pub async fn fetch(&mut self) -> Result<(), anyhow::Error> {
-        self.data = Some(self.location.fetch_bytes().await?);
-        trace!("Fetched data from location: {:?}", self.data);
+        let data = self.location.fetch_bytes().await?;
+        trace!("Fetched data from location: {} bytes", data.len());
+        self.data = Some(data);
         Ok(())
     }
 

--- a/src/access_controller/rule.rs
+++ b/src/access_controller/rule.rs
@@ -368,21 +368,12 @@ impl AccessRule {
                 .update_aggr(rule_meta.clone(), &aggr, ctx.transaction_budget as i64)
                 .await
                 .context("Updating aggregate failed")?;
-            let is_matched = gas_limit.value.matches(total_gas_claim as u64);
-            // If not matched then we need to 'restore' the state of aggregate,
-            // because the rule will not be applied. And also there is no need to create
-            // a confirmation request that 'fixes' the state of aggregate.
-            if !is_matched {
-                ctx.stats_tracker
-                    .update_aggr(rule_meta.clone(), &aggr, -(ctx.transaction_budget as i64))
-                    .await
-                    .context("Restoring aggregate failed")?;
-            }
-            let confirmation_request = is_matched.then(|| GasUsageConfirmationRequest {
+            let confirmation_request = GasUsageConfirmationRequest {
                 rule_meta,
                 aggregate: aggr,
                 gas_usage: ctx.transaction_budget,
-            });
+            };
+            let is_matched = gas_limit.value.matches(total_gas_claim as u64);
             let result_reason = format!(
                 "total gas usage {} {}: {}",
                 total_gas_claim,
@@ -393,11 +384,10 @@ impl AccessRule {
                 },
                 gas_limit.value
             );
-
-            Ok((
+            return Ok((
                 PredicateReport::new(predicate_names::GAS_USAGE, is_matched, result_reason),
-                confirmation_request,
-            ))
+                Some(confirmation_request),
+            ));
         } else {
             // If the gas limit is not defined then the rule matches
             return Ok((

--- a/src/access_controller/rule.rs
+++ b/src/access_controller/rule.rs
@@ -31,7 +31,7 @@ use crate::{
     },
 };
 
-mod predicate_names {
+pub(crate) mod predicate_names {
     pub const SENDER_ADDRESS: &str = "sender_address";
     pub const GAS_BUDGET: &str = "gas_budget";
     pub const MOVE_CALL_PACKAGE_ADDRESS: &str = "move_call_package_address";
@@ -328,7 +328,10 @@ impl AccessRule {
     }
 
     /// Returns the rule meta data as a JSON object. The rule meta is used to calculate the hash of the rule.
-    fn get_rule_meta(&self, ctx: &TransactionContext) -> Result<Map<String, Value>, anyhow::Error> {
+    pub fn get_rule_meta(
+        &self,
+        ctx: &TransactionContext,
+    ) -> Result<Map<String, Value>, anyhow::Error> {
         let json_rule =
             serde_json::to_value(self.clone()).context("Failed to serialize rule to JSON")?;
         let mut rule_to_hash = json_rule
@@ -354,7 +357,7 @@ impl AccessRule {
         if let Some(gas_limit) = self.gas_usage.as_ref() {
             let rule_meta = self
                 .get_rule_meta(ctx)
-                .context("Failed to calculate rule meta")?;
+                .context("Failed to calculate rule meta for gas limit")?;
 
             let aggr = Aggregate::with_name(predicate_names::GAS_USAGE)
                 .with_aggr_type(AggregateType::Sum)
@@ -365,21 +368,36 @@ impl AccessRule {
                 .update_aggr(rule_meta.clone(), &aggr, ctx.transaction_budget as i64)
                 .await
                 .context("Updating aggregate failed")?;
-
-            let confirmation_request = GasUsageConfirmationRequest {
+            let is_matched = gas_limit.value.matches(total_gas_claim as u64);
+            // If not matched then we need to 'restore' the state of aggregate,
+            // because the rule will not be applied. And also there is no need to create
+            // a confirmation request that 'fixes' the state of aggregate.
+            if !is_matched {
+                ctx.stats_tracker
+                    .update_aggr(rule_meta.clone(), &aggr, -(ctx.transaction_budget as i64))
+                    .await
+                    .context("Restoring aggregate failed")?;
+            }
+            let confirmation_request = is_matched.then(|| GasUsageConfirmationRequest {
                 rule_meta,
                 aggregate: aggr,
                 gas_usage: ctx.transaction_budget,
-            };
+            });
+            let result_reason = format!(
+                "total gas usage {} {}: {}",
+                total_gas_claim,
+                if is_matched {
+                    "matches"
+                } else {
+                    "does not match"
+                },
+                gas_limit.value
+            );
 
-            return Ok((
-                PredicateReport::new(
-                    predicate_names::GAS_USAGE,
-                    gas_limit.value.matches(total_gas_claim as u64),
-                    format!("gas usage {} matches: {}", total_gas_claim, gas_limit.value),
-                ),
-                Some(confirmation_request),
-            ));
+            Ok((
+                PredicateReport::new(predicate_names::GAS_USAGE, is_matched, result_reason),
+                confirmation_request,
+            ))
         } else {
             // If the gas limit is not defined then the rule matches
             return Ok((

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -203,10 +203,12 @@ mod tests {
             .is_err());
     }
 
-    // The rule with gas-usage partially matches (sender address), but not action applied,
-    // and the another in order rule should be applied. Gas-usage counter should remain untouched.
+    // The rule with gas-usage matches (sender address), but not action applied
+    // due to of gas-limit constraint. The next in order rule should be applied with deny action.
+    // When there is a `deny` action, there is no gas usage, so the gas-usage counter
+    // from first rule should go back to its original state `0`
     #[tokio::test]
-    async fn test_access_denied_from_controller_gas_usage_partially_matches() {
+    async fn test_access_denied_from_controller_by_another_rule() {
         let rule_gas_usage = AccessRuleBuilder::new()
             .gas_limit(ValueAggregate::new(
                 Duration::from_secs(120),
@@ -214,7 +216,7 @@ mod tests {
             ))
             .allow()
             .build();
-        let rule_allow_any = AccessRuleBuilder::new().allow().build();
+        let rule_allow_any = AccessRuleBuilder::new().deny().build();
         let rules = [rule_gas_usage.clone(), rule_allow_any];
         let (test_cluster, container, server) =
             start_rpc_server_for_testing_with_access_controller(
@@ -244,7 +246,7 @@ mod tests {
         assert!(client
             .execute_tx(reservation_id, &tx_data, &user_sig, None, None)
             .await
-            .is_ok());
+            .is_err());
 
         let value = fetch_redis_val::<i64>(&redis_key);
         assert_eq!(value, 0);

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -14,15 +14,17 @@ mod tests {
 
     use crate::access_controller::policy::AccessPolicy;
     use crate::access_controller::predicates::{ValueAggregate, ValueNumber};
-    use crate::access_controller::rule::AccessRuleBuilder;
+    use crate::access_controller::rule::{predicate_names, AccessRuleBuilder};
     use crate::access_controller::AccessController;
     use crate::config::GasStationConfig;
     use crate::rpc::ExecuteTransactionRequestType;
     use crate::test_env::{
-        create_test_transaction, start_rpc_server_for_testing,
+        create_test_transaction, fetch_redis_val, remove_redis_key, start_rpc_server_for_testing,
         start_rpc_server_for_testing_empty_auth, start_rpc_server_for_testing_no_auth,
         start_rpc_server_for_testing_with_access_controller, DEFAULT_TEST_CONFIG_PATH,
     };
+    use crate::tracker::stats_tracker_storage::redis::get_redis_aggr_key;
+    use crate::tracker::stats_tracker_storage::AggregateType;
     use crate::AUTH_ENV_NAME;
     use iota_config::Config;
     use iota_json_rpc_types::IotaTransactionBlockEffectsAPI;
@@ -199,6 +201,53 @@ mod tests {
             .execute_tx(reservation_id, &tx_data, &user_sig, None, None)
             .await
             .is_err());
+    }
+
+    // The rule with gas-usage partially matches (sender address), but not action applied,
+    // and the another in order rule should be applied. Gas-usage counter should remain untouched.
+    #[tokio::test]
+    async fn test_access_denied_from_controller_gas_usage_partially_matches() {
+        let rule_gas_usage = AccessRuleBuilder::new()
+            .gas_limit(ValueAggregate::new(
+                Duration::from_secs(120),
+                ValueNumber::LessThanOrEqual(3333),
+            ))
+            .allow()
+            .build();
+        let rule_allow_any = AccessRuleBuilder::new().allow().build();
+        let rules = [rule_gas_usage.clone(), rule_allow_any];
+        let (test_cluster, container, server) =
+            start_rpc_server_for_testing_with_access_controller(
+                vec![NANOS_PER_IOTA; 60],
+                NANOS_PER_IOTA,
+                AccessController::new(AccessPolicy::DenyAll, rules),
+            )
+            .await;
+
+        let rule_meta = rule_gas_usage.get_rule_meta(&Default::default()).unwrap();
+        let signer_address = container.get_signer_address();
+        let rule_key = get_redis_aggr_key(
+            predicate_names::GAS_USAGE,
+            AggregateType::Sum,
+            rule_meta.clone().into_iter().collect::<Vec<_>>().as_slice(),
+        );
+        let redis_key = format!("{}:{}", signer_address, rule_key);
+
+        // We want to make sure the redis key is not present
+        remove_redis_key::<i64>(&redis_key);
+
+        let client = server.get_local_client();
+        let (sponsor, reservation_id, gas_coins) =
+            client.reserve_gas(NANOS_PER_IOTA, 10).await.unwrap();
+        let (tx_data, user_sig) = create_test_transaction(&test_cluster, sponsor, gas_coins).await;
+
+        assert!(client
+            .execute_tx(reservation_id, &tx_data, &user_sig, None, None)
+            .await
+            .is_ok());
+
+        let value = fetch_redis_val::<i64>(&redis_key);
+        assert_eq!(value, 0);
     }
 
     #[tokio::test]

--- a/src/rpc/server.rs
+++ b/src/rpc/server.rs
@@ -319,7 +319,7 @@ async fn execute_tx_impl(
 ) -> (StatusCode, Json<ExecuteTxResponse>) {
     let transaction_digest = tx_data.digest();
 
-    let matching_result = match access_controller.load().check_access(&ctx).await {
+    let check_access_result = match access_controller.load().check_access(&ctx).await {
         Ok(Decision::Allow) => {
             metrics.num_allowed_execute_tx_requests.inc();
             None
@@ -349,7 +349,7 @@ async fn execute_tx_impl(
         }
     };
 
-    if let Some((status_code, error)) = matching_result {
+    if let Some((status_code, error)) = check_access_result {
         let confirmation_result = access_controller
             .load()
             .confirm_transaction(

--- a/src/rpc/server.rs
+++ b/src/rpc/server.rs
@@ -317,18 +317,21 @@ async fn execute_tx_impl(
     access_controller: Arc<ArcSwap<AccessController>>,
     ctx: TransactionContext,
 ) -> (StatusCode, Json<ExecuteTxResponse>) {
-    match access_controller.load().check_access(&ctx).await {
+    let transaction_digest = tx_data.digest();
+
+    let matching_result = match access_controller.load().check_access(&ctx).await {
         Ok(Decision::Allow) => {
             metrics.num_allowed_execute_tx_requests.inc();
+            None
         }
         Ok(Decision::Deny) => {
             metrics.num_failed_execute_tx_requests.inc();
-            return (
+            Some((
                 StatusCode::FORBIDDEN,
                 Json(ExecuteTxResponse::new_err(anyhow::anyhow!(
                     "Access denied by access controller"
                 ))),
-            );
+            ))
         }
         Err(err) => {
             let event_id = generate_event_id();
@@ -336,17 +339,30 @@ async fn execute_tx_impl(
                 "EventId={} Error while checking access: {:?}",
                 event_id, err
             );
-            return (
+            Some((
                 StatusCode::BAD_REQUEST,
                 Json(ExecuteTxResponse::new_err(anyhow::anyhow!(
                     "Error while checking access. EventId={}",
                     event_id
                 ))),
-            );
+            ))
         }
+    };
+
+    if let Some((status_code, error)) = matching_result {
+        let confirmation_result = access_controller
+            .load()
+            .confirm_transaction(
+                TransactionExecutionResult::new(transaction_digest),
+                &ctx.stats_tracker,
+            )
+            .await;
+        if let Err(err) = confirmation_result {
+            error!("Error while canceling transaction in AC: {:?}", err);
+        }
+        return (status_code, error);
     }
 
-    let transaction_digest = tx_data.digest();
     match gas_station
         .execute_transaction(ctx.reservation_id, tx_data, user_sig, ctx.request_type)
         .await
@@ -360,7 +376,6 @@ async fn execute_tx_impl(
             );
             trace!(target: "transactions", "{}", TxLogMessage::new(&effects));
 
-            metrics.num_successful_execute_tx_requests.inc();
             let confirmation_result = access_controller
                 .load()
                 .confirm_transaction(
@@ -374,7 +389,7 @@ async fn execute_tx_impl(
             if let Err(err) = confirmation_result {
                 error!("Error while confirming transaction in AC: {:?}", err);
             }
-
+            metrics.num_successful_execute_tx_requests.inc();
             (StatusCode::OK, Json(ExecuteTxResponse::new_ok(effects)))
         }
         Err(err) => {

--- a/src/rpc/server.rs
+++ b/src/rpc/server.rs
@@ -319,7 +319,7 @@ async fn execute_tx_impl(
 ) -> (StatusCode, Json<ExecuteTxResponse>) {
     let transaction_digest = tx_data.digest();
 
-    let check_access_result = match access_controller.load().check_access(&ctx).await {
+    let is_rejected = match access_controller.load().check_access(&ctx).await {
         Ok(Decision::Allow) => {
             metrics.num_allowed_execute_tx_requests.inc();
             None
@@ -349,7 +349,7 @@ async fn execute_tx_impl(
         }
     };
 
-    if let Some((status_code, error)) = check_access_result {
+    if let Some((status_code, error)) = is_rejected {
         let confirmation_result = access_controller
             .load()
             .confirm_transaction(

--- a/src/test_env.rs
+++ b/src/test_env.rs
@@ -23,6 +23,7 @@ use iota_types::crypto::get_account_key_pair;
 use iota_types::gas_coin::NANOS_PER_IOTA;
 use iota_types::signature::GenericSignature;
 use iota_types::transaction::{TransactionData, TransactionDataAPI};
+use redis::{Commands, FromRedisValue};
 use serde_json::Value;
 use std::path::PathBuf;
 use std::str::FromStr;
@@ -231,4 +232,25 @@ impl StatsTrackerStorage for MockedStatsTrackerStorage {
 
 pub fn mocked_stats_tracker() -> StatsTracker {
     StatsTracker::new(Arc::new(MockedStatsTrackerStorage {}))
+}
+
+pub fn fetch_redis_val<T: FromRedisValue>(redis_key: &str) -> T {
+    let default_redis_url = match GasStationStorageConfig::default() {
+        GasStationStorageConfig::Redis { redis_url } => redis_url,
+    };
+    let redis_client = redis::Client::open(default_redis_url).unwrap();
+    let mut redis_connection = redis_client.get_connection().unwrap();
+    let value: T = redis_connection.get(redis_key).unwrap();
+    value
+}
+
+pub fn remove_redis_key<K: FromRedisValue>(redis_key: &str) {
+    let default_redis_url = match GasStationStorageConfig::default() {
+        GasStationStorageConfig::Redis { redis_url } => redis_url,
+    };
+    let redis_client = redis::Client::open(default_redis_url).unwrap();
+    let mut redis_connection = redis_client.get_connection().unwrap();
+    redis_connection
+        .del::<String, K>(redis_key.to_string())
+        .unwrap();
 }

--- a/src/tracker/stats_tracker_storage/redis/mod.rs
+++ b/src/tracker/stats_tracker_storage/redis/mod.rs
@@ -51,8 +51,7 @@ impl StatsTrackerStorage for RedisStatsTrackerStorage {
         aggr: &Aggregate,
         value: i64,
     ) -> Result<i64> {
-        let hash = generate_hash_from_key(key);
-        let key = format!("{}:{}:{}", aggr.name, aggr.aggr_type, hash);
+        let key = get_redis_aggr_key(&aggr.name, aggr.aggr_type, key);
 
         match aggr.aggr_type {
             AggregateType::Sum => {
@@ -69,6 +68,15 @@ impl StatsTrackerStorage for RedisStatsTrackerStorage {
             }
         }
     }
+}
+
+pub(crate) fn get_redis_aggr_key(
+    aggr_name: &str,
+    aggr_type: AggregateType,
+    key: &[(String, Value)],
+) -> String {
+    let hash = generate_hash_from_key(key);
+    format!("{}:{}:{}", aggr_name, aggr_type, hash)
 }
 
 // we should generate the canonical hash key from the given key
@@ -125,23 +133,14 @@ mod test {
         .into_iter()
         .collect::<Vec<_>>();
 
-        let result = storage
-            .update_aggr(&key_meta, &aggregate, 1)
-            .await
-            .unwrap();
+        let result = storage.update_aggr(&key_meta, &aggregate, 1).await.unwrap();
         assert_eq!(result, 1);
 
-        let result = storage
-            .update_aggr(&key_meta, &aggregate, 2)
-            .await
-            .unwrap();
+        let result = storage.update_aggr(&key_meta, &aggregate, 2).await.unwrap();
         assert_eq!(result, 3);
 
         time::sleep(window_size + Duration::from_secs(1)).await;
-        let result = storage
-            .update_aggr(&key_meta, &aggregate, 2)
-            .await
-            .unwrap();
+        let result = storage.update_aggr(&key_meta, &aggregate, 2).await.unwrap();
         assert_eq!(result, 2);
     }
 


### PR DESCRIPTION
Fixes the problem when the incorrect collection of gas usage leads to underflow panic. This especially happens when gas usage in the first rule isn't enough, but the next rule (a similar one) in the order denies the request.

**Changes:**
- Replaced subtraction with `saturating_sub()` to prevent integer underflow for undiscovered states
- Fixed the gas-usage collection when the access controller denies a transaction
- Added test coverage for partial rule matching scenarios

**Impact:** Prevents underflow panics and ensures failed transactions don't corrupt gas quota tracking.