### PR TITLE
chore: bump up iota protocol to 1.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1080,8 +1080,8 @@ dependencies = [
 
 [[package]]
 name = "bin-version"
-version = "1.9.2"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#ac83d2f8fd55eb384fdb6845d1fc1cfe824d6f9d"
+version = "1.10.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.10.0#40ac2b68694ce1bc1889d484d207981a380bcd2b"
 dependencies = [
  "const-str",
  "git-version",
@@ -1262,6 +1262,19 @@ checksum = "e90f7deecfac93095eb874a40febd69427776e24e1bd7f87f33ac62d6f0174df"
 dependencies = [
  "arrayref",
  "arrayvec",
+ "constant_time_eq 0.3.1",
+]
+
+[[package]]
+name = "blake3"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3888aaa89e4b2a40fca9848e400f6a658a5a3978de7be858e209cafa8be9a4a0"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
  "constant_time_eq 0.3.1",
 ]
 
@@ -1766,7 +1779,7 @@ dependencies = [
 [[package]]
 name = "consensus-config"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#ac83d2f8fd55eb384fdb6845d1fc1cfe824d6f9d"
+source = "git+https://github.com/iotaledger/iota?tag=v1.10.0#40ac2b68694ce1bc1889d484d207981a380bcd2b"
 dependencies = [
  "fastcrypto",
  "iota-network-stack",
@@ -1778,7 +1791,7 @@ dependencies = [
 [[package]]
 name = "consensus-core"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#ac83d2f8fd55eb384fdb6845d1fc1cfe824d6f9d"
+source = "git+https://github.com/iotaledger/iota?tag=v1.10.0#40ac2b68694ce1bc1889d484d207981a380bcd2b"
 dependencies = [
  "async-trait",
  "base64 0.21.7",
@@ -2657,7 +2670,7 @@ dependencies = [
 [[package]]
 name = "enum-compat-util"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#ac83d2f8fd55eb384fdb6845d1fc1cfe824d6f9d"
+source = "git+https://github.com/iotaledger/iota?tag=v1.10.0#40ac2b68694ce1bc1889d484d207981a380bcd2b"
 dependencies = [
  "serde_yaml 0.8.26",
 ]
@@ -3057,9 +3070,9 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
@@ -3961,9 +3974,9 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
-version = "1.0.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
 dependencies = [
  "idna_adapter",
  "smallvec",
@@ -4146,7 +4159,7 @@ dependencies = [
 [[package]]
 name = "iota-adapter-latest"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#ac83d2f8fd55eb384fdb6845d1fc1cfe824d6f9d"
+source = "git+https://github.com/iotaledger/iota?tag=v1.10.0#40ac2b68694ce1bc1889d484d207981a380bcd2b"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4173,8 +4186,8 @@ dependencies = [
 
 [[package]]
 name = "iota-archival"
-version = "1.9.2"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#ac83d2f8fd55eb384fdb6845d1fc1cfe824d6f9d"
+version = "1.10.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.10.0#40ac2b68694ce1bc1889d484d207981a380bcd2b"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -4198,8 +4211,8 @@ dependencies = [
 
 [[package]]
 name = "iota-authority-aggregation"
-version = "1.9.2"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#ac83d2f8fd55eb384fdb6845d1fc1cfe824d6f9d"
+version = "1.10.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.10.0#40ac2b68694ce1bc1889d484d207981a380bcd2b"
 dependencies = [
  "futures",
  "iota-metrics",
@@ -4210,8 +4223,8 @@ dependencies = [
 
 [[package]]
 name = "iota-common"
-version = "1.9.2"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#ac83d2f8fd55eb384fdb6845d1fc1cfe824d6f9d"
+version = "1.10.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.10.0#40ac2b68694ce1bc1889d484d207981a380bcd2b"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -4229,8 +4242,8 @@ dependencies = [
 
 [[package]]
 name = "iota-config"
-version = "1.9.2"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#ac83d2f8fd55eb384fdb6845d1fc1cfe824d6f9d"
+version = "1.10.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.10.0#40ac2b68694ce1bc1889d484d207981a380bcd2b"
 dependencies = [
  "anemo",
  "anyhow",
@@ -4253,13 +4266,14 @@ dependencies = [
  "reqwest 0.12.14",
  "serde",
  "serde_yaml 0.8.26",
+ "starfish-config",
  "tracing",
 ]
 
 [[package]]
 name = "iota-core"
-version = "1.9.2"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#ac83d2f8fd55eb384fdb6845d1fc1cfe824d6f9d"
+version = "1.10.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.10.0#40ac2b68694ce1bc1889d484d207981a380bcd2b"
 dependencies = [
  "anemo",
  "anyhow",
@@ -4290,8 +4304,6 @@ dependencies = [
  "iota-execution",
  "iota-framework",
  "iota-genesis-builder",
- "iota-grpc-api",
- "iota-grpc-types",
  "iota-json-rpc-types",
  "iota-macros",
  "iota-metrics",
@@ -4380,8 +4392,8 @@ dependencies = [
 
 [[package]]
 name = "iota-enum-compat-util"
-version = "1.9.2"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#ac83d2f8fd55eb384fdb6845d1fc1cfe824d6f9d"
+version = "1.10.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.10.0#40ac2b68694ce1bc1889d484d207981a380bcd2b"
 dependencies = [
  "serde_yaml 0.8.26",
 ]
@@ -4389,7 +4401,7 @@ dependencies = [
 [[package]]
 name = "iota-execution"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#ac83d2f8fd55eb384fdb6845d1fc1cfe824d6f9d"
+source = "git+https://github.com/iotaledger/iota?tag=v1.10.0#40ac2b68694ce1bc1889d484d207981a380bcd2b"
 dependencies = [
  "iota-adapter-latest",
  "iota-move-natives-latest",
@@ -4406,8 +4418,8 @@ dependencies = [
 
 [[package]]
 name = "iota-framework"
-version = "1.9.2"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#ac83d2f8fd55eb384fdb6845d1fc1cfe824d6f9d"
+version = "1.10.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.10.0#40ac2b68694ce1bc1889d484d207981a380bcd2b"
 dependencies = [
  "bcs",
  "iota-types",
@@ -4419,8 +4431,8 @@ dependencies = [
 
 [[package]]
 name = "iota-framework-snapshot"
-version = "1.9.2"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#ac83d2f8fd55eb384fdb6845d1fc1cfe824d6f9d"
+version = "1.10.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.10.0#40ac2b68694ce1bc1889d484d207981a380bcd2b"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4455,7 +4467,7 @@ dependencies = [
  "iota-config",
  "iota-json-rpc-types",
  "iota-metrics",
- "iota-sdk 1.9.2",
+ "iota-sdk 1.10.0",
  "iota-swarm-config",
  "iota-types",
  "itertools 0.14.0",
@@ -4488,8 +4500,8 @@ dependencies = [
 
 [[package]]
 name = "iota-genesis-builder"
-version = "1.9.2"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#ac83d2f8fd55eb384fdb6845d1fc1cfe824d6f9d"
+version = "1.10.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.10.0#40ac2b68694ce1bc1889d484d207981a380bcd2b"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4538,8 +4550,8 @@ dependencies = [
 
 [[package]]
 name = "iota-genesis-common"
-version = "1.9.2"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#ac83d2f8fd55eb384fdb6845d1fc1cfe824d6f9d"
+version = "1.10.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.10.0#40ac2b68694ce1bc1889d484d207981a380bcd2b"
 dependencies = [
  "iota-execution",
  "iota-protocol-config",
@@ -4548,43 +4560,45 @@ dependencies = [
 ]
 
 [[package]]
-name = "iota-grpc-api"
-version = "1.9.2"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#ac83d2f8fd55eb384fdb6845d1fc1cfe824d6f9d"
+name = "iota-grpc-server"
+version = "1.10.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.10.0#40ac2b68694ce1bc1889d484d207981a380bcd2b"
 dependencies = [
  "anyhow",
  "async-stream",
- "bcs",
  "futures",
  "iota-config",
+ "iota-core",
  "iota-grpc-types",
  "iota-json-rpc-types",
  "iota-types",
  "move-core-types",
- "prost",
  "serde",
- "serde_json",
  "tokio",
  "tokio-stream",
  "tokio-util 0.7.14",
  "tonic 0.13.1",
- "tonic-build",
  "tracing",
 ]
 
 [[package]]
 name = "iota-grpc-types"
-version = "1.9.2"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#ac83d2f8fd55eb384fdb6845d1fc1cfe824d6f9d"
+version = "1.10.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.10.0#40ac2b68694ce1bc1889d484d207981a380bcd2b"
 dependencies = [
+ "bcs",
+ "iota-json-rpc-types",
  "iota-types",
+ "prost",
  "serde",
+ "tonic 0.13.1",
+ "tonic-build",
 ]
 
 [[package]]
 name = "iota-http"
-version = "1.9.2"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#ac83d2f8fd55eb384fdb6845d1fc1cfe824d6f9d"
+version = "1.10.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.10.0#40ac2b68694ce1bc1889d484d207981a380bcd2b"
 dependencies = [
  "bytes",
  "http 1.3.1",
@@ -4603,8 +4617,8 @@ dependencies = [
 
 [[package]]
 name = "iota-json"
-version = "1.9.2"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#ac83d2f8fd55eb384fdb6845d1fc1cfe824d6f9d"
+version = "1.10.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.10.0#40ac2b68694ce1bc1889d484d207981a380bcd2b"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4620,8 +4634,8 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc"
-version = "1.9.2"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#ac83d2f8fd55eb384fdb6845d1fc1cfe824d6f9d"
+version = "1.10.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.10.0#40ac2b68694ce1bc1889d484d207981a380bcd2b"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4646,6 +4660,7 @@ dependencies = [
  "iota-metrics",
  "iota-names",
  "iota-open-rpc",
+ "iota-package-resolver",
  "iota-protocol-config",
  "iota-storage",
  "iota-transaction-builder",
@@ -4673,8 +4688,8 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc-api"
-version = "1.9.2"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#ac83d2f8fd55eb384fdb6845d1fc1cfe824d6f9d"
+version = "1.10.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.10.0#40ac2b68694ce1bc1889d484d207981a380bcd2b"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -4693,14 +4708,15 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc-types"
-version = "1.9.2"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#ac83d2f8fd55eb384fdb6845d1fc1cfe824d6f9d"
+version = "1.10.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.10.0#40ac2b68694ce1bc1889d484d207981a380bcd2b"
 dependencies = [
  "anyhow",
  "bcs",
  "colored",
  "enum_dispatch",
  "fastcrypto",
+ "futures",
  "iota-enum-compat-util",
  "iota-json",
  "iota-macros",
@@ -4727,8 +4743,8 @@ dependencies = [
 
 [[package]]
 name = "iota-keys"
-version = "1.9.2"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#ac83d2f8fd55eb384fdb6845d1fc1cfe824d6f9d"
+version = "1.10.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.10.0#40ac2b68694ce1bc1889d484d207981a380bcd2b"
 dependencies = [
  "anyhow",
  "bip32",
@@ -4748,8 +4764,8 @@ dependencies = [
 
 [[package]]
 name = "iota-macros"
-version = "1.9.2"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#ac83d2f8fd55eb384fdb6845d1fc1cfe824d6f9d"
+version = "1.10.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.10.0#40ac2b68694ce1bc1889d484d207981a380bcd2b"
 dependencies = [
  "futures",
  "iota-proc-macros",
@@ -4759,8 +4775,8 @@ dependencies = [
 
 [[package]]
 name = "iota-mainnet-unlocks"
-version = "1.9.2"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#ac83d2f8fd55eb384fdb6845d1fc1cfe824d6f9d"
+version = "1.10.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.10.0#40ac2b68694ce1bc1889d484d207981a380bcd2b"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4772,8 +4788,8 @@ dependencies = [
 
 [[package]]
 name = "iota-metrics"
-version = "1.9.2"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#ac83d2f8fd55eb384fdb6845d1fc1cfe824d6f9d"
+version = "1.10.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.10.0#40ac2b68694ce1bc1889d484d207981a380bcd2b"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -4798,8 +4814,8 @@ dependencies = [
 
 [[package]]
 name = "iota-move-build"
-version = "1.9.2"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#ac83d2f8fd55eb384fdb6845d1fc1cfe824d6f9d"
+version = "1.10.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.10.0#40ac2b68694ce1bc1889d484d207981a380bcd2b"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -4821,7 +4837,7 @@ dependencies = [
 [[package]]
 name = "iota-move-natives-latest"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#ac83d2f8fd55eb384fdb6845d1fc1cfe824d6f9d"
+source = "git+https://github.com/iotaledger/iota?tag=v1.10.0#40ac2b68694ce1bc1889d484d207981a380bcd2b"
 dependencies = [
  "bcs",
  "better_any",
@@ -4843,8 +4859,8 @@ dependencies = [
 
 [[package]]
 name = "iota-names"
-version = "1.9.2"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#ac83d2f8fd55eb384fdb6845d1fc1cfe824d6f9d"
+version = "1.10.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.10.0#40ac2b68694ce1bc1889d484d207981a380bcd2b"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4856,8 +4872,8 @@ dependencies = [
 
 [[package]]
 name = "iota-network"
-version = "1.9.2"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#ac83d2f8fd55eb384fdb6845d1fc1cfe824d6f9d"
+version = "1.10.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.10.0#40ac2b68694ce1bc1889d484d207981a380bcd2b"
 dependencies = [
  "anemo",
  "anemo-build",
@@ -4892,8 +4908,8 @@ dependencies = [
 
 [[package]]
 name = "iota-network-stack"
-version = "1.9.2"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#ac83d2f8fd55eb384fdb6845d1fc1cfe824d6f9d"
+version = "1.10.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.10.0#40ac2b68694ce1bc1889d484d207981a380bcd2b"
 dependencies = [
  "anemo",
  "bcs",
@@ -4904,6 +4920,7 @@ dependencies = [
  "http-body 1.0.1",
  "hyper-rustls",
  "hyper-util",
+ "idna",
  "iota-http",
  "multiaddr",
  "once_cell",
@@ -4921,8 +4938,8 @@ dependencies = [
 
 [[package]]
 name = "iota-node"
-version = "1.9.2"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#ac83d2f8fd55eb384fdb6845d1fc1cfe824d6f9d"
+version = "1.10.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.10.0#40ac2b68694ce1bc1889d484d207981a380bcd2b"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -4941,8 +4958,7 @@ dependencies = [
  "iota-common",
  "iota-config",
  "iota-core",
- "iota-grpc-api",
- "iota-grpc-types",
+ "iota-grpc-server",
  "iota-http",
  "iota-json-rpc",
  "iota-json-rpc-api",
@@ -4975,8 +4991,8 @@ dependencies = [
 
 [[package]]
 name = "iota-open-rpc"
-version = "1.9.2"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#ac83d2f8fd55eb384fdb6845d1fc1cfe824d6f9d"
+version = "1.10.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.10.0#40ac2b68694ce1bc1889d484d207981a380bcd2b"
 dependencies = [
  "schemars",
  "serde",
@@ -4986,8 +5002,8 @@ dependencies = [
 
 [[package]]
 name = "iota-open-rpc-macros"
-version = "1.9.2"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#ac83d2f8fd55eb384fdb6845d1fc1cfe824d6f9d"
+version = "1.10.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.10.0#40ac2b68694ce1bc1889d484d207981a380bcd2b"
 dependencies = [
  "derive-syn-parse",
  "itertools 0.13.0",
@@ -4999,14 +5015,14 @@ dependencies = [
 
 [[package]]
 name = "iota-package-management"
-version = "1.9.2"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#ac83d2f8fd55eb384fdb6845d1fc1cfe824d6f9d"
+version = "1.10.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.10.0#40ac2b68694ce1bc1889d484d207981a380bcd2b"
 dependencies = [
  "anyhow",
  "iota-framework-snapshot",
  "iota-json-rpc-types",
  "iota-protocol-config",
- "iota-sdk 1.9.2",
+ "iota-sdk 1.10.0",
  "iota-types",
  "move-core-types",
  "move-package",
@@ -5016,8 +5032,8 @@ dependencies = [
 
 [[package]]
 name = "iota-package-resolver"
-version = "1.9.2"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#ac83d2f8fd55eb384fdb6845d1fc1cfe824d6f9d"
+version = "1.10.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.10.0#40ac2b68694ce1bc1889d484d207981a380bcd2b"
 dependencies = [
  "async-trait",
  "bcs",
@@ -5032,8 +5048,8 @@ dependencies = [
 
 [[package]]
 name = "iota-proc-macros"
-version = "1.9.2"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#ac83d2f8fd55eb384fdb6845d1fc1cfe824d6f9d"
+version = "1.10.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.10.0#40ac2b68694ce1bc1889d484d207981a380bcd2b"
 dependencies = [
  "msim-macros",
  "proc-macro2",
@@ -5043,8 +5059,8 @@ dependencies = [
 
 [[package]]
 name = "iota-protocol-config"
-version = "1.9.2"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#ac83d2f8fd55eb384fdb6845d1fc1cfe824d6f9d"
+version = "1.10.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.10.0#40ac2b68694ce1bc1889d484d207981a380bcd2b"
 dependencies = [
  "clap",
  "iota-protocol-config-macros",
@@ -5058,8 +5074,8 @@ dependencies = [
 
 [[package]]
 name = "iota-protocol-config-macros"
-version = "1.9.2"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#ac83d2f8fd55eb384fdb6845d1fc1cfe824d6f9d"
+version = "1.10.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.10.0#40ac2b68694ce1bc1889d484d207981a380bcd2b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5068,8 +5084,8 @@ dependencies = [
 
 [[package]]
 name = "iota-rest-api"
-version = "1.9.2"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#ac83d2f8fd55eb384fdb6845d1fc1cfe824d6f9d"
+version = "1.10.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.10.0#40ac2b68694ce1bc1889d484d207981a380bcd2b"
 dependencies = [
  "anyhow",
  "axum 0.8.4",
@@ -5149,8 +5165,8 @@ dependencies = [
 
 [[package]]
 name = "iota-sdk"
-version = "1.9.2"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#ac83d2f8fd55eb384fdb6845d1fc1cfe824d6f9d"
+version = "1.10.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.10.0#40ac2b68694ce1bc1889d484d207981a380bcd2b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5183,8 +5199,8 @@ dependencies = [
 
 [[package]]
 name = "iota-simulator"
-version = "1.9.2"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#ac83d2f8fd55eb384fdb6845d1fc1cfe824d6f9d"
+version = "1.10.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.10.0#40ac2b68694ce1bc1889d484d207981a380bcd2b"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -5206,8 +5222,8 @@ dependencies = [
 
 [[package]]
 name = "iota-snapshot"
-version = "1.9.2"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#ac83d2f8fd55eb384fdb6845d1fc1cfe824d6f9d"
+version = "1.10.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.10.0#40ac2b68694ce1bc1889d484d207981a380bcd2b"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5233,8 +5249,8 @@ dependencies = [
 
 [[package]]
 name = "iota-storage"
-version = "1.9.2"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#ac83d2f8fd55eb384fdb6845d1fc1cfe824d6f9d"
+version = "1.10.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.10.0#40ac2b68694ce1bc1889d484d207981a380bcd2b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5282,13 +5298,12 @@ dependencies = [
 
 [[package]]
 name = "iota-swarm"
-version = "1.9.2"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#ac83d2f8fd55eb384fdb6845d1fc1cfe824d6f9d"
+version = "1.10.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.10.0#40ac2b68694ce1bc1889d484d207981a380bcd2b"
 dependencies = [
  "anyhow",
  "futures",
  "iota-config",
- "iota-grpc-api",
  "iota-macros",
  "iota-metrics",
  "iota-names",
@@ -5311,8 +5326,8 @@ dependencies = [
 
 [[package]]
 name = "iota-swarm-config"
-version = "1.9.2"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#ac83d2f8fd55eb384fdb6845d1fc1cfe824d6f9d"
+version = "1.10.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.10.0#40ac2b68694ce1bc1889d484d207981a380bcd2b"
 dependencies = [
  "anemo",
  "anyhow",
@@ -5338,13 +5353,13 @@ dependencies = [
 
 [[package]]
 name = "iota-test-transaction-builder"
-version = "1.9.2"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#ac83d2f8fd55eb384fdb6845d1fc1cfe824d6f9d"
+version = "1.10.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.10.0#40ac2b68694ce1bc1889d484d207981a380bcd2b"
 dependencies = [
  "bcs",
  "iota-genesis-builder",
  "iota-move-build",
- "iota-sdk 1.9.2",
+ "iota-sdk 1.10.0",
  "iota-types",
  "move-core-types",
  "shared-crypto",
@@ -5352,8 +5367,8 @@ dependencies = [
 
 [[package]]
 name = "iota-tls"
-version = "1.9.2"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#ac83d2f8fd55eb384fdb6845d1fc1cfe824d6f9d"
+version = "1.10.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.10.0#40ac2b68694ce1bc1889d484d207981a380bcd2b"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -5374,8 +5389,8 @@ dependencies = [
 
 [[package]]
 name = "iota-transaction-builder"
-version = "1.9.2"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#ac83d2f8fd55eb384fdb6845d1fc1cfe824d6f9d"
+version = "1.10.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.10.0#40ac2b68694ce1bc1889d484d207981a380bcd2b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5391,8 +5406,8 @@ dependencies = [
 
 [[package]]
 name = "iota-transaction-checks"
-version = "1.9.2"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#ac83d2f8fd55eb384fdb6845d1fc1cfe824d6f9d"
+version = "1.10.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.10.0#40ac2b68694ce1bc1889d484d207981a380bcd2b"
 dependencies = [
  "fastcrypto-zkp",
  "iota-config",
@@ -5405,8 +5420,8 @@ dependencies = [
 
 [[package]]
 name = "iota-types"
-version = "1.9.2"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#ac83d2f8fd55eb384fdb6845d1fc1cfe824d6f9d"
+version = "1.10.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.10.0#40ac2b68694ce1bc1889d484d207981a380bcd2b"
 dependencies = [
  "anemo",
  "anyhow",
@@ -5471,7 +5486,7 @@ dependencies = [
 [[package]]
 name = "iota-verifier-latest"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#ac83d2f8fd55eb384fdb6845d1fc1cfe824d6f9d"
+source = "git+https://github.com/iotaledger/iota?tag=v1.10.0#40ac2b68694ce1bc1889d484d207981a380bcd2b"
 dependencies = [
  "iota-types",
  "move-abstract-interpreter",
@@ -6249,7 +6264,7 @@ dependencies = [
 [[package]]
 name = "move-abstract-interpreter"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#ac83d2f8fd55eb384fdb6845d1fc1cfe824d6f9d"
+source = "git+https://github.com/iotaledger/iota?tag=v1.10.0#40ac2b68694ce1bc1889d484d207981a380bcd2b"
 dependencies = [
  "move-binary-format",
  "move-bytecode-verifier-meter",
@@ -6258,12 +6273,12 @@ dependencies = [
 [[package]]
 name = "move-abstract-stack"
 version = "0.0.1"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#ac83d2f8fd55eb384fdb6845d1fc1cfe824d6f9d"
+source = "git+https://github.com/iotaledger/iota?tag=v1.10.0#40ac2b68694ce1bc1889d484d207981a380bcd2b"
 
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#ac83d2f8fd55eb384fdb6845d1fc1cfe824d6f9d"
+source = "git+https://github.com/iotaledger/iota?tag=v1.10.0#40ac2b68694ce1bc1889d484d207981a380bcd2b"
 dependencies = [
  "anyhow",
  "enum-compat-util",
@@ -6277,12 +6292,12 @@ dependencies = [
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#ac83d2f8fd55eb384fdb6845d1fc1cfe824d6f9d"
+source = "git+https://github.com/iotaledger/iota?tag=v1.10.0#40ac2b68694ce1bc1889d484d207981a380bcd2b"
 
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#ac83d2f8fd55eb384fdb6845d1fc1cfe824d6f9d"
+source = "git+https://github.com/iotaledger/iota?tag=v1.10.0#40ac2b68694ce1bc1889d484d207981a380bcd2b"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6298,7 +6313,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#ac83d2f8fd55eb384fdb6845d1fc1cfe824d6f9d"
+source = "git+https://github.com/iotaledger/iota?tag=v1.10.0#40ac2b68694ce1bc1889d484d207981a380bcd2b"
 dependencies = [
  "anyhow",
  "indexmap 2.11.4",
@@ -6312,7 +6327,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#ac83d2f8fd55eb384fdb6845d1fc1cfe824d6f9d"
+source = "git+https://github.com/iotaledger/iota?tag=v1.10.0#40ac2b68694ce1bc1889d484d207981a380bcd2b"
 dependencies = [
  "move-abstract-interpreter",
  "move-abstract-stack",
@@ -6327,7 +6342,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier-meter"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#ac83d2f8fd55eb384fdb6845d1fc1cfe824d6f9d"
+source = "git+https://github.com/iotaledger/iota?tag=v1.10.0#40ac2b68694ce1bc1889d484d207981a380bcd2b"
 dependencies = [
  "move-binary-format",
  "move-core-types",
@@ -6337,7 +6352,7 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#ac83d2f8fd55eb384fdb6845d1fc1cfe824d6f9d"
+source = "git+https://github.com/iotaledger/iota?tag=v1.10.0#40ac2b68694ce1bc1889d484d207981a380bcd2b"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6357,7 +6372,7 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#ac83d2f8fd55eb384fdb6845d1fc1cfe824d6f9d"
+source = "git+https://github.com/iotaledger/iota?tag=v1.10.0#40ac2b68694ce1bc1889d484d207981a380bcd2b"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6392,7 +6407,7 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#ac83d2f8fd55eb384fdb6845d1fc1cfe824d6f9d"
+source = "git+https://github.com/iotaledger/iota?tag=v1.10.0#40ac2b68694ce1bc1889d484d207981a380bcd2b"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6416,7 +6431,7 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#ac83d2f8fd55eb384fdb6845d1fc1cfe824d6f9d"
+source = "git+https://github.com/iotaledger/iota?tag=v1.10.0#40ac2b68694ce1bc1889d484d207981a380bcd2b"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6437,7 +6452,7 @@ dependencies = [
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#ac83d2f8fd55eb384fdb6845d1fc1cfe824d6f9d"
+source = "git+https://github.com/iotaledger/iota?tag=v1.10.0#40ac2b68694ce1bc1889d484d207981a380bcd2b"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6458,7 +6473,7 @@ dependencies = [
 [[package]]
 name = "move-docgen"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#ac83d2f8fd55eb384fdb6845d1fc1cfe824d6f9d"
+source = "git+https://github.com/iotaledger/iota?tag=v1.10.0#40ac2b68694ce1bc1889d484d207981a380bcd2b"
 dependencies = [
  "anyhow",
  "clap",
@@ -6481,7 +6496,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#ac83d2f8fd55eb384fdb6845d1fc1cfe824d6f9d"
+source = "git+https://github.com/iotaledger/iota?tag=v1.10.0#40ac2b68694ce1bc1889d484d207981a380bcd2b"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -6499,7 +6514,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#ac83d2f8fd55eb384fdb6845d1fc1cfe824d6f9d"
+source = "git+https://github.com/iotaledger/iota?tag=v1.10.0#40ac2b68694ce1bc1889d484d207981a380bcd2b"
 dependencies = [
  "anyhow",
  "hex",
@@ -6512,7 +6527,7 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#ac83d2f8fd55eb384fdb6845d1fc1cfe824d6f9d"
+source = "git+https://github.com/iotaledger/iota?tag=v1.10.0#40ac2b68694ce1bc1889d484d207981a380bcd2b"
 dependencies = [
  "hex",
  "move-command-line-common",
@@ -6525,7 +6540,7 @@ dependencies = [
 [[package]]
 name = "move-model-2"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#ac83d2f8fd55eb384fdb6845d1fc1cfe824d6f9d"
+source = "git+https://github.com/iotaledger/iota?tag=v1.10.0#40ac2b68694ce1bc1889d484d207981a380bcd2b"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6546,7 +6561,7 @@ dependencies = [
 [[package]]
 name = "move-package"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#ac83d2f8fd55eb384fdb6845d1fc1cfe824d6f9d"
+source = "git+https://github.com/iotaledger/iota?tag=v1.10.0#40ac2b68694ce1bc1889d484d207981a380bcd2b"
 dependencies = [
  "anyhow",
  "clap",
@@ -6582,7 +6597,7 @@ dependencies = [
 [[package]]
 name = "move-proc-macros"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#ac83d2f8fd55eb384fdb6845d1fc1cfe824d6f9d"
+source = "git+https://github.com/iotaledger/iota?tag=v1.10.0#40ac2b68694ce1bc1889d484d207981a380bcd2b"
 dependencies = [
  "quote",
  "syn 2.0.100",
@@ -6591,7 +6606,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib-natives"
 version = "0.1.1"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#ac83d2f8fd55eb384fdb6845d1fc1cfe824d6f9d"
+source = "git+https://github.com/iotaledger/iota?tag=v1.10.0#40ac2b68694ce1bc1889d484d207981a380bcd2b"
 dependencies = [
  "hex",
  "move-binary-format",
@@ -6606,7 +6621,7 @@ dependencies = [
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#ac83d2f8fd55eb384fdb6845d1fc1cfe824d6f9d"
+source = "git+https://github.com/iotaledger/iota?tag=v1.10.0#40ac2b68694ce1bc1889d484d207981a380bcd2b"
 dependencies = [
  "once_cell",
  "phf",
@@ -6616,7 +6631,7 @@ dependencies = [
 [[package]]
 name = "move-trace-format"
 version = "0.0.1"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#ac83d2f8fd55eb384fdb6845d1fc1cfe824d6f9d"
+source = "git+https://github.com/iotaledger/iota?tag=v1.10.0#40ac2b68694ce1bc1889d484d207981a380bcd2b"
 dependencies = [
  "move-binary-format",
  "move-core-types",
@@ -6627,7 +6642,7 @@ dependencies = [
 [[package]]
 name = "move-vm-config"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#ac83d2f8fd55eb384fdb6845d1fc1cfe824d6f9d"
+source = "git+https://github.com/iotaledger/iota?tag=v1.10.0#40ac2b68694ce1bc1889d484d207981a380bcd2b"
 dependencies = [
  "move-binary-format",
  "once_cell",
@@ -6636,7 +6651,7 @@ dependencies = [
 [[package]]
 name = "move-vm-profiler"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#ac83d2f8fd55eb384fdb6845d1fc1cfe824d6f9d"
+source = "git+https://github.com/iotaledger/iota?tag=v1.10.0#40ac2b68694ce1bc1889d484d207981a380bcd2b"
 dependencies = [
  "move-vm-config",
  "once_cell",
@@ -6646,7 +6661,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#ac83d2f8fd55eb384fdb6845d1fc1cfe824d6f9d"
+source = "git+https://github.com/iotaledger/iota?tag=v1.10.0#40ac2b68694ce1bc1889d484d207981a380bcd2b"
 dependencies = [
  "better_any",
  "fail",
@@ -6666,7 +6681,7 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#ac83d2f8fd55eb384fdb6845d1fc1cfe824d6f9d"
+source = "git+https://github.com/iotaledger/iota?tag=v1.10.0#40ac2b68694ce1bc1889d484d207981a380bcd2b"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -6680,7 +6695,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#ac83d2f8fd55eb384fdb6845d1fc1cfe824d6f9d"
+source = "git+https://github.com/iotaledger/iota?tag=v1.10.0#40ac2b68694ce1bc1889d484d207981a380bcd2b"
 dependencies = [
  "bcs",
  "move-binary-format",
@@ -7666,9 +7681,9 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
-version = "2.3.1"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "petgraph"
@@ -8079,8 +8094,8 @@ dependencies = [
 
 [[package]]
 name = "prometheus-closure-metric"
-version = "1.9.2"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#ac83d2f8fd55eb384fdb6845d1fc1cfe824d6f9d"
+version = "1.10.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.10.0#40ac2b68694ce1bc1889d484d207981a380bcd2b"
 dependencies = [
  "anyhow",
  "prometheus",
@@ -9541,8 +9556,8 @@ dependencies = [
 
 [[package]]
 name = "shared-crypto"
-version = "1.9.2"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#ac83d2f8fd55eb384fdb6845d1fc1cfe824d6f9d"
+version = "1.10.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.10.0#40ac2b68694ce1bc1889d484d207981a380bcd2b"
 dependencies = [
  "bcs",
  "eyre",
@@ -9805,8 +9820,9 @@ dependencies = [
 [[package]]
 name = "starfish-config"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#ac83d2f8fd55eb384fdb6845d1fc1cfe824d6f9d"
+source = "git+https://github.com/iotaledger/iota?tag=v1.10.0#40ac2b68694ce1bc1889d484d207981a380bcd2b"
 dependencies = [
+ "blake3",
  "fastcrypto",
  "iota-network-stack",
  "rand 0.8.5",
@@ -9818,8 +9834,9 @@ dependencies = [
 [[package]]
 name = "starfish-core"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#ac83d2f8fd55eb384fdb6845d1fc1cfe824d6f9d"
+source = "git+https://github.com/iotaledger/iota?tag=v1.10.0#40ac2b68694ce1bc1889d484d207981a380bcd2b"
 dependencies = [
+ "ahash",
  "anyhow",
  "arc-swap",
  "async-trait",
@@ -10156,8 +10173,8 @@ dependencies = [
 
 [[package]]
 name = "telemetry-subscribers"
-version = "1.9.2"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#ac83d2f8fd55eb384fdb6845d1fc1cfe824d6f9d"
+version = "1.10.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.10.0#40ac2b68694ce1bc1889d484d207981a380bcd2b"
 dependencies = [
  "atomic_float",
  "bytes",
@@ -10222,8 +10239,8 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "test-cluster"
-version = "1.9.2"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#ac83d2f8fd55eb384fdb6845d1fc1cfe824d6f9d"
+version = "1.10.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.10.0#40ac2b68694ce1bc1889d484d207981a380bcd2b"
 dependencies = [
  "anyhow",
  "fastcrypto-zkp",
@@ -10233,14 +10250,13 @@ dependencies = [
  "iota-core",
  "iota-framework",
  "iota-genesis-builder",
- "iota-grpc-api",
  "iota-json-rpc",
  "iota-json-rpc-api",
  "iota-json-rpc-types",
  "iota-keys",
  "iota-node",
  "iota-protocol-config",
- "iota-sdk 1.9.2",
+ "iota-sdk 1.10.0",
  "iota-simulator",
  "iota-swarm",
  "iota-swarm-config",
@@ -10947,8 +10963,8 @@ dependencies = [
 
 [[package]]
 name = "typed-store"
-version = "1.9.2"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#ac83d2f8fd55eb384fdb6845d1fc1cfe824d6f9d"
+version = "1.10.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.10.0#40ac2b68694ce1bc1889d484d207981a380bcd2b"
 dependencies = [
  "bcs",
  "bincode",
@@ -10974,8 +10990,8 @@ dependencies = [
 
 [[package]]
 name = "typed-store-derive"
-version = "1.9.2"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#ac83d2f8fd55eb384fdb6845d1fc1cfe824d6f9d"
+version = "1.10.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.10.0#40ac2b68694ce1bc1889d484d207981a380bcd2b"
 dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
@@ -10985,8 +11001,8 @@ dependencies = [
 
 [[package]]
 name = "typed-store-error"
-version = "1.9.2"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#ac83d2f8fd55eb384fdb6845d1fc1cfe824d6f9d"
+version = "1.10.0"
+source = "git+https://github.com/iotaledger/iota?tag=v1.10.0#40ac2b68694ce1bc1889d484d207981a380bcd2b"
 dependencies = [
  "serde",
  "thiserror 1.0.69",
@@ -11119,9 +11135,9 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.5.4"
+version = "2.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
+checksum = "08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b"
 dependencies = [
  "form_urlencoded",
  "idna",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,13 +10,13 @@ repository = "https://github.com/iotaledger/gas-station"
 
 fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "69d496c71fb37e3d22fe85e5bbfd4256d61422b9" }
 
-iota-metrics = { git = "https://github.com/iotaledger/iota", tag = "v1.9.2", package = "iota-metrics" }
-iota-config = { git = "https://github.com/iotaledger/iota", tag = "v1.9.2", package = "iota-config" }
-iota-json-rpc-types = { git = "https://github.com/iotaledger/iota", tag = "v1.9.2", package = "iota-json-rpc-types" }
-iota-sdk = { git = "https://github.com/iotaledger/iota", tag = "v1.9.2", package = "iota-sdk" }
-iota-types = { git = "https://github.com/iotaledger/iota", tag = "v1.9.2", package = "iota-types" }
-shared-crypto = { git = "https://github.com/iotaledger/iota", tag = "v1.9.2", package = "shared-crypto" }
-telemetry-subscribers = { git = "https://github.com/iotaledger/iota", tag = "v1.9.2", package = "telemetry-subscribers" }
+iota-metrics = { git = "https://github.com/iotaledger/iota", tag = "v1.10.0", package = "iota-metrics" }
+iota-config = { git = "https://github.com/iotaledger/iota", tag = "v1.10.0", package = "iota-config" }
+iota-json-rpc-types = { git = "https://github.com/iotaledger/iota", tag = "v1.10.0", package = "iota-json-rpc-types" }
+iota-sdk = { git = "https://github.com/iotaledger/iota", tag = "v1.10.0", package = "iota-sdk" }
+iota-types = { git = "https://github.com/iotaledger/iota", tag = "v1.10.0", package = "iota-types" }
+shared-crypto = { git = "https://github.com/iotaledger/iota", tag = "v1.10.0", package = "shared-crypto" }
+telemetry-subscribers = { git = "https://github.com/iotaledger/iota", tag = "v1.10.0", package = "telemetry-subscribers" }
 
 
 anyhow = "1.0.75"
@@ -57,15 +57,15 @@ lazy_static = "1.5.0"
 uuid = { version = "1.17.0", features = ["v4"] }
 humantime = "2.2.0"
 regorus = { version = "0.4.0" }
-url = { version = "2.5.4", features = ["serde"] }
+url = { version = "2.5.7", features = ["serde"] }
 
 
 [dev-dependencies]
 indoc = "2"
 rand = "0.8.5"
 wiremock = "0.6.3"
-iota-swarm-config = { git = "https://github.com/iotaledger/iota", tag = "v1.9.2", package = "iota-swarm-config" }
-test-cluster = { git = "https://github.com/iotaledger/iota", tag = "v1.9.2", package = "test-cluster" }
+iota-swarm-config = { git = "https://github.com/iotaledger/iota", tag = "v1.10.0", package = "iota-swarm-config" }
+test-cluster = { git = "https://github.com/iotaledger/iota", tag = "v1.10.0", package = "test-cluster" }
 
 [profile.release]
 panic = "abort"

--- a/examples/hook/Cargo.toml
+++ b/examples/hook/Cargo.toml
@@ -10,7 +10,7 @@ anyhow = "1.0.98"
 axum = "0.8.0"
 base64 = "0.22.1"
 bcs = "0.1.4"
-iota-types = { git = "https://github.com/iotaledger/iota", tag = "v1.9.2", package = "iota-types" }
+iota-types = { git = "https://github.com/iotaledger/iota", tag = "v1.10.0", package = "iota-types" }
 serde = "1"
 serde_json = "1.0.140"
 thiserror = "2.0.12"


### PR DESCRIPTION
Bump up the IOTA protocol libs to `1.10`

closes #145 