### PR TITLE
support HTTP Headers in access contoller

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+test:
+	cargo nextest run -j 1
+
 redis-start:
 	docker run -d --name gas-station-redis -p 6379:6379 redis:7.2.5
 

--- a/docs/access-controller.md
+++ b/docs/access-controller.md
@@ -429,7 +429,7 @@ access-controller:
       gas-usage:
         value: "<1000000"
         window: 1day
-        count-by: http-header::x-account-id
+        count-by: [ http-header::x-account-id ]
       action: allow
 ```
 

--- a/docs/access-controller.md
+++ b/docs/access-controller.md
@@ -106,6 +106,10 @@ Below is an example JSON payload against which a Rego rule is evaluated:
 
 ```json
 {
+  "http_headers" : {
+    "content-type":  [ "application/json"]
+  },
+
   "transaction_data": {
     "V1": {
       "kind": {
@@ -330,7 +334,7 @@ The **Gas Usage Limit** feature enables you to track gas consumption based on pr
 gas-usage:
   value: [range_of_numbers]
   window: [duration]
-  count-by: [ sender-address ] # optional
+  count-by: [ sender-address, http-header::header_name ] # optional
 ```
 
 > **Note:** The syntax of `duration` follows the specification used in the [`humantime`](https://docs.rs/humantime/latest/humantime/index.html) crate
@@ -398,6 +402,38 @@ access-controller:
         count-by: [ sender-address ]
       action: allow
 ```
+
+**4. Limit Gas Usage per HTTP Header**
+
+When implementing multi-tenant or account-based gas station usage, you can track gas consumption per account using HTTP headers. This allows each account to have its own gas usage limit, even when using the same sender address.
+
+The account ID is passed via an HTTP header (e.g., `X-Account-Id`) by your account management system:
+
+```http
+POST /v1/execute_tx
+X-Account-Id: 123
+Content-Type: application/json
+
+{
+  "transaction": "..."
+}
+```
+
+Configure the access controller to count gas usage separately for each unique header value:
+
+```yaml
+access-controller:
+  access-policy: deny-all
+  rules:
+    - sender-address: "*"
+      gas-usage:
+        value: "<1000000"
+        window: 1day
+        count-by: http-header::x-account-id
+      action: allow
+```
+
+This configuration ensures that, each unique `X-Account-Id` value gets its own 1,000,000 gas limit per day
 
 ## Hook Server
 

--- a/src/access_controller/hook/hook_action.rs
+++ b/src/access_controller/hook/hook_action.rs
@@ -12,19 +12,13 @@ use super::{
     HookActionConfig, HookActionDetailed, HookActionHeaders,
 };
 
-use crate::access_controller::rule::TransactionContext;
+use crate::access_controller::{rule::TransactionContext, utils::header_map_to_btree_map};
 
 const HOOK_REQUEST_TIMEOUT_SECONDS: u64 = 60;
 
 fn header_map_to_hash_map(ctx: &TransactionContext) -> HookActionHeaders {
-    let mut header_hashmap: HookActionHeaders = HookActionHeaders::new();
-    for (k, v) in ctx.headers.clone() {
-        let k = k.map(|v| v.to_string()).unwrap_or_default();
-        let v = String::from_utf8_lossy(v.as_bytes()).into_owned();
-        header_hashmap.entry(k).or_insert_with(Vec::new).push(v);
-    }
-
-    header_hashmap
+    let headers = header_map_to_btree_map(&ctx.headers);
+    headers.into()
 }
 
 fn build_execute_tx_hook_request_payload(ctx: &TransactionContext) -> ExecuteTxHookRequest {

--- a/src/access_controller/mod.rs
+++ b/src/access_controller/mod.rs
@@ -10,6 +10,7 @@ pub mod policy;
 pub mod predicates;
 pub mod reports;
 pub mod rule;
+pub mod utils;
 
 use std::{collections::HashMap, fmt::Formatter, sync::Arc};
 

--- a/src/access_controller/mod.rs
+++ b/src/access_controller/mod.rs
@@ -150,7 +150,7 @@ impl AccessController {
             for req in requests {
                 let diff = if let Some(real_gas_usage) = result.gas_usage {
                     let reserved_gas_usage = req.gas_usage;
-                    let diff = reserved_gas_usage - real_gas_usage;
+                    let diff = reserved_gas_usage.saturating_sub(real_gas_usage);
                     debug!("Transaction with id: {transaction_digest} confirmed, reserved gas usage: {reserved_gas_usage}, real gas usage: {real_gas_usage}, diff: {diff}");
                     diff
                 } else {

--- a/src/access_controller/predicates/aggregate.rs
+++ b/src/access_controller/predicates/aggregate.rs
@@ -15,7 +15,7 @@ pub struct ValueAggregate {
     pub window: Duration,
     pub value: ValueNumber<u64>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub count_by: Vec<LimitBy>,
+    pub count_by: Vec<CountBy>,
 }
 
 impl ValueAggregate {
@@ -27,7 +27,7 @@ impl ValueAggregate {
         }
     }
 
-    pub fn with_count_by(mut self, group_by: Vec<LimitBy>) -> Self {
+    pub fn with_count_by(mut self, group_by: Vec<CountBy>) -> Self {
         self.count_by = group_by;
         self
     }
@@ -35,20 +35,20 @@ impl ValueAggregate {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
-pub enum LimitBy {
+pub enum CountBy {
     SenderAddress,
     HttpHeader(CountByHttpHeader),
 }
 
-impl LimitBy {
+impl CountBy {
     pub fn new_http_header(header_name: impl AsRef<str>) -> Self {
-        LimitBy::HttpHeader(CountByHttpHeader {
+        CountBy::HttpHeader(CountByHttpHeader {
             header_name: header_name.as_ref().to_string(),
         })
     }
 
     pub fn new_sender_address() -> Self {
-        LimitBy::SenderAddress
+        CountBy::SenderAddress
     }
 }
 
@@ -105,11 +105,11 @@ impl TryFrom<&String> for CountByHttpHeader {
     }
 }
 
-impl ToString for LimitBy {
+impl ToString for CountBy {
     fn to_string(&self) -> String {
         match self {
-            LimitBy::SenderAddress => "sender-address".to_string(),
-            LimitBy::HttpHeader(header) => header.to_string(),
+            CountBy::SenderAddress => "sender-address".to_string(),
+            CountBy::HttpHeader(header) => header.to_string(),
         }
     }
 }
@@ -146,21 +146,21 @@ mod serde_duration {
 
 #[cfg(test)]
 mod test {
-    use super::{CountByHttpHeader, LimitBy};
+    use super::{CountBy, CountByHttpHeader};
     use crate::access_controller::predicates::{ValueAggregate, ValueNumber};
 
     #[test]
     fn test_serde_limit_by() {
-        let limit_by = LimitBy::HttpHeader(CountByHttpHeader {
+        let limit_by = CountBy::HttpHeader(CountByHttpHeader {
             header_name: "X-Forwarded-For".to_string(),
         });
         let json = serde_json::to_string(&limit_by).unwrap();
         assert_eq!(json, r#""http-header::X-Forwarded-For""#);
 
-        let limit_by: LimitBy = serde_json::from_str(&json).unwrap();
+        let limit_by: CountBy = serde_json::from_str(&json).unwrap();
         assert_eq!(
             limit_by,
-            LimitBy::HttpHeader(CountByHttpHeader {
+            CountBy::HttpHeader(CountByHttpHeader {
                 header_name: "X-Forwarded-For".to_string(),
             })
         );

--- a/src/access_controller/predicates/aggregate.rs
+++ b/src/access_controller/predicates/aggregate.rs
@@ -1,8 +1,10 @@
-use std::time::Duration;
+use std::{str::FromStr, time::Duration};
 
 use serde::{Deserialize, Serialize};
 
 use super::ValueNumber;
+
+const HTTP_HEADER_PREFIX: &str = "http-header::";
 
 /// ValueAggregate is a struct that represents an aggregate value with a specified window and limit.
 /// It must use persistent storage [`Tracker`] to store the aggregate value.
@@ -31,17 +33,90 @@ impl ValueAggregate {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
 pub enum LimitBy {
     SenderAddress,
+    HttpHeader(CountByHttpHeader),
+}
+
+impl LimitBy {
+    pub fn new_http_header(header_name: impl AsRef<str>) -> Self {
+        LimitBy::HttpHeader(CountByHttpHeader {
+            header_name: header_name.as_ref().to_string(),
+        })
+    }
+
+    pub fn new_sender_address() -> Self {
+        LimitBy::SenderAddress
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CountByHttpHeader {
+    pub header_name: String,
+}
+
+impl Serialize for CountByHttpHeader {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+impl<'de> Deserialize<'de> for CountByHttpHeader {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        Ok(CountByHttpHeader::from_str(&s).unwrap())
+    }
+}
+
+// The HttpHeader should be serialized to string like: http-header::<header-name>
+impl FromStr for CountByHttpHeader {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let parts = s.split(HTTP_HEADER_PREFIX).collect::<Vec<&str>>();
+        if parts.len() != 2 {
+            return Err(anyhow::anyhow!("Invalid HttpHeader: {}", s));
+        }
+        Ok(CountByHttpHeader {
+            header_name: parts[1].to_string(),
+        })
+    }
+}
+
+impl From<&CountByHttpHeader> for String {
+    fn from(header: &CountByHttpHeader) -> Self {
+        format!("{HTTP_HEADER_PREFIX}{}", header.header_name)
+    }
+}
+
+impl TryFrom<&String> for CountByHttpHeader {
+    type Error = anyhow::Error;
+
+    fn try_from(s: &String) -> Result<Self, Self::Error> {
+        CountByHttpHeader::from_str(&s).map_err(|e| anyhow::anyhow!("Invalid HttpHeader: {}", e))
+    }
 }
 
 impl ToString for LimitBy {
     fn to_string(&self) -> String {
         match self {
             LimitBy::SenderAddress => "sender-address".to_string(),
+            LimitBy::HttpHeader(header) => header.to_string(),
         }
+    }
+}
+
+impl ToString for CountByHttpHeader {
+    fn to_string(&self) -> String {
+        self.into()
     }
 }
 
@@ -71,7 +146,25 @@ mod serde_duration {
 
 #[cfg(test)]
 mod test {
+    use super::{CountByHttpHeader, LimitBy};
     use crate::access_controller::predicates::{ValueAggregate, ValueNumber};
+
+    #[test]
+    fn test_serde_limit_by() {
+        let limit_by = LimitBy::HttpHeader(CountByHttpHeader {
+            header_name: "X-Forwarded-For".to_string(),
+        });
+        let json = serde_json::to_string(&limit_by).unwrap();
+        assert_eq!(json, r#""http-header::X-Forwarded-For""#);
+
+        let limit_by: LimitBy = serde_json::from_str(&json).unwrap();
+        assert_eq!(
+            limit_by,
+            LimitBy::HttpHeader(CountByHttpHeader {
+                header_name: "X-Forwarded-For".to_string(),
+            })
+        );
+    }
 
     #[test]
     fn test_deserialize_value_aggregate() {

--- a/src/access_controller/predicates/aggregate.rs
+++ b/src/access_controller/predicates/aggregate.rs
@@ -33,8 +33,7 @@ impl ValueAggregate {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "kebab-case")]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CountBy {
     SenderAddress,
     HttpHeader(CountByHttpHeader),
@@ -49,6 +48,35 @@ impl CountBy {
 
     pub fn new_sender_address() -> Self {
         CountBy::SenderAddress
+    }
+}
+
+impl Serialize for CountBy {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            CountBy::SenderAddress => serializer.serialize_str("sender-address"),
+            CountBy::HttpHeader(header) => serializer.serialize_str(&header.to_string()),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for CountBy {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        match s.as_str() {
+            "sender-address" => Ok(CountBy::SenderAddress),
+            _ if s.starts_with(HTTP_HEADER_PREFIX) => {
+                let header = CountByHttpHeader::from_str(&s).map_err(serde::de::Error::custom)?;
+                Ok(CountBy::HttpHeader(header))
+            }
+            _ => Err(serde::de::Error::custom(format!("Invalid CountBy: {}", s))),
+        }
     }
 }
 
@@ -150,11 +178,21 @@ mod test {
     use crate::access_controller::predicates::{ValueAggregate, ValueNumber};
 
     #[test]
-    fn test_serde_limit_by() {
-        let limit_by = CountBy::HttpHeader(CountByHttpHeader {
+    fn test_serde_count_by_sender_address() {
+        let count_by = CountBy::SenderAddress;
+        let json = serde_json::to_string(&count_by).unwrap();
+        assert_eq!(json, r#""sender-address""#);
+
+        let count_by: CountBy = serde_json::from_str(&json).unwrap();
+        assert_eq!(count_by, CountBy::SenderAddress);
+    }
+
+    #[test]
+    fn test_serde_count_by_http_header() {
+        let count_by = CountBy::HttpHeader(CountByHttpHeader {
             header_name: "X-Forwarded-For".to_string(),
         });
-        let json = serde_json::to_string(&limit_by).unwrap();
+        let json = serde_json::to_string(&count_by).unwrap();
         assert_eq!(json, r#""http-header::X-Forwarded-For""#);
 
         let limit_by: CountBy = serde_json::from_str(&json).unwrap();

--- a/src/access_controller/predicates/aggregate/count_by.rs
+++ b/src/access_controller/predicates/aggregate/count_by.rs
@@ -1,37 +1,8 @@
-use std::{str::FromStr, time::Duration};
+use std::str::FromStr;
 
 use serde::{Deserialize, Serialize};
 
-use super::ValueNumber;
-
 const HTTP_HEADER_PREFIX: &str = "http-header::";
-
-/// ValueAggregate is a struct that represents an aggregate value with a specified window and limit.
-/// It must use persistent storage [`Tracker`] to store the aggregate value.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "kebab-case")]
-pub struct ValueAggregate {
-    #[serde(with = "serde_duration")]
-    pub window: Duration,
-    pub value: ValueNumber<u64>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub count_by: Vec<CountBy>,
-}
-
-impl ValueAggregate {
-    pub fn new(window: Duration, limit: ValueNumber<u64>) -> Self {
-        ValueAggregate {
-            window,
-            value: limit,
-            count_by: vec![],
-        }
-    }
-
-    pub fn with_count_by(mut self, group_by: Vec<CountBy>) -> Self {
-        self.count_by = group_by;
-        self
-    }
-}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CountBy {
@@ -148,35 +119,9 @@ impl ToString for CountByHttpHeader {
     }
 }
 
-mod serde_duration {
-    use serde::Deserialize;
-
-    fn parse_duration(s: &str) -> std::time::Duration {
-        humantime::parse_duration(s).unwrap_or_else(|_| panic!("Failed to parse duration: {}", s))
-    }
-
-    pub fn serialize<S>(value: &std::time::Duration, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        let s = humantime::format_duration(*value).to_string();
-        serializer.serialize_str(&s)
-    }
-
-    pub fn deserialize<'de, D>(deserializer: D) -> Result<std::time::Duration, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        let s = String::deserialize(deserializer)?;
-        Ok(parse_duration(&s))
-    }
-}
-
 #[cfg(test)]
 mod test {
     use super::{CountBy, CountByHttpHeader};
-    use crate::access_controller::predicates::{ValueAggregate, ValueNumber};
-
     #[test]
     fn test_serde_count_by_sender_address() {
         let count_by = CountBy::SenderAddress;
@@ -202,27 +147,5 @@ mod test {
                 header_name: "X-Forwarded-For".to_string(),
             })
         );
-    }
-
-    #[test]
-    fn test_deserialize_value_aggregate() {
-        let json = r#"{"window":"1h 30 min","value": ">100"}"#;
-        let value_aggregate: ValueAggregate = serde_json::from_str(json).unwrap();
-
-        assert_eq!(value_aggregate.window.as_secs(), 5400);
-        assert!(matches!(
-            value_aggregate.value,
-            ValueNumber::GreaterThan(100),
-        ));
-    }
-
-    #[test]
-    fn test_serialize_value_aggregate() {
-        let value_aggregate = ValueAggregate::new(
-            std::time::Duration::new(5400, 0),
-            ValueNumber::GreaterThan(100),
-        );
-        let json = serde_json::to_string(&value_aggregate).unwrap();
-        assert_eq!(json, r#"{"window":"1h 30m","value":">100"}"#);
     }
 }

--- a/src/access_controller/predicates/aggregate/count_by.rs
+++ b/src/access_controller/predicates/aggregate/count_by.rs
@@ -1,6 +1,8 @@
-use std::str::FromStr;
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
 
 use serde::{Deserialize, Serialize};
+use std::str::FromStr;
 
 const HTTP_HEADER_PREFIX: &str = "http-header::";
 

--- a/src/access_controller/predicates/aggregate/mod.rs
+++ b/src/access_controller/predicates/aggregate/mod.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 use std::time::Duration;
 
 use serde::{Deserialize, Serialize};

--- a/src/access_controller/predicates/aggregate/mod.rs
+++ b/src/access_controller/predicates/aggregate/mod.rs
@@ -1,0 +1,86 @@
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+
+use crate::access_controller::predicates::aggregate::count_by::CountBy;
+use crate::access_controller::predicates::number::ValueNumber;
+
+pub mod count_by;
+
+/// ValueAggregate is a struct that represents an aggregate value with a specified window and limit.
+/// It must use persistent storage [`Tracker`] to store the aggregate value.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct ValueAggregate {
+    #[serde(with = "serde_duration")]
+    pub window: Duration,
+    pub value: ValueNumber<u64>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub count_by: Vec<CountBy>,
+}
+
+impl ValueAggregate {
+    pub fn new(window: Duration, limit: ValueNumber<u64>) -> Self {
+        ValueAggregate {
+            window,
+            value: limit,
+            count_by: vec![],
+        }
+    }
+
+    pub fn with_count_by(mut self, group_by: Vec<CountBy>) -> Self {
+        self.count_by = group_by;
+        self
+    }
+}
+
+mod serde_duration {
+    use serde::Deserialize;
+
+    fn parse_duration(s: &str) -> std::time::Duration {
+        humantime::parse_duration(s).unwrap_or_else(|_| panic!("Failed to parse duration: {}", s))
+    }
+
+    pub fn serialize<S>(value: &std::time::Duration, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let s = humantime::format_duration(*value).to_string();
+        serializer.serialize_str(&s)
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<std::time::Duration, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        Ok(parse_duration(&s))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::access_controller::predicates::{ValueAggregate, ValueNumber};
+
+    #[test]
+    fn test_deserialize_value_aggregate() {
+        let json = r#"{"window":"1h 30 min","value": ">100"}"#;
+        let value_aggregate: ValueAggregate = serde_json::from_str(json).unwrap();
+
+        assert_eq!(value_aggregate.window.as_secs(), 5400);
+        assert!(matches!(
+            value_aggregate.value,
+            ValueNumber::GreaterThan(100),
+        ));
+    }
+
+    #[test]
+    fn test_serialize_value_aggregate() {
+        let value_aggregate = ValueAggregate::new(
+            std::time::Duration::new(5400, 0),
+            ValueNumber::GreaterThan(100),
+        );
+        let json = serde_json::to_string(&value_aggregate).unwrap();
+        assert_eq!(json, r#"{"window":"1h 30m","value":">100"}"#);
+    }
+}

--- a/src/access_controller/predicates/mod.rs
+++ b/src/access_controller/predicates/mod.rs
@@ -8,7 +8,7 @@ mod number;
 mod rego_expression;
 mod source;
 pub use action::Action;
-pub use aggregate::{LimitBy, ValueAggregate};
+pub use aggregate::{CountByHttpHeader, LimitBy, ValueAggregate};
 pub use iota_address::ValueIotaAddress;
 pub use number::ValueNumber;
 pub use rego_expression::RegoExpression;

--- a/src/access_controller/predicates/mod.rs
+++ b/src/access_controller/predicates/mod.rs
@@ -8,7 +8,7 @@ mod number;
 mod rego_expression;
 mod source;
 pub use action::Action;
-pub use aggregate::{CountByHttpHeader, LimitBy, ValueAggregate};
+pub use aggregate::{CountBy, CountByHttpHeader, ValueAggregate};
 pub use iota_address::ValueIotaAddress;
 pub use number::ValueNumber;
 pub use rego_expression::RegoExpression;

--- a/src/access_controller/predicates/mod.rs
+++ b/src/access_controller/predicates/mod.rs
@@ -8,7 +8,10 @@ mod number;
 mod rego_expression;
 mod source;
 pub use action::Action;
-pub use aggregate::{CountBy, CountByHttpHeader, ValueAggregate};
+pub use aggregate::{
+    count_by::{CountBy, CountByHttpHeader},
+    ValueAggregate,
+};
 pub use iota_address::ValueIotaAddress;
 pub use number::ValueNumber;
 pub use rego_expression::RegoExpression;

--- a/src/access_controller/predicates/source.rs
+++ b/src/access_controller/predicates/source.rs
@@ -23,8 +23,9 @@ impl SourceWithData {
     }
     // Fetch the data from the location.
     pub async fn fetch(&mut self) -> Result<(), anyhow::Error> {
-        self.data = Some(self.location.fetch_bytes().await?);
-        trace!("Fetched data from location: {:?}", self.data);
+        let data = self.location.fetch_bytes().await?;
+        trace!("Fetched data from location: {} bytes", data.len());
+        self.data = Some(data);
         Ok(())
     }
 

--- a/src/access_controller/rule.rs
+++ b/src/access_controller/rule.rs
@@ -3,7 +3,7 @@
 
 use std::collections::BTreeMap;
 
-use anyhow::{bail, Context};
+use anyhow::Context;
 use axum::http::HeaderMap;
 use fastcrypto::encoding::Base64;
 use iota_types::{
@@ -20,12 +20,13 @@ use tracing::trace;
 use url::Url;
 
 use crate::{
-    access_controller::reports::{PredicateReport, RuleReport},
     access_controller::{
         hook::{HookAction, HookActionHeaders},
         predicates::{
             Action, CountBy, RegoExpression, ValueAggregate, ValueIotaAddress, ValueNumber,
         },
+        reports::{PredicateReport, RuleReport},
+        utils::header_map_to_btree_map,
     },
     rpc::rpc_types::ExecuteTransactionRequestType,
     tracker::{
@@ -417,6 +418,8 @@ impl AccessRule {
     ) -> Result<PredicateReport, anyhow::Error> {
         if let Some(rego_expression) = self.rego_expression.as_ref() {
             let input_payload = RegoInputPayload::from_context(ctx);
+            println!("input_payload: {:#?}", input_payload);
+
             let input_string = serde_json::to_string_pretty(&input_payload)
                 .context("Failed to serialize input payload to JSON")?;
             let result = rego_expression
@@ -461,16 +464,7 @@ impl RegoInputPayload {
     pub fn from_context(ctx: &TransactionContext) -> Self {
         Self {
             transaction_data: ctx.transaction_data.clone(),
-            http_headers: ctx
-                .headers
-                .iter()
-                .map(|(key, value)| {
-                    (
-                        key.to_string(),
-                        vec![value.to_str().unwrap_or("").to_string()],
-                    )
-                })
-                .collect(),
+            http_headers: header_map_to_btree_map(&ctx.headers),
         }
     }
 }
@@ -931,6 +925,41 @@ mod test {
             HeaderValue::from_str("456").unwrap(),
         )]));
         assert!(!rule.matches(&unmatched_data).await.unwrap().is_matched);
+    }
+
+    #[tokio::test]
+    async fn test_constraint_rego_expression_with_multiple_http_header_values() {
+        let rego_content = r#"
+            package test
+
+            default allow_account = false
+            allow_account if {
+                input.http_headers["x-account-id"][0] == "123"
+                input.http_headers["x-account-id"][1] == "456"
+            }
+        "#;
+        let location = Location::new_memory(rego_content, "data.test.allow_account");
+        let mut source = SourceWithData::new(location);
+        source.fetch().await.unwrap();
+
+        let rego_expression =
+            RegoExpression::from_source(source).expect("Failed to create Rego expression");
+        let rule = AccessRuleBuilder::new()
+            .rego_expression(rego_expression)
+            .allow()
+            .build();
+
+        let matched_data = TransactionContext::default().with_headers(HeaderMap::from_iter([
+            (
+                HeaderName::from_str("X-Account-Id").unwrap(),
+                HeaderValue::from_str("123").unwrap(),
+            ),
+            (
+                HeaderName::from_str("X-Account-Id").unwrap(),
+                HeaderValue::from_str("456").unwrap(),
+            ),
+        ]));
+        assert!(rule.matches(&matched_data).await.unwrap().is_matched);
     }
 
     #[tokio::test]

--- a/src/access_controller/rule.rs
+++ b/src/access_controller/rule.rs
@@ -12,6 +12,7 @@ use iota_types::{
     signature::GenericSignature,
     transaction::{TransactionData, TransactionDataAPI, TransactionDataV1, TransactionKind},
 };
+use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use serde_with::skip_serializing_none;
@@ -346,15 +347,15 @@ impl AccessRule {
                 let count_by_value = match count_by {
                     CountBy::SenderAddress => ctx.sender_address.to_string(),
                     CountBy::HttpHeader(header) => {
-                        match ctx.headers.get(header.header_name.as_str()) {
-                            Some(value) => value
-                                .to_str()
-                                .context("Failed to convert header value to string")?
-                                .to_string(),
-                            None => {
-                                bail!("Header not found: {}", header.header_name)
-                            }
-                        }
+                        // in case when there are multiple header values, we join them by the comma
+                        // we also sort the values to make sure the same header values are hashed the same way
+                        let values = ctx.headers.get_all(header.header_name.as_str());
+                        values
+                            .iter()
+                            .map(|value| value.to_str().unwrap_or("").to_string())
+                            .sorted()
+                            .collect::<Vec<String>>()
+                            .join(",")
                     }
                 };
                 (&mut rule_to_hash).insert(count_by.to_string(), Value::String(count_by_value));

--- a/src/access_controller/rule.rs
+++ b/src/access_controller/rule.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::Context;
+use anyhow::{bail, Context};
 use axum::http::HeaderMap;
 use fastcrypto::encoding::Base64;
 use iota_types::{
@@ -343,6 +343,17 @@ impl AccessRule {
             for count_by in gas_limit.count_by.iter() {
                 let count_by_value = match count_by {
                     LimitBy::SenderAddress => ctx.sender_address.to_string(),
+                    LimitBy::HttpHeader(header) => {
+                        match ctx.headers.get(header.header_name.as_str()) {
+                            Some(value) => value
+                                .to_str()
+                                .context("Failed to convert header value to string")?
+                                .to_string(),
+                            None => {
+                                bail!("Header not found: {}", header.header_name)
+                            }
+                        }
+                    }
                 };
                 (&mut rule_to_hash).insert(count_by.to_string(), Value::String(count_by_value));
             }
@@ -597,8 +608,9 @@ fn get_move_call_package_addresses(transaction_data: &TransactionData) -> Vec<Io
 #[cfg(test)]
 mod test {
 
-    use std::vec;
+    use std::{str::FromStr, vec};
 
+    use axum::http::{HeaderMap, HeaderName, HeaderValue};
     use iota_types::{
         base_types::IotaAddress,
         transaction::{
@@ -868,6 +880,74 @@ mod test {
             !rule
                 .match_rego_expression(&unmatched_data)
                 .unwrap()
+                .is_matched
+        );
+    }
+
+    #[tokio::test]
+    async fn test_constraint_gas_usage_with_http_header() {
+        let sender_address = random_address();
+        let sponsor_address = random_address();
+        let stats_tracker = new_stats_tracker_for_testing(sponsor_address).await;
+        let rule = AccessRuleBuilder::new()
+            .gas_limit(
+                ValueAggregate::new(
+                    std::time::Duration::from_secs(10),
+                    ValueNumber::LessThanOrEqual(300),
+                )
+                .with_count_by(vec![LimitBy::new_http_header("X-Account-Id")]),
+            )
+            .allow()
+            .build();
+
+        let account_1_ctx = TransactionContext::default()
+            .with_headers(HeaderMap::from_iter([(
+                HeaderName::from_str("X-Account-Id").unwrap(),
+                HeaderValue::from_str("123").unwrap(),
+            )]))
+            .with_gas_budget(300)
+            .with_stats_tracker(stats_tracker.clone())
+            .with_sender_address(sender_address);
+        let account_2_ctx = TransactionContext::default()
+            .with_headers(HeaderMap::from_iter([(
+                HeaderName::from_str("X-Account-Id").unwrap(),
+                HeaderValue::from_str("456").unwrap(),
+            )]))
+            .with_gas_budget(300)
+            .with_stats_tracker(stats_tracker)
+            .with_sender_address(sender_address);
+
+        // Even though the transactions come from the same sender, they should
+        // be distinguished by the account ID. Each account ID should have a separate
+        // gas usage limit and should be separately blocked after its limit is used.
+        assert!(
+            rule.match_global_limits(&account_1_ctx)
+                .await
+                .unwrap()
+                .0
+                .is_matched
+        );
+        assert!(
+            !rule
+                .match_global_limits(&account_1_ctx)
+                .await
+                .unwrap()
+                .0
+                .is_matched
+        );
+        assert!(
+            rule.match_global_limits(&account_2_ctx)
+                .await
+                .unwrap()
+                .0
+                .is_matched
+        );
+        assert!(
+            !rule
+                .match_global_limits(&account_2_ctx)
+                .await
+                .unwrap()
+                .0
                 .is_matched
         );
     }

--- a/src/access_controller/rule.rs
+++ b/src/access_controller/rule.rs
@@ -368,21 +368,12 @@ impl AccessRule {
                 .update_aggr(rule_meta.clone(), &aggr, ctx.transaction_budget as i64)
                 .await
                 .context("Updating aggregate failed")?;
-            let is_matched = gas_limit.value.matches(total_gas_claim as u64);
-            // If not matched then we need to 'restore' the state of aggregate,
-            // because the rule will not be applied. And also there is no need to create
-            // a confirmation request that 'fixes' the state of aggregate.
-            if !is_matched {
-                ctx.stats_tracker
-                    .update_aggr(rule_meta.clone(), &aggr, -(ctx.transaction_budget as i64))
-                    .await
-                    .context("Restoring aggregate failed")?;
-            }
-            let confirmation_request = is_matched.then(|| GasUsageConfirmationRequest {
+            let confirmation_request = GasUsageConfirmationRequest {
                 rule_meta,
                 aggregate: aggr,
                 gas_usage: ctx.transaction_budget,
-            });
+            };
+            let is_matched = gas_limit.value.matches(total_gas_claim as u64);
             let result_reason = format!(
                 "total gas usage {} {}: {}",
                 total_gas_claim,
@@ -393,11 +384,10 @@ impl AccessRule {
                 },
                 gas_limit.value
             );
-
-            Ok((
+            return Ok((
                 PredicateReport::new(predicate_names::GAS_USAGE, is_matched, result_reason),
-                confirmation_request,
-            ))
+                Some(confirmation_request),
+            ));
         } else {
             // If the gas limit is not defined then the rule matches
             return Ok((

--- a/src/access_controller/rule.rs
+++ b/src/access_controller/rule.rs
@@ -899,6 +899,40 @@ mod test {
     }
 
     #[tokio::test]
+    async fn test_constraint_rego_expression_with_http_header() {
+        let rego_content = r#"
+            package test
+
+            default allow_account = false
+            allow_account if {
+                input.http_headers["x-account-id"][0] == "123"
+            }
+        "#;
+        let location = Location::new_memory(rego_content, "data.test.allow_account");
+        let mut source = SourceWithData::new(location);
+        source.fetch().await.unwrap();
+
+        let rego_expression =
+            RegoExpression::from_source(source).expect("Failed to create Rego expression");
+        let rule = AccessRuleBuilder::new()
+            .rego_expression(rego_expression)
+            .allow()
+            .build();
+
+        let matched_data = TransactionContext::default().with_headers(HeaderMap::from_iter([(
+            HeaderName::from_str("X-Account-Id").unwrap(),
+            HeaderValue::from_str("123").unwrap(),
+        )]));
+        assert!(rule.matches(&matched_data).await.unwrap().is_matched);
+
+        let unmatched_data = TransactionContext::default().with_headers(HeaderMap::from_iter([(
+            HeaderName::from_str("X-Account-Id").unwrap(),
+            HeaderValue::from_str("456").unwrap(),
+        )]));
+        assert!(!rule.matches(&unmatched_data).await.unwrap().is_matched);
+    }
+
+    #[tokio::test]
     async fn test_constraint_gas_usage_with_http_header() {
         let sender_address = random_address();
         let sponsor_address = random_address();

--- a/src/access_controller/rule.rs
+++ b/src/access_controller/rule.rs
@@ -1,6 +1,8 @@
 // Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::BTreeMap;
+
 use anyhow::{bail, Context};
 use axum::http::HeaderMap;
 use fastcrypto::encoding::Base64;
@@ -450,12 +452,24 @@ impl AccessRule {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct RegoInputPayload {
     pub transaction_data: Value,
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    pub http_headers: BTreeMap<String, Vec<String>>,
 }
 
 impl RegoInputPayload {
     pub fn from_context(ctx: &TransactionContext) -> Self {
         Self {
             transaction_data: ctx.transaction_data.clone(),
+            http_headers: ctx
+                .headers
+                .iter()
+                .map(|(key, value)| {
+                    (
+                        key.to_string(),
+                        vec![value.to_str().unwrap_or("").to_string()],
+                    )
+                })
+                .collect(),
         }
     }
 }

--- a/src/access_controller/rule.rs
+++ b/src/access_controller/rule.rs
@@ -21,7 +21,7 @@ use crate::{
     access_controller::{
         hook::{HookAction, HookActionHeaders},
         predicates::{
-            Action, LimitBy, RegoExpression, ValueAggregate, ValueIotaAddress, ValueNumber,
+            Action, CountBy, RegoExpression, ValueAggregate, ValueIotaAddress, ValueNumber,
         },
     },
     rpc::rpc_types::ExecuteTransactionRequestType,
@@ -342,8 +342,8 @@ impl AccessRule {
         if let Some(gas_limit) = self.gas_usage.as_ref() {
             for count_by in gas_limit.count_by.iter() {
                 let count_by_value = match count_by {
-                    LimitBy::SenderAddress => ctx.sender_address.to_string(),
-                    LimitBy::HttpHeader(header) => {
+                    CountBy::SenderAddress => ctx.sender_address.to_string(),
+                    CountBy::HttpHeader(header) => {
                         match ctx.headers.get(header.header_name.as_str()) {
                             Some(value) => value
                                 .to_str()
@@ -622,7 +622,7 @@ mod test {
     use crate::{
         access_controller::{
             predicates::{
-                Action, LimitBy, Location, RegoExpression, SourceWithData, ValueAggregate,
+                Action, CountBy, Location, RegoExpression, SourceWithData, ValueAggregate,
                 ValueIotaAddress, ValueNumber,
             },
             rule::{AccessRule, AccessRuleBuilder, TransactionContext},
@@ -791,7 +791,7 @@ mod test {
                     std::time::Duration::from_secs(10),
                     ValueNumber::GreaterThanOrEqual(300),
                 )
-                .with_count_by(vec![LimitBy::SenderAddress]),
+                .with_count_by(vec![CountBy::SenderAddress]),
             )
             .deny()
             .build();
@@ -895,7 +895,7 @@ mod test {
                     std::time::Duration::from_secs(10),
                     ValueNumber::LessThanOrEqual(300),
                 )
-                .with_count_by(vec![LimitBy::new_http_header("X-Account-Id")]),
+                .with_count_by(vec![CountBy::new_http_header("X-Account-Id")]),
             )
             .allow()
             .build();

--- a/src/access_controller/rule.rs
+++ b/src/access_controller/rule.rs
@@ -31,7 +31,7 @@ use crate::{
     },
 };
 
-mod predicate_names {
+pub(crate) mod predicate_names {
     pub const SENDER_ADDRESS: &str = "sender_address";
     pub const GAS_BUDGET: &str = "gas_budget";
     pub const MOVE_CALL_PACKAGE_ADDRESS: &str = "move_call_package_address";
@@ -328,7 +328,10 @@ impl AccessRule {
     }
 
     /// Returns the rule meta data as a JSON object. The rule meta is used to calculate the hash of the rule.
-    fn get_rule_meta(&self, ctx: &TransactionContext) -> Result<Map<String, Value>, anyhow::Error> {
+    pub fn get_rule_meta(
+        &self,
+        ctx: &TransactionContext,
+    ) -> Result<Map<String, Value>, anyhow::Error> {
         let json_rule =
             serde_json::to_value(self.clone()).context("Failed to serialize rule to JSON")?;
         let mut rule_to_hash = json_rule
@@ -354,7 +357,7 @@ impl AccessRule {
         if let Some(gas_limit) = self.gas_usage.as_ref() {
             let rule_meta = self
                 .get_rule_meta(ctx)
-                .context("Failed to calculate rule meta")?;
+                .context("Failed to calculate rule meta for gas limit")?;
 
             let aggr = Aggregate::with_name(predicate_names::GAS_USAGE)
                 .with_aggr_type(AggregateType::Sum)
@@ -365,21 +368,36 @@ impl AccessRule {
                 .update_aggr(rule_meta.clone(), &aggr, ctx.transaction_budget as i64)
                 .await
                 .context("Updating aggregate failed")?;
-
-            let confirmation_request = GasUsageConfirmationRequest {
+            let is_matched = gas_limit.value.matches(total_gas_claim as u64);
+            // If not matched then we need to 'restore' the state of aggregate,
+            // because the rule will not be applied. And also there is no need to create
+            // a confirmation request that 'fixes' the state of aggregate.
+            if !is_matched {
+                ctx.stats_tracker
+                    .update_aggr(rule_meta.clone(), &aggr, -(ctx.transaction_budget as i64))
+                    .await
+                    .context("Restoring aggregate failed")?;
+            }
+            let confirmation_request = is_matched.then(|| GasUsageConfirmationRequest {
                 rule_meta,
                 aggregate: aggr,
                 gas_usage: ctx.transaction_budget,
-            };
+            });
+            let result_reason = format!(
+                "total gas usage {} {}: {}",
+                total_gas_claim,
+                if is_matched {
+                    "matches"
+                } else {
+                    "does not match"
+                },
+                gas_limit.value
+            );
 
-            return Ok((
-                PredicateReport::new(
-                    predicate_names::GAS_USAGE,
-                    gas_limit.value.matches(total_gas_claim as u64),
-                    format!("gas usage {} matches: {}", total_gas_claim, gas_limit.value),
-                ),
-                Some(confirmation_request),
-            ));
+            Ok((
+                PredicateReport::new(predicate_names::GAS_USAGE, is_matched, result_reason),
+                confirmation_request,
+            ))
         } else {
             // If the gas limit is not defined then the rule matches
             return Ok((

--- a/src/access_controller/rule.rs
+++ b/src/access_controller/rule.rs
@@ -418,8 +418,6 @@ impl AccessRule {
     ) -> Result<PredicateReport, anyhow::Error> {
         if let Some(rego_expression) = self.rego_expression.as_ref() {
             let input_payload = RegoInputPayload::from_context(ctx);
-            println!("input_payload: {:#?}", input_payload);
-
             let input_string = serde_json::to_string_pretty(&input_payload)
                 .context("Failed to serialize input payload to JSON")?;
             let result = rego_expression

--- a/src/access_controller/utils.rs
+++ b/src/access_controller/utils.rs
@@ -1,0 +1,59 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::BTreeMap;
+
+use axum::http::HeaderMap;
+
+pub fn header_map_to_btree_map(headers: &HeaderMap) -> BTreeMap<String, Vec<String>> {
+    let mut header_btree_map = BTreeMap::new();
+    for (k, v) in headers.clone().iter() {
+        let k = k.to_string();
+        let v = String::from_utf8_lossy(v.as_bytes()).into_owned();
+        header_btree_map.entry(k).or_insert_with(Vec::new).push(v);
+    }
+    header_btree_map
+}
+
+#[cfg(test)]
+mod test {
+    use axum::http::{HeaderName, HeaderValue};
+    use std::str::FromStr;
+
+    use super::*;
+
+    #[test]
+    fn test_header_map_to_btree_map() {
+        let headers = HeaderMap::from_iter([(
+            HeaderName::from_str("X-Account-Id").unwrap(),
+            HeaderValue::from_str("123").unwrap(),
+        )]);
+        let btree_map = header_map_to_btree_map(&headers);
+        assert_eq!(
+            btree_map,
+            BTreeMap::from_iter([("x-account-id".to_string(), vec!["123".to_string()])])
+        );
+    }
+
+    #[test]
+    fn test_header_map_to_btree_map_with_multiple_values() {
+        let headers = HeaderMap::from_iter([
+            (
+                HeaderName::from_str("X-Account-Id").unwrap(),
+                HeaderValue::from_str("123").unwrap(),
+            ),
+            (
+                HeaderName::from_str("X-Account-Id").unwrap(),
+                HeaderValue::from_str("456").unwrap(),
+            ),
+        ]);
+        let btree_map = header_map_to_btree_map(&headers);
+        assert_eq!(
+            btree_map,
+            BTreeMap::from_iter([(
+                "x-account-id".to_string(),
+                vec!["123".to_string(), "456".to_string()]
+            )])
+        );
+    }
+}

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -203,10 +203,12 @@ mod tests {
             .is_err());
     }
 
-    // The rule with gas-usage partially matches (sender address), but not action applied,
-    // and the another in order rule should be applied. Gas-usage counter should remain untouched.
+    // The rule with gas-usage matches (sender address), but not action applied
+    // due to of gas-limit constraint. The next in order rule should be applied with deny action.
+    // When there is a `deny` action, there is no gas usage, so the gas-usage counter
+    // from first rule should go back to its original state `0`
     #[tokio::test]
-    async fn test_access_denied_from_controller_gas_usage_partially_matches() {
+    async fn test_access_denied_from_controller_by_another_rule() {
         let rule_gas_usage = AccessRuleBuilder::new()
             .gas_limit(ValueAggregate::new(
                 Duration::from_secs(120),
@@ -214,7 +216,7 @@ mod tests {
             ))
             .allow()
             .build();
-        let rule_allow_any = AccessRuleBuilder::new().allow().build();
+        let rule_allow_any = AccessRuleBuilder::new().deny().build();
         let rules = [rule_gas_usage.clone(), rule_allow_any];
         let (test_cluster, container, server) =
             start_rpc_server_for_testing_with_access_controller(
@@ -244,7 +246,7 @@ mod tests {
         assert!(client
             .execute_tx(reservation_id, &tx_data, &user_sig, None, None)
             .await
-            .is_ok());
+            .is_err());
 
         let value = fetch_redis_val::<i64>(&redis_key);
         assert_eq!(value, 0);

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -14,15 +14,17 @@ mod tests {
 
     use crate::access_controller::policy::AccessPolicy;
     use crate::access_controller::predicates::{ValueAggregate, ValueNumber};
-    use crate::access_controller::rule::AccessRuleBuilder;
+    use crate::access_controller::rule::{predicate_names, AccessRuleBuilder};
     use crate::access_controller::AccessController;
     use crate::config::GasStationConfig;
     use crate::rpc::ExecuteTransactionRequestType;
     use crate::test_env::{
-        create_test_transaction, start_rpc_server_for_testing,
+        create_test_transaction, fetch_redis_val, remove_redis_key, start_rpc_server_for_testing,
         start_rpc_server_for_testing_empty_auth, start_rpc_server_for_testing_no_auth,
         start_rpc_server_for_testing_with_access_controller, DEFAULT_TEST_CONFIG_PATH,
     };
+    use crate::tracker::stats_tracker_storage::redis::get_redis_aggr_key;
+    use crate::tracker::stats_tracker_storage::AggregateType;
     use crate::AUTH_ENV_NAME;
     use iota_config::Config;
     use iota_json_rpc_types::IotaTransactionBlockEffectsAPI;
@@ -199,6 +201,53 @@ mod tests {
             .execute_tx(reservation_id, &tx_data, &user_sig, None, None)
             .await
             .is_err());
+    }
+
+    // The rule with gas-usage partially matches (sender address), but not action applied,
+    // and the another in order rule should be applied. Gas-usage counter should remain untouched.
+    #[tokio::test]
+    async fn test_access_denied_from_controller_gas_usage_partially_matches() {
+        let rule_gas_usage = AccessRuleBuilder::new()
+            .gas_limit(ValueAggregate::new(
+                Duration::from_secs(120),
+                ValueNumber::LessThanOrEqual(3333),
+            ))
+            .allow()
+            .build();
+        let rule_allow_any = AccessRuleBuilder::new().allow().build();
+        let rules = [rule_gas_usage.clone(), rule_allow_any];
+        let (test_cluster, container, server) =
+            start_rpc_server_for_testing_with_access_controller(
+                vec![NANOS_PER_IOTA; 60],
+                NANOS_PER_IOTA,
+                AccessController::new(AccessPolicy::DenyAll, rules),
+            )
+            .await;
+
+        let rule_meta = rule_gas_usage.get_rule_meta(&Default::default()).unwrap();
+        let signer_address = container.get_signer_address();
+        let rule_key = get_redis_aggr_key(
+            predicate_names::GAS_USAGE,
+            AggregateType::Sum,
+            rule_meta.clone().into_iter().collect::<Vec<_>>().as_slice(),
+        );
+        let redis_key = format!("{}:{}", signer_address, rule_key);
+
+        // We want to make sure the redis key is not present
+        remove_redis_key::<i64>(&redis_key);
+
+        let client = server.get_local_client();
+        let (sponsor, reservation_id, gas_coins) =
+            client.reserve_gas(NANOS_PER_IOTA, 10).await.unwrap();
+        let (tx_data, user_sig) = create_test_transaction(&test_cluster, sponsor, gas_coins).await;
+
+        assert!(client
+            .execute_tx(reservation_id, &tx_data, &user_sig, None, None)
+            .await
+            .is_ok());
+
+        let value = fetch_redis_val::<i64>(&redis_key);
+        assert_eq!(value, 0);
     }
 
     #[tokio::test]

--- a/src/rpc/server.rs
+++ b/src/rpc/server.rs
@@ -319,7 +319,7 @@ async fn execute_tx_impl(
 ) -> (StatusCode, Json<ExecuteTxResponse>) {
     let transaction_digest = tx_data.digest();
 
-    let matching_result = match access_controller.load().check_access(&ctx).await {
+    let check_access_result = match access_controller.load().check_access(&ctx).await {
         Ok(Decision::Allow) => {
             metrics.num_allowed_execute_tx_requests.inc();
             None
@@ -349,7 +349,7 @@ async fn execute_tx_impl(
         }
     };
 
-    if let Some((status_code, error)) = matching_result {
+    if let Some((status_code, error)) = check_access_result {
         let confirmation_result = access_controller
             .load()
             .confirm_transaction(

--- a/src/rpc/server.rs
+++ b/src/rpc/server.rs
@@ -317,18 +317,21 @@ async fn execute_tx_impl(
     access_controller: Arc<ArcSwap<AccessController>>,
     ctx: TransactionContext,
 ) -> (StatusCode, Json<ExecuteTxResponse>) {
-    match access_controller.load().check_access(&ctx).await {
+    let transaction_digest = tx_data.digest();
+
+    let matching_result = match access_controller.load().check_access(&ctx).await {
         Ok(Decision::Allow) => {
             metrics.num_allowed_execute_tx_requests.inc();
+            None
         }
         Ok(Decision::Deny) => {
             metrics.num_failed_execute_tx_requests.inc();
-            return (
+            Some((
                 StatusCode::FORBIDDEN,
                 Json(ExecuteTxResponse::new_err(anyhow::anyhow!(
                     "Access denied by access controller"
                 ))),
-            );
+            ))
         }
         Err(err) => {
             let event_id = generate_event_id();
@@ -336,17 +339,30 @@ async fn execute_tx_impl(
                 "EventId={} Error while checking access: {:?}",
                 event_id, err
             );
-            return (
+            Some((
                 StatusCode::BAD_REQUEST,
                 Json(ExecuteTxResponse::new_err(anyhow::anyhow!(
                     "Error while checking access. EventId={}",
                     event_id
                 ))),
-            );
+            ))
         }
+    };
+
+    if let Some((status_code, error)) = matching_result {
+        let confirmation_result = access_controller
+            .load()
+            .confirm_transaction(
+                TransactionExecutionResult::new(transaction_digest),
+                &ctx.stats_tracker,
+            )
+            .await;
+        if let Err(err) = confirmation_result {
+            error!("Error while canceling transaction in AC: {:?}", err);
+        }
+        return (status_code, error);
     }
 
-    let transaction_digest = tx_data.digest();
     match gas_station
         .execute_transaction(ctx.reservation_id, tx_data, user_sig, ctx.request_type)
         .await
@@ -360,7 +376,6 @@ async fn execute_tx_impl(
             );
             trace!(target: "transactions", "{}", TxLogMessage::new(&effects));
 
-            metrics.num_successful_execute_tx_requests.inc();
             let confirmation_result = access_controller
                 .load()
                 .confirm_transaction(
@@ -374,7 +389,7 @@ async fn execute_tx_impl(
             if let Err(err) = confirmation_result {
                 error!("Error while confirming transaction in AC: {:?}", err);
             }
-
+            metrics.num_successful_execute_tx_requests.inc();
             (StatusCode::OK, Json(ExecuteTxResponse::new_ok(effects)))
         }
         Err(err) => {

--- a/src/rpc/server.rs
+++ b/src/rpc/server.rs
@@ -319,7 +319,7 @@ async fn execute_tx_impl(
 ) -> (StatusCode, Json<ExecuteTxResponse>) {
     let transaction_digest = tx_data.digest();
 
-    let check_access_result = match access_controller.load().check_access(&ctx).await {
+    let is_rejected = match access_controller.load().check_access(&ctx).await {
         Ok(Decision::Allow) => {
             metrics.num_allowed_execute_tx_requests.inc();
             None
@@ -349,7 +349,7 @@ async fn execute_tx_impl(
         }
     };
 
-    if let Some((status_code, error)) = check_access_result {
+    if let Some((status_code, error)) = is_rejected {
         let confirmation_result = access_controller
             .load()
             .confirm_transaction(

--- a/src/test_env.rs
+++ b/src/test_env.rs
@@ -23,6 +23,7 @@ use iota_types::crypto::get_account_key_pair;
 use iota_types::gas_coin::NANOS_PER_IOTA;
 use iota_types::signature::GenericSignature;
 use iota_types::transaction::{TransactionData, TransactionDataAPI};
+use redis::{Commands, FromRedisValue};
 use serde_json::Value;
 use std::path::PathBuf;
 use std::str::FromStr;
@@ -231,4 +232,25 @@ impl StatsTrackerStorage for MockedStatsTrackerStorage {
 
 pub fn mocked_stats_tracker() -> StatsTracker {
     StatsTracker::new(Arc::new(MockedStatsTrackerStorage {}))
+}
+
+pub fn fetch_redis_val<T: FromRedisValue>(redis_key: &str) -> T {
+    let default_redis_url = match GasStationStorageConfig::default() {
+        GasStationStorageConfig::Redis { redis_url } => redis_url,
+    };
+    let redis_client = redis::Client::open(default_redis_url).unwrap();
+    let mut redis_connection = redis_client.get_connection().unwrap();
+    let value: T = redis_connection.get(redis_key).unwrap();
+    value
+}
+
+pub fn remove_redis_key<K: FromRedisValue>(redis_key: &str) {
+    let default_redis_url = match GasStationStorageConfig::default() {
+        GasStationStorageConfig::Redis { redis_url } => redis_url,
+    };
+    let redis_client = redis::Client::open(default_redis_url).unwrap();
+    let mut redis_connection = redis_client.get_connection().unwrap();
+    redis_connection
+        .del::<String, K>(redis_key.to_string())
+        .unwrap();
 }

--- a/src/tracker/stats_tracker_storage/redis/mod.rs
+++ b/src/tracker/stats_tracker_storage/redis/mod.rs
@@ -51,8 +51,7 @@ impl StatsTrackerStorage for RedisStatsTrackerStorage {
         aggr: &Aggregate,
         value: i64,
     ) -> Result<i64> {
-        let hash = generate_hash_from_key(key);
-        let key = format!("{}:{}:{}", aggr.name, aggr.aggr_type, hash);
+        let key = get_redis_aggr_key(&aggr.name, aggr.aggr_type, key);
 
         match aggr.aggr_type {
             AggregateType::Sum => {
@@ -69,6 +68,15 @@ impl StatsTrackerStorage for RedisStatsTrackerStorage {
             }
         }
     }
+}
+
+pub(crate) fn get_redis_aggr_key(
+    aggr_name: &str,
+    aggr_type: AggregateType,
+    key: &[(String, Value)],
+) -> String {
+    let hash = generate_hash_from_key(key);
+    format!("{}:{}:{}", aggr_name, aggr_type, hash)
 }
 
 // we should generate the canonical hash key from the given key
@@ -125,23 +133,14 @@ mod test {
         .into_iter()
         .collect::<Vec<_>>();
 
-        let result = storage
-            .update_aggr(&key_meta, &aggregate, 1)
-            .await
-            .unwrap();
+        let result = storage.update_aggr(&key_meta, &aggregate, 1).await.unwrap();
         assert_eq!(result, 1);
 
-        let result = storage
-            .update_aggr(&key_meta, &aggregate, 2)
-            .await
-            .unwrap();
+        let result = storage.update_aggr(&key_meta, &aggregate, 2).await.unwrap();
         assert_eq!(result, 3);
 
         time::sleep(window_size + Duration::from_secs(1)).await;
-        let result = storage
-            .update_aggr(&key_meta, &aggregate, 2)
-            .await
-            .unwrap();
+        let result = storage.update_aggr(&key_meta, &aggregate, 2).await.unwrap();
         assert_eq!(result, 2);
     }
 


### PR DESCRIPTION
## Summary
Adds HTTP headers support to the IOTA Gas Station access controller, enabling access control and gas usage tracking based on HTTP request headers.

## Key Features
- Access control based on HTTP header values
- Separate gas usage limits per header value (e.g., per account ID)
- Backward compatible - no breaking changes
- Proper serialization format: `"http-header::<header-name>"`



### Usage example in rego: 

```rego
# Rego expression
default allow_account = false
allow_account if {
    input.http_headers["x-account-id"][0] == "123"
}
```


### Usage example with gas-usage:


```yaml
    - sender-address: ["0xa2e17e20f97355af6491580ff5c11ecefcdcf76ea224d163e5cb92389adf2311"]
      gas-usage:
        value: <=6000000
        window: 1day
        count-by: http-header::x-account-id
      action: allow

``` 

closes #82 