### PR TITLE
fix gas register for over-sized gas coins 

### DIFF
--- a/docs/common-issues.md
+++ b/docs/common-issues.md
@@ -29,6 +29,44 @@ If you have a local instance or an instance with persistent storage, you can use
 redis-cli FLUSHALL
 ```
 
+## Warning: Oversized Coins
+
+**Problem:**
+
+After executing a transaction, the following warning appears:
+
+```log
+Oversized coins found during transaction execution. Initiating rescan to split these coins. If this occurs frequently, consider adjusting target_init_balance or the maximum transaction budget.
+```
+
+**Explanation:**
+
+The Gas Station uses a self-balancing algorithm to maintain optimal liquidity by keeping gas coins at a manageable size. When a transaction is executed, the unused portion of the gas coin is returned as change. If this change exceeds `200 × target_init_balance`, it is considered "oversized."
+
+The Gas Station automatically downsizes oversized coins by splitting them into smaller coins (approximately `target_init_balance` each) to maintain pool liquidity. This rescan and split process consumes additional computing resources and reduces performance. If this happens frequently, it indicates that your configuration needs adjustment.
+
+Under normal operating conditions with properly configured `target_init_balance`, the returned change should remain below the `200 × target_init_balance` threshold, allowing coins to be returned directly to the pool without requiring expensive splitting operations.
+
+**Solution:**
+
+To minimize oversized coin occurrences, ensure the difference between reserved gas and actual gas usage stays below `200 × target_init_balance`. You can optimize your configuration by:
+
+- **Reducing the gas reservation size** - Reserve amounts closer to actual usage
+- **Increasing `target_init_balance`** - Set it appropriate to your traffic patterns
+
+**Monitoring:**
+
+The Gas Station provides Prometheus metrics to help you tune your configuration:
+
+- `reserved_gas_real_gas_usage_delta` - A histogram tracking the difference between reserved gas and actual gas usage. You can perform statistical queries on this metric to understand your usage patterns. Ideally, this delta should never exceed `200 × target_init_balance`.
+
+- `oversized_gas_coins_count` - Tracks how frequently oversized gas coins occur. Lower is better.
+
+The acceptable frequency depends on your performance requirements and traffic volume. For example:
+
+- **Low volume:** 5% of transactions returning oversized gas might trigger a rescan once per day (likely acceptable)
+- **High volume:** 5% of transactions could trigger constant rescans (problematic and requires configuration adjustment)
+
 ## Access Denied by Access Controller
 
 **Problem:**

--- a/src/command.rs
+++ b/src/command.rs
@@ -3,7 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::config::GasStationConfig;
-use crate::gas_station::gas_station_core::{GasStationContainer, GasStationRescanConfig};
+use crate::gas_station::gas_station_core::GasStationContainer;
+use crate::gas_station::rescan_trigger::RescanGasObjectsTrigger;
 use crate::gas_station_initializer::GasStationInitializer;
 use crate::iota_client::IotaClient;
 use crate::metrics::{GasStationCoreMetrics, GasStationRpcMetrics, StorageMetrics};
@@ -71,7 +72,7 @@ impl Command {
         let storage = connect_storage(&gas_station_config, sponsor_address, storage_metrics).await;
         let iota_client = IotaClient::new(&fullnode_url, fullnode_basic_auth).await;
 
-        let mut rescan_config = GasStationRescanConfig::new(
+        let mut rescan_config = RescanGasObjectsTrigger::new(
             coin_init_config
                 .clone()
                 .unwrap_or_default()

--- a/src/command.rs
+++ b/src/command.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::config::GasStationConfig;
-use crate::gas_station::gas_station_core::GasStationContainer;
+use crate::gas_station::gas_station_core::{GasStationContainer, GasStationRescanConfig};
 use crate::gas_station_initializer::GasStationInitializer;
 use crate::iota_client::IotaClient;
 use crate::metrics::{GasStationCoreMetrics, GasStationRpcMetrics, StorageMetrics};
@@ -70,12 +70,21 @@ impl Command {
 
         let storage = connect_storage(&gas_station_config, sponsor_address, storage_metrics).await;
         let iota_client = IotaClient::new(&fullnode_url, fullnode_basic_auth).await;
+
+        let mut rescan_config = GasStationRescanConfig::new(
+            coin_init_config
+                .clone()
+                .unwrap_or_default()
+                .target_init_balance,
+        );
+        let rescan_trigger_receiver = rescan_config.create_receiver();
         let _coin_init_task = if let Some(coin_init_config) = coin_init_config {
             let task = GasStationInitializer::start(
                 iota_client.clone(),
                 storage.clone(),
                 coin_init_config,
                 signer.clone(),
+                rescan_trigger_receiver,
             )
             .await;
             Some(task)
@@ -91,6 +100,7 @@ impl Command {
             iota_client,
             daily_gas_usage_cap,
             core_metrics,
+            rescan_config,
         )
         .await;
         let rpc_metrics = GasStationRpcMetrics::new(&prometheus_registry);

--- a/src/config.rs
+++ b/src/config.rs
@@ -118,7 +118,7 @@ impl TxSignerConfig {
 }
 
 #[serde_as]
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 #[serde(rename_all = "kebab-case")]
 pub struct CoinInitConfig {
     /// When we split a new gas coin, what is the target balance for the new coins, in NANOs.

--- a/src/gas_station/gas_station_core.rs
+++ b/src/gas_station/gas_station_core.rs
@@ -20,8 +20,9 @@ use iota_types::transaction::{
 use std::sync::Arc;
 use std::time::Duration;
 use tap::TapFallible;
+use tokio::sync::mpsc::Receiver;
 use tokio::task::JoinHandle;
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, warn};
 
 use super::gas_usage_cap::GasUsageCap;
 
@@ -40,6 +41,7 @@ pub struct GasStation {
     iota_client: IotaClient,
     metrics: Arc<GasStationCoreMetrics>,
     gas_usage_cap: Arc<GasUsageCap>,
+    rescan_config: GasStationRescanConfig,
 }
 
 impl GasStation {
@@ -49,6 +51,7 @@ impl GasStation {
         iota_client: IotaClient,
         metrics: Arc<GasStationCoreMetrics>,
         gas_usage_cap: Arc<GasUsageCap>,
+        rescan_config: GasStationRescanConfig,
     ) -> Arc<Self> {
         let pool = Self {
             signer,
@@ -56,6 +59,7 @@ impl GasStation {
             iota_client,
             metrics,
             gas_usage_cap,
+            rescan_config,
         };
 
         Arc::new(pool)
@@ -77,7 +81,7 @@ impl GasStation {
         self.metrics.reserve_gas_latency_ms.observe(elapsed as u64);
         self.metrics
             .reserved_gas_coin_count_per_request
-            .observe(gas_coins.len() as u64);
+            .observe(gas_coins.len().try_into().unwrap_or(u64::MAX));
         Ok((
             sponsor,
             reservation_id,
@@ -161,10 +165,24 @@ impl GasStation {
             }
         };
         let smashed_coin_count = payment_count - updated_coins.len();
-        // Regardless of whether the transaction succeeded, we need to release the coins.
-        // Otherwise, we lose track of them. This is because `ready_for_execution` already takes
-        // the coins out of the pool and will not be covered by the auto-release mechanism.
-        self.release_gas_coins(updated_coins).await;
+        // before the we re-add the coins to the pool we check if the coins size go over 200*target_init_balance
+        let does_contain_big_coins = updated_coins
+            .iter()
+            .any(|coin| coin.balance > 200 * self.rescan_config.target_init_balance);
+        if does_contain_big_coins {
+            warn!("Big coins detected in transaction execution. Triggering rescan to split the coins. If this happens frequently, please adjust the target_init_balance or maximum budget per transaction");
+            self.rescan_config.trigger_rescan().await;
+        } else {
+            // Regardless of whether the transaction succeeded, we need to release the coins.
+            // Otherwise, we lose track of them. This is because `ready_for_execution` already takes
+            // the coins out of the pool and will not be covered by the auto-release mechanism.
+            info!(
+                ?reservation_id,
+                "Releasing {} coins back to the pool",
+                updated_coins.len()
+            );
+            self.release_gas_coins(updated_coins).await;
+        }
         if smashed_coin_count > 0 {
             info!(
                 ?reservation_id,
@@ -348,6 +366,7 @@ impl GasStationContainer {
         iota_client: IotaClient,
         gas_usage_daily_cap: u64,
         metrics: Arc<GasStationCoreMetrics>,
+        rescan_config: GasStationRescanConfig,
     ) -> Self {
         let inner = GasStation::new(
             signer,
@@ -355,6 +374,7 @@ impl GasStationContainer {
             iota_client,
             metrics,
             Arc::new(GasUsageCap::new(gas_usage_daily_cap)),
+            rescan_config,
         )
         .await;
         let (cancel_sender, cancel_receiver) = tokio::sync::oneshot::channel();
@@ -380,5 +400,49 @@ impl GasStationContainer {
 impl Drop for GasStationContainer {
     fn drop(&mut self) {
         self.cancel_sender.take().unwrap().send(()).unwrap();
+    }
+}
+
+#[derive(Clone)]
+pub struct GasStationRescanConfig {
+    pub target_init_balance: u64,
+    trigger_rescan_sender: Option<tokio::sync::mpsc::Sender<()>>,
+}
+
+impl GasStationRescanConfig {
+    pub fn new(target_init_balance: u64) -> Self {
+        Self {
+            target_init_balance,
+            trigger_rescan_sender: None,
+        }
+    }
+
+    pub fn with_trigger_rescan_sender(
+        mut self,
+        trigger_rescan_sender: tokio::sync::mpsc::Sender<()>,
+    ) -> Self {
+        self.trigger_rescan_sender = Some(trigger_rescan_sender);
+        self
+    }
+
+    pub fn create_receiver(&mut self) -> Receiver<()> {
+        // the buffer size is 5 to create a throttling mechanism.
+        // If new requests are received while the buffer is full, the requests will be dropped.
+        let (sender, receiver) = tokio::sync::mpsc::channel::<()>(5);
+        self.trigger_rescan_sender = Some(sender);
+        receiver
+    }
+
+    pub async fn trigger_rescan(&self) {
+        if let Some(trigger_rescan_sender) = self.trigger_rescan_sender.as_ref() {
+            match trigger_rescan_sender.try_send(()) {
+                Ok(()) => {}
+                Err(error) => {
+                    warn!("Failed to send rescan trigger: {:?}", error);
+                }
+            }
+        } else {
+            warn!("No trigger rescan sender found. Please set it up before triggering rescan");
+        }
     }
 }

--- a/src/gas_station/gas_station_core.rs
+++ b/src/gas_station/gas_station_core.rs
@@ -176,17 +176,20 @@ impl GasStation {
         let smashed_coin_count = payment_count - updated_coins.len();
         // Before returning the coins to the pool, verify if any coin exceeds
         // NEW_COIN_BALANCE_FACTOR_THRESHOLD times the target initial balance.
-        let contains_oversized_coins = updated_coins.iter().any(|coin| {
-            coin.balance
-                > NEW_COIN_BALANCE_FACTOR_THRESHOLD * self.rescan_config.target_init_balance
-        });
-        if contains_oversized_coins {
+        let oversized_coins_count = updated_coins
+            .iter()
+            .filter(|coin| {
+                coin.balance
+                    > NEW_COIN_BALANCE_FACTOR_THRESHOLD * self.rescan_config.target_init_balance
+            })
+            .count();
+        if oversized_coins_count > 0 {
             warn!("Oversized coins found during transaction execution. Initiating rescan to split these coins. If this occurs frequently, consider adjusting target_init_balance or the maximum transaction budget.");
             self.rescan_config.trigger_rescan().await;
             self.metrics
                 .oversized_gas_coins_count
                 .with_label_values(&[&sponsor.to_string()])
-                .inc_by(updated_coins.len() as u64);
+                .inc_by(oversized_coins_count as u64);
         } else {
             // Regardless of whether the transaction succeeded, we need to release the coins.
             // Otherwise, we lose track of them. This is because `ready_for_execution` already takes

--- a/src/gas_station/gas_station_core.rs
+++ b/src/gas_station/gas_station_core.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::gas_station::rescan_trigger::RescanGasObjectsTrigger;
+use crate::gas_station_initializer::NEW_COIN_BALANCE_FACTOR_THRESHOLD;
 use crate::iota_client::IotaClient;
 use crate::metrics::GasStationCoreMetrics;
 use crate::rpc::rpc_types::ExecuteTransactionRequestType;
@@ -17,10 +19,10 @@ use iota_types::signature::GenericSignature;
 use iota_types::transaction::{
     Argument, Command, Transaction, TransactionData, TransactionDataAPI, TransactionKind,
 };
+use std::cmp::min;
 use std::sync::Arc;
 use std::time::Duration;
 use tap::TapFallible;
-use tokio::sync::mpsc::Receiver;
 use tokio::task::JoinHandle;
 use tracing::{debug, error, info, warn};
 
@@ -41,7 +43,7 @@ pub struct GasStation {
     iota_client: IotaClient,
     metrics: Arc<GasStationCoreMetrics>,
     gas_usage_cap: Arc<GasUsageCap>,
-    rescan_config: GasStationRescanConfig,
+    rescan_config: RescanGasObjectsTrigger,
 }
 
 impl GasStation {
@@ -51,7 +53,7 @@ impl GasStation {
         iota_client: IotaClient,
         metrics: Arc<GasStationCoreMetrics>,
         gas_usage_cap: Arc<GasUsageCap>,
-        rescan_config: GasStationRescanConfig,
+        rescan_config: RescanGasObjectsTrigger,
     ) -> Arc<Self> {
         let pool = Self {
             signer,
@@ -146,6 +148,13 @@ impl GasStation {
                         new_balance as u64
                     );
                 }
+                self.metrics
+                    .gas_usage_per_transaction
+                    .observe(effects.gas_cost_summary().net_gas_usage() as u64);
+                self.metrics
+                    .reserved_gas_real_gas_usage_delta
+                    // If a refund occurs, ensure that the delta does not exceed the original total balance of the gas coins
+                    .observe(min(new_balance, total_gas_coin_balance as i64) as u64);
                 vec![GasCoin {
                     object_ref: new_gas_coin,
                     balance: new_balance as u64,
@@ -165,13 +174,19 @@ impl GasStation {
             }
         };
         let smashed_coin_count = payment_count - updated_coins.len();
-        // before the we re-add the coins to the pool we check if the coins size go over 200*target_init_balance
-        let does_contain_big_coins = updated_coins
-            .iter()
-            .any(|coin| coin.balance > 200 * self.rescan_config.target_init_balance);
-        if does_contain_big_coins {
-            warn!("Big coins detected in transaction execution. Triggering rescan to split the coins. If this happens frequently, please adjust the target_init_balance or maximum budget per transaction");
+        // Before returning the coins to the pool, verify if any coin exceeds
+        // NEW_COIN_BALANCE_FACTOR_THRESHOLD times the target initial balance.
+        let contains_oversized_coins = updated_coins.iter().any(|coin| {
+            coin.balance
+                > NEW_COIN_BALANCE_FACTOR_THRESHOLD * self.rescan_config.target_init_balance
+        });
+        if contains_oversized_coins {
+            warn!("Oversized coins found during transaction execution. Initiating rescan to split these coins. If this occurs frequently, consider adjusting target_init_balance or the maximum transaction budget.");
             self.rescan_config.trigger_rescan().await;
+            self.metrics
+                .oversized_gas_coins_count
+                .with_label_values(&[&sponsor.to_string()])
+                .inc_by(updated_coins.len() as u64);
         } else {
             // Regardless of whether the transaction succeeded, we need to release the coins.
             // Otherwise, we lose track of them. This is because `ready_for_execution` already takes
@@ -366,7 +381,7 @@ impl GasStationContainer {
         iota_client: IotaClient,
         gas_usage_daily_cap: u64,
         metrics: Arc<GasStationCoreMetrics>,
-        rescan_config: GasStationRescanConfig,
+        rescan_config: RescanGasObjectsTrigger,
     ) -> Self {
         let inner = GasStation::new(
             signer,
@@ -400,49 +415,5 @@ impl GasStationContainer {
 impl Drop for GasStationContainer {
     fn drop(&mut self) {
         self.cancel_sender.take().unwrap().send(()).unwrap();
-    }
-}
-
-#[derive(Clone)]
-pub struct GasStationRescanConfig {
-    pub target_init_balance: u64,
-    trigger_rescan_sender: Option<tokio::sync::mpsc::Sender<()>>,
-}
-
-impl GasStationRescanConfig {
-    pub fn new(target_init_balance: u64) -> Self {
-        Self {
-            target_init_balance,
-            trigger_rescan_sender: None,
-        }
-    }
-
-    pub fn with_trigger_rescan_sender(
-        mut self,
-        trigger_rescan_sender: tokio::sync::mpsc::Sender<()>,
-    ) -> Self {
-        self.trigger_rescan_sender = Some(trigger_rescan_sender);
-        self
-    }
-
-    pub fn create_receiver(&mut self) -> Receiver<()> {
-        // the buffer size is 5 to create a throttling mechanism.
-        // If new requests are received while the buffer is full, the requests will be dropped.
-        let (sender, receiver) = tokio::sync::mpsc::channel::<()>(5);
-        self.trigger_rescan_sender = Some(sender);
-        receiver
-    }
-
-    pub async fn trigger_rescan(&self) {
-        if let Some(trigger_rescan_sender) = self.trigger_rescan_sender.as_ref() {
-            match trigger_rescan_sender.try_send(()) {
-                Ok(()) => {}
-                Err(error) => {
-                    warn!("Failed to send rescan trigger: {:?}", error);
-                }
-            }
-        } else {
-            warn!("No trigger rescan sender found. Please set it up before triggering rescan");
-        }
     }
 }

--- a/src/gas_station/mod.rs
+++ b/src/gas_station/mod.rs
@@ -3,6 +3,7 @@
 
 pub mod gas_station_core;
 mod gas_usage_cap;
+pub(crate) mod rescan_trigger;
 
 #[cfg(test)]
 mod tests {

--- a/src/gas_station/rescan_trigger.rs
+++ b/src/gas_station/rescan_trigger.rs
@@ -1,0 +1,60 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use tokio::sync::mpsc::{error::TrySendError, Receiver, Sender};
+use tracing::{error, warn};
+
+/// The buffer size for the rescan trigger channel.
+/// It is set to 5 to limit how frequently rescans can be triggered.
+/// Additional rescan requests beyond this limit will be discarded if the buffer is full.
+const RESCAN_TRIGGER_CHANNEL_BUFFER_SIZE: usize = 5;
+
+#[derive(Clone)]
+pub struct RescanGasObjectsTrigger {
+    pub target_init_balance: u64,
+    trigger_rescan_sender: Option<Sender<()>>,
+}
+
+impl RescanGasObjectsTrigger {
+    /// Create a new RescanGasObjectsTrigger with the given target initial balance.
+    /// Please make sure the channel is set before triggering rescan by calling
+    /// [`with_trigger_rescan_sender`](Self::with_trigger_rescan_sender) or [`create_receiver`](Self::create_receiver).
+    pub fn new(target_init_balance: u64) -> Self {
+        Self {
+            target_init_balance,
+            trigger_rescan_sender: None,
+        }
+    }
+
+    pub fn with_trigger_rescan_sender(mut self, trigger_rescan_sender: Sender<()>) -> Self {
+        self.trigger_rescan_sender = Some(trigger_rescan_sender);
+        self
+    }
+
+    /// Create a new receiver for the rescan trigger.
+    pub fn create_receiver(&mut self) -> Receiver<()> {
+        let (sender, receiver) =
+            tokio::sync::mpsc::channel::<()>(RESCAN_TRIGGER_CHANNEL_BUFFER_SIZE);
+        self.trigger_rescan_sender = Some(sender);
+        receiver
+    }
+
+    /// Trigger a rescan for new coins.
+    /// This method will send a message to the rescan trigger channel.
+    /// If the channel is full, the request will be dropped.
+    pub async fn trigger_rescan(&self) {
+        if let Some(trigger_rescan_sender) = self.trigger_rescan_sender.as_ref() {
+            match trigger_rescan_sender.try_send(()) {
+                Ok(()) => {}
+                Err(TrySendError::Full(_)) => {
+                    warn!("Failed to send rescan trigger. Too many requests are pending. Dropping the request.");
+                }
+                Err(TrySendError::Closed(_)) => {
+                    error!("Failed to send rescan trigger. The channel has been closed. Please restart the Gas Station.");
+                }
+            }
+        } else {
+            warn!("No trigger rescan sender found. Please set it up before triggering rescan");
+        }
+    }
+}

--- a/src/gas_station_initializer.rs
+++ b/src/gas_station_initializer.rs
@@ -164,18 +164,16 @@ enum RunMode {
 }
 
 enum WakeReason {
-    RescanTrigger,
-    CoinInit,
+    ForcedTrigger,
+    Scheduled,
     Cancel,
 }
 
 impl WakeReason {
     fn reason(&self) -> &str {
         match self {
-            WakeReason::RescanTrigger => "Rescan trigger received. Rescanning for new coins",
-            WakeReason::CoinInit => {
-                "Coin init task waking up and looking for new coins to initialize"
-            }
+            WakeReason::ForcedTrigger => "Forced trigger received. Rescanning for new coins",
+            WakeReason::Scheduled => "Scheduled trigger received. Rescanning for new coins",
             WakeReason::Cancel => "Coin init task is cancelled",
         }
     }
@@ -242,10 +240,10 @@ impl GasStationInitializer {
         loop {
             let wake_reason = tokio::select! {
                 Some(_) = rescan_trigger_receiver.recv() => {
-                    WakeReason::RescanTrigger
+                    WakeReason::ForcedTrigger
                 }
                 _ = ticker.tick() => {
-                    WakeReason::CoinInit
+                    WakeReason::Scheduled
                 }
                 _ = &mut cancel_receiver => {
                     WakeReason::Cancel
@@ -253,7 +251,7 @@ impl GasStationInitializer {
             };
 
             match wake_reason {
-                WakeReason::RescanTrigger | WakeReason::CoinInit => {
+                WakeReason::ForcedTrigger | WakeReason::Scheduled => {
                     info!("{}", wake_reason.reason());
                     Self::run_once(
                         iota_client.clone(),

--- a/src/gas_station_initializer.rs
+++ b/src/gas_station_initializer.rs
@@ -22,12 +22,12 @@ use std::sync::Arc;
 use std::time::Duration;
 use tap::TapFallible;
 use tokio::task::JoinHandle;
-use tokio::time::Instant;
+use tokio::time::{Instant, MissedTickBehavior};
 use tracing::{debug, error, info};
 
 /// Any coin owned by the sponsor address with balance above target_init_coin_balance * NEW_COIN_BALANCE_FACTOR_THRESHOLD
 /// is considered a new coin, and we will try to split it into smaller coins with balance close to target_init_coin_balance.
-const NEW_COIN_BALANCE_FACTOR_THRESHOLD: u64 = 200;
+pub const NEW_COIN_BALANCE_FACTOR_THRESHOLD: u64 = 200;
 
 /// Assume that initializing the Gas Station (i.e. splitting coins) will take at most 12 hours.
 const MAX_INIT_DURATION_SEC: u64 = 60 * 60 * 12;
@@ -219,22 +219,24 @@ impl GasStationInitializer {
     ) {
         let mut ticker =
             tokio::time::interval(Duration::from_secs(coin_init_config.refresh_interval_sec));
+        ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
 
         loop {
-            tokio::select! {
-                 Some(_) = rescan_trigger_receiver.recv() => {
-                    info!("Rescan trigger received. Rescaning for new coins");
-                    Self::run_once(
-                        iota_client.clone(),
-                        &storage,
-                        RunMode::Refresh,
-                        coin_init_config.target_init_balance,
-                        &signer,
-                    )
-                    .await;
-                 }
+            let wake_reason = tokio::select! {
+                Some(_) = rescan_trigger_receiver.recv() => {
+                    Some("Rescan trigger received. Rescanning for new coins")
+                }
                 _ = ticker.tick() => {
-                    info!("Coin init task waking up and looking for new coins to initialize");
+                    Some("Coin init task waking up and looking for new coins to initialize")
+                }
+                _ = &mut cancel_receiver => {
+                    None
+                }
+            };
+
+            match wake_reason {
+                Some(reason) => {
+                    info!("{}", reason);
                     Self::run_once(
                         iota_client.clone(),
                         &storage,
@@ -244,7 +246,7 @@ impl GasStationInitializer {
                     )
                     .await;
                 }
-                _ = &mut cancel_receiver => {
+                None => {
                     info!("Coin init task is cancelled");
                     break;
                 }

--- a/src/gas_station_initializer.rs
+++ b/src/gas_station_initializer.rs
@@ -181,6 +181,7 @@ impl GasStationInitializer {
         storage: Arc<dyn Storage>,
         coin_init_config: CoinInitConfig,
         signer: Arc<dyn TxSigner>,
+        rescan_trigger_receiver: tokio::sync::mpsc::Receiver<()>,
     ) -> Self {
         if !storage.is_initialized().await.unwrap() {
             // If the pool has never been initialized, always run once at the beginning to make sure we have enough coins.
@@ -200,6 +201,7 @@ impl GasStationInitializer {
             coin_init_config,
             signer,
             cancel_receiver,
+            rescan_trigger_receiver,
         ));
         Self {
             _task_handle,
@@ -213,24 +215,40 @@ impl GasStationInitializer {
         coin_init_config: CoinInitConfig,
         signer: Arc<dyn TxSigner>,
         mut cancel_receiver: tokio::sync::oneshot::Receiver<()>,
+        mut rescan_trigger_receiver: tokio::sync::mpsc::Receiver<()>,
     ) {
+        let mut ticker =
+            tokio::time::interval(Duration::from_secs(coin_init_config.refresh_interval_sec));
+
         loop {
             tokio::select! {
-                _ = tokio::time::sleep(Duration::from_secs(coin_init_config.refresh_interval_sec)) => {}
+                 Some(_) = rescan_trigger_receiver.recv() => {
+                    info!("Rescan trigger received. Rescaning for new coins");
+                    Self::run_once(
+                        iota_client.clone(),
+                        &storage,
+                        RunMode::Refresh,
+                        coin_init_config.target_init_balance,
+                        &signer,
+                    )
+                    .await;
+                 }
+                _ = ticker.tick() => {
+                    info!("Coin init task waking up and looking for new coins to initialize");
+                    Self::run_once(
+                        iota_client.clone(),
+                        &storage,
+                        RunMode::Refresh,
+                        coin_init_config.target_init_balance,
+                        &signer,
+                    )
+                    .await;
+                }
                 _ = &mut cancel_receiver => {
                     info!("Coin init task is cancelled");
                     break;
                 }
             }
-            info!("Coin init task waking up and looking for new coins to initialize");
-            Self::run_once(
-                iota_client.clone(),
-                &storage,
-                RunMode::Refresh,
-                coin_init_config.target_init_balance,
-                &signer,
-            )
-            .await;
         }
     }
 
@@ -340,6 +358,7 @@ mod tests {
     use crate::storage::connect_storage_for_testing;
     use crate::test_env::start_iota_cluster;
     use iota_types::gas_coin::NANOS_PER_IOTA;
+    use tokio::sync::mpsc::channel;
 
     // TODO: Add more accurate tests.
 
@@ -350,7 +369,8 @@ mod tests {
         let fullnode_url = cluster.fullnode_handle.rpc_url;
         let storage = connect_storage_for_testing(signer.get_address()).await;
         let iota_client = IotaClient::new(&fullnode_url, None).await;
-        let _ = GasStationInitializer::start(
+        let (_rescan_trigger_sender, rescan_trigger_receiver) = channel::<()>(1024);
+        let _init_task = GasStationInitializer::start(
             iota_client,
             storage.clone(),
             CoinInitConfig {
@@ -358,6 +378,7 @@ mod tests {
                 refresh_interval_sec: 200,
             },
             signer,
+            rescan_trigger_receiver,
         )
         .await;
         assert!(storage.get_available_coin_count().await.unwrap() > 900);
@@ -371,7 +392,8 @@ mod tests {
         let storage = connect_storage_for_testing(signer.get_address()).await;
         let target_init_balance = 12345 * NANOS_PER_IOTA;
         let iota_client = IotaClient::new(&fullnode_url, None).await;
-        let _ = GasStationInitializer::start(
+        let (_rescan_trigger_sender, rescan_trigger_receiver) = channel::<()>(1024);
+        let _init_task = GasStationInitializer::start(
             iota_client,
             storage.clone(),
             CoinInitConfig {
@@ -379,6 +401,7 @@ mod tests {
                 refresh_interval_sec: 200,
             },
             signer,
+            rescan_trigger_receiver,
         )
         .await;
         assert!(storage.get_available_coin_count().await.unwrap() > 800);
@@ -392,6 +415,7 @@ mod tests {
         let fullnode_url = cluster.fullnode_handle.rpc_url.clone();
         let storage = connect_storage_for_testing(signer.get_address()).await;
         let iota_client = IotaClient::new(&fullnode_url, None).await;
+        let (_rescan_trigger_sender, rescan_trigger_receiver) = channel::<()>(1024);
         let _init_task = GasStationInitializer::start(
             iota_client,
             storage.clone(),
@@ -400,6 +424,7 @@ mod tests {
                 refresh_interval_sec: 1,
             },
             signer,
+            rescan_trigger_receiver,
         )
         .await;
         assert!(storage.is_initialized().await.unwrap());

--- a/src/gas_station_initializer.rs
+++ b/src/gas_station_initializer.rs
@@ -163,6 +163,24 @@ enum RunMode {
     Refresh,
 }
 
+enum WakeReason {
+    RescanTrigger,
+    CoinInit,
+    Cancel,
+}
+
+impl WakeReason {
+    fn reason(&self) -> &str {
+        match self {
+            WakeReason::RescanTrigger => "Rescan trigger received. Rescanning for new coins",
+            WakeReason::CoinInit => {
+                "Coin init task waking up and looking for new coins to initialize"
+            }
+            WakeReason::Cancel => "Coin init task is cancelled",
+        }
+    }
+}
+
 pub struct GasStationInitializer {
     _task_handle: JoinHandle<()>,
     // This is always Some. It is None only after the drop method is called.
@@ -224,19 +242,19 @@ impl GasStationInitializer {
         loop {
             let wake_reason = tokio::select! {
                 Some(_) = rescan_trigger_receiver.recv() => {
-                    Some("Rescan trigger received. Rescanning for new coins")
+                    WakeReason::RescanTrigger
                 }
                 _ = ticker.tick() => {
-                    Some("Coin init task waking up and looking for new coins to initialize")
+                    WakeReason::CoinInit
                 }
                 _ = &mut cancel_receiver => {
-                    None
+                    WakeReason::Cancel
                 }
             };
 
             match wake_reason {
-                Some(reason) => {
-                    info!("{}", reason);
+                WakeReason::RescanTrigger | WakeReason::CoinInit => {
+                    info!("{}", wake_reason.reason());
                     Self::run_once(
                         iota_client.clone(),
                         &storage,
@@ -246,8 +264,8 @@ impl GasStationInitializer {
                     )
                     .await;
                 }
-                None => {
-                    info!("Coin init task is cancelled");
+                WakeReason::Cancel => {
+                    info!("{}", wake_reason.reason());
                     break;
                 }
             }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -122,6 +122,9 @@ pub struct GasStationCoreMetrics {
     pub transaction_execution_latency_ms: Histogram,
     pub num_gas_station_invariant_violations: IntCounter,
     pub daily_gas_usage: IntGaugeVec,
+    pub oversized_gas_coins_count: IntCounterVec,
+    pub gas_usage_per_transaction: Histogram,
+    pub reserved_gas_real_gas_usage_delta: Histogram,
 }
 
 impl GasStationCoreMetrics {
@@ -174,6 +177,23 @@ impl GasStationCoreMetrics {
                 registry,
             )
                 .unwrap(),
+            oversized_gas_coins_count: register_int_counter_vec_with_registry!(
+                "oversized_gas_coins_count",
+                "Total number of oversized gas coins",
+                &["sponsor"],
+                registry,
+            )
+                .unwrap(),
+            gas_usage_per_transaction: Histogram::new_in_registry(
+                "gas_usage_per_transaction",
+                "Gas usage per transaction",
+                registry,
+            ),
+            reserved_gas_real_gas_usage_delta: Histogram::new_in_registry(
+                "reserved_gas_real_gas_usage_delta",
+                "Reserved gas vs real gas usage delta",
+                registry,
+            ),
         })
     }
 

--- a/src/test_env.rs
+++ b/src/test_env.rs
@@ -3,7 +3,8 @@
 
 use crate::access_controller::AccessController;
 use crate::config::{CoinInitConfig, GasStationStorageConfig, DEFAULT_DAILY_GAS_USAGE_CAP};
-use crate::gas_station::gas_station_core::{GasStationContainer, GasStationRescanConfig};
+use crate::gas_station::gas_station_core::GasStationContainer;
+use crate::gas_station::rescan_trigger::RescanGasObjectsTrigger;
 use crate::gas_station_initializer::GasStationInitializer;
 use crate::iota_client::IotaClient;
 use crate::metrics::{GasStationCoreMetrics, GasStationRpcMetrics};
@@ -29,7 +30,6 @@ use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::Arc;
 use test_cluster::{TestCluster, TestClusterBuilder};
-use tokio::sync::mpsc::channel;
 use tracing::debug;
 
 pub const DEFAULT_TEST_CONFIG_PATH: &str = "./test-env-config.yaml";
@@ -64,7 +64,7 @@ pub async fn start_gas_station(
     debug!("Starting storage. Sponsor address: {:?}", sponsor_address);
     let storage = connect_storage_for_testing(sponsor_address).await;
     let iota_client = IotaClient::new(&fullnode_url, None).await;
-    let mut rescan_config = GasStationRescanConfig::new(target_init_coin_balance);
+    let mut rescan_config = RescanGasObjectsTrigger::new(target_init_coin_balance);
     let rescan_trigger_receiver = rescan_config.create_receiver();
     GasStationInitializer::start(
         iota_client.clone(),

--- a/src/test_env.rs
+++ b/src/test_env.rs
@@ -3,7 +3,7 @@
 
 use crate::access_controller::AccessController;
 use crate::config::{CoinInitConfig, GasStationStorageConfig, DEFAULT_DAILY_GAS_USAGE_CAP};
-use crate::gas_station::gas_station_core::GasStationContainer;
+use crate::gas_station::gas_station_core::{GasStationContainer, GasStationRescanConfig};
 use crate::gas_station_initializer::GasStationInitializer;
 use crate::iota_client::IotaClient;
 use crate::metrics::{GasStationCoreMetrics, GasStationRpcMetrics};
@@ -29,6 +29,7 @@ use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::Arc;
 use test_cluster::{TestCluster, TestClusterBuilder};
+use tokio::sync::mpsc::channel;
 use tracing::debug;
 
 pub const DEFAULT_TEST_CONFIG_PATH: &str = "./test-env-config.yaml";
@@ -63,6 +64,8 @@ pub async fn start_gas_station(
     debug!("Starting storage. Sponsor address: {:?}", sponsor_address);
     let storage = connect_storage_for_testing(sponsor_address).await;
     let iota_client = IotaClient::new(&fullnode_url, None).await;
+    let mut rescan_config = GasStationRescanConfig::new(target_init_coin_balance);
+    let rescan_trigger_receiver = rescan_config.create_receiver();
     GasStationInitializer::start(
         iota_client.clone(),
         storage.clone(),
@@ -71,6 +74,7 @@ pub async fn start_gas_station(
             ..Default::default()
         },
         signer.clone(),
+        rescan_trigger_receiver,
     )
     .await;
     let station = GasStationContainer::new(
@@ -79,6 +83,7 @@ pub async fn start_gas_station(
         iota_client,
         DEFAULT_DAILY_GAS_USAGE_CAP,
         GasStationCoreMetrics::new_for_testing(),
+        rescan_config,
     )
     .await;
     (test_cluster, station)


### PR DESCRIPTION
The PR implements an automatic detection and splitting mechanism with four key components:

1. **Oversized Coin Detection**: Checks if returned coins exceed `200 × target_init_balance`

2. **Automatic Rescan Trigger**: New `RescanGasObjectsTrigger` component that:
   - Triggers rescan when oversized coins are detected
   - Uses buffered channel to handle concurrent requests
   - Prevents oversized coins from polluting the pool

3. **Enhanced Metrics**: Three new Prometheus metrics:
   - `reserved_gas_real_gas_usage_delta` - tracks gas over-reservation
   - `gas_usage_per_transaction` - tracks actual consumption
   - `oversized_gas_coins_count` - counts oversized occurrences

4. **Documentation**: Comprehensive troubleshooting guide in `docs/common-issues.md`

closes #143 
