### PR TITLE
fix: add redis flush requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,9 +97,9 @@ metrics-port: 9184
 storage-config:
   redis:
     redis-url: "redis://127.0.0.1"
-fullnode-url: "https://api.testnet.iota.cafe"
+fullnode-url: "https://api.testnet.iota.cafe" # requires redis to be cleared
 coin-init-config:
-  target-init-balance: 100000000
+  target-init-balance: 100000000 # requires redis to be cleared
   refresh-interval-sec: 86400
 daily-gas-usage-cap: 1500000000000
 access-controller:
@@ -107,19 +107,22 @@ access-controller:
 ```
 
 ### Configuration parameters
-`
-| Parameter                               | Description                                                               | Example                                                                                         |
-| --------------------------------------- | ------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
-| `signer-config`                         | Configuration of signer. It can be a local or an external KMS.            | See [down below](#signer-configuration)                                                         |
-| `rpc-host-ip`                           | IP address for the RPC server                                             | `0.0.0.0`                                                                                       |
-| `rpc-port`                              | Port for the RPC server                                                   | `9527`                                                                                          |
-| `metrics-port`                          | Port for collecting and exposing metrics                                  | `9184`                                                                                          |
-| `storage-config.redis.redis-url`        | Redis connection URL                                                      | `redis://127.0.0.1`                                                                             |
-| `fullnode-url`                          | URL of the IOTA full node                                                 | `https://api.testnet.iota.cafe`                                                                 |
-| `coin-init-config.target-init-balance`  | Target balance for the new coins when we splitting new gas coins in NANOs | `100000000`                                                                                     |
-| `coin-init-config.refresh-interval-sec` | Interval in seconds to refresh balance and check for new coins to split   | `86400`                                                                                         |
-| `daily-gas-usage-cap`                   | Maximum allowed daily gas usage                                           | `1500000000000`                                                                                 |
-| `access-controller.access-policy`       | Access policy mode.                                                       | `disabled`, `allow-all`, `deny-all`. See [this link](./docs/access-controller.md) to learn more |
+
+| Parameter                               | Db rebuild required?| Description                                                               | Example                                                                                         |
+| --------------------------------------- |---------------------|---------------------------------------------------------------------------| ----------------------------------------------------------------------------------------------- |
+| `signer-config`                         | no                  | Configuration of signer. It can be a local or an external KMS.            | See [down below](#signer-configuration)                                                         |
+| `rpc-host-ip`                           | no                  | IP address for the RPC server                                             | `0.0.0.0`                                                                                       |
+| `rpc-port`                              | no                  | Port for the RPC server                                                   | `9527`                                                                                          |
+| `metrics-port`                          | no                  | Port for collecting and exposing metrics                                  | `9184`                                                                                          |
+| `storage-config.redis.redis-url`        | no                  | Redis connection URL                                                      | `redis://127.0.0.1`                                                                             |
+| `fullnode-url`                          | yes ⚠               | URL of the IOTA full node                                                 | `https://api.testnet.iota.cafe`                                                                 |
+| `coin-init-config.target-init-balance`  | yes ⚠               | Target balance for the new coins when we splitting new gas coins in NANOs | `100000000`                                                                                     |
+| `coin-init-config.refresh-interval-sec` | no                  | Interval in seconds to refresh balance and check for new coins to split   | `86400`                                                                                         |
+| `daily-gas-usage-cap`                   | no                  | Maximum allowed daily gas usage                                           | `1500000000000`                                                                                 |
+| `access-controller.access-policy`       | no                  | Access policy mode.                                                       | `disabled`, `allow-all`, `deny-all`. See [this link](./docs/access-controller.md) to learn more |
+
+> [!WARNING]
+> **Important:** Some configuration parameters require the Redis database to be cleared (flushed) before changes can take effect safely. Modifying these settings without resetting the database may result in inconsistencies or corruption of the gas coin registry. **Always flush the Redis database prior to changing such parameters and restart the service to avoid issues.**
 
 #### Signer Configuration
 

--- a/src/bin/tool.rs
+++ b/src/bin/tool.rs
@@ -1,9 +1,8 @@
 // Copyright (c) Mysten Labs, Inc.
-// Modifications Copyright (c) 2024 IOTA Stiftung
+// Modifications Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
 use clap::*;
-use iota_config::Config;
 use iota_gas_station::benchmarks::kms_stress::run_kms_stress_test;
 use iota_gas_station::benchmarks::BenchmarkMode;
 use iota_gas_station::config::{GasStationConfig, GasStationStorageConfig, TxSignerConfig};
@@ -161,13 +160,22 @@ impl ToolCommand {
                     eprintln!("Config file already exists. Use --force (-f) to overwrite.");
                     std::process::exit(1);
                 }
+                let config_string =
+                    serde_yaml::to_string(&config).expect("Failed to convert config to YAML");
+
+                let options_required_flush = ["target-init-balance:", "fullnode-url:"];
+                let new_config_string =
+                    add_redis_flush_warning(config_string.lines(), &options_required_flush)
+                        .join("\n");
+
+                std::fs::write(config_path, new_config_string).unwrap();
+
                 if let Some(iota_address) = new_iota_address {
                     println!(
                         "Generated a new IOTA address. If you plan to use it, please make sure it has enough funds: '{}'",
                         iota_address
                     );
                 }
-                config.save(config_path).unwrap();
             }
             ToolCommand::CLI { cli_command } => match cli_command {
                 CliCommand::CheckStationHealth { station_rpc_url } => {
@@ -199,6 +207,25 @@ impl ToolCommand {
             }
         }
     }
+}
+
+fn add_redis_flush_warning<'a>(
+    config_lines: impl Iterator<Item = &'a str>,
+    options: &[&str],
+) -> Vec<String> {
+    let mut new_config_lines = Vec::new();
+    for line in config_lines {
+        if options.iter().any(|option| line.contains(option)) {
+            let spaces = line.chars().take_while(|c| c.is_whitespace()).count();
+            let new_line = format!(
+                "{}# If you change this, you need to flush the Redis database",
+                " ".repeat(spaces)
+            );
+            new_config_lines.push(new_line);
+        }
+        new_config_lines.push(line.to_string());
+    }
+    new_config_lines
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum, Default)]


### PR DESCRIPTION
### Summary
- document that `fullnode-url` and `coin-init-config.target-init-balance` changes require flushing Redis before restarting the gas station
- add CLI safeguard that comments the generated config with Redis flush warnings beside those options
- refresh copyright notice year

### Testing
- manual: generated config includes Redis flush comment


part of #144 