### PR TITLE
Add Config Value for Max Gas Budget

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ coin-init-config:
   target-init-balance: 100000000 # requires redis to be cleared
   refresh-interval-sec: 86400
 daily-gas-usage-cap: 1500000000000
+max-gas-budget: 2000000000
 access-controller:
   access-policy: disabled
 ```
@@ -119,6 +120,7 @@ access-controller:
 | `coin-init-config.target-init-balance`  | yes ⚠               | Target balance for the new coins when we splitting new gas coins in NANOs | `100000000`                                                                                     |
 | `coin-init-config.refresh-interval-sec` | no                  | Interval in seconds to refresh balance and check for new coins to split   | `86400`                                                                                         |
 | `daily-gas-usage-cap`                   | no                  | Maximum allowed daily gas usage                                           | `1500000000000`                                                                                 |
+| `max-gas-budget`                        | no                  | Maximum allowed reservable gas budget                                     | `2000000000`                                                                                    |
 | `access-controller.access-policy`       | no                  | Access policy mode.                                                       | `disabled`, `allow-all`, `deny-all`. See [this link](./docs/access-controller.md) to learn more |
 
 

--- a/src/command.rs
+++ b/src/command.rs
@@ -72,6 +72,7 @@ impl Command {
             metrics_port,
             coin_init_config,
             daily_gas_usage_cap,
+            max_gas_budget,
             mut access_controller,
         } = config;
 
@@ -156,6 +157,7 @@ impl Command {
             storage,
             iota_client,
             daily_gas_usage_cap,
+            max_gas_budget,
             core_metrics,
             rescan_config,
         )

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -20,13 +20,21 @@ pub const DEFAULT_METRICS_PORT: u16 = 9184;
 pub const DEFAULT_INIT_COIN_BALANCE: u64 = NANOS_PER_IOTA / 10;
 // 24 hours.
 const DEFAULT_COIN_POOL_REFRESH_INTERVAL_SEC: u64 = 60 * 60 * 24;
+// 1500 IOTA.
 pub const DEFAULT_DAILY_GAS_USAGE_CAP: u64 = 1500 * NANOS_PER_IOTA;
+// 2 IOTA.
+pub const DEFAULT_MAX_GAS_BUDGET: u64 = 2 * NANOS_PER_IOTA;
 
 // Use 127.0.0.1 for tests to avoid OS complaining about permissions.
 #[cfg(test)]
 pub const LOCALHOST: Ipv4Addr = Ipv4Addr::new(127, 0, 0, 1);
 #[cfg(not(test))]
 pub const LOCALHOST: Ipv4Addr = Ipv4Addr::new(0, 0, 0, 0);
+
+/// Helper function for serde deserialization.
+fn default_max_gas_budget() -> u64 {
+    DEFAULT_MAX_GAS_BUDGET
+}
 
 #[serde_as]
 #[derive(Debug, Deserialize, Serialize)]
@@ -45,6 +53,8 @@ pub struct GasStationConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub coin_init_config: Option<CoinInitConfig>,
     pub daily_gas_usage_cap: u64,
+    #[serde(default = "default_max_gas_budget")]
+    pub max_gas_budget: u64,
     #[serde(default)]
     pub access_controller: AccessController,
 }
@@ -63,6 +73,7 @@ impl Default for GasStationConfig {
             fullnode_basic_auth: None,
             coin_init_config: Some(CoinInitConfig::default()),
             daily_gas_usage_cap: DEFAULT_DAILY_GAS_USAGE_CAP,
+            max_gas_budget: DEFAULT_MAX_GAS_BUDGET,
             access_controller: AccessController::default(),
         }
     }
@@ -146,7 +157,7 @@ mod test {
     use indoc::indoc;
 
     #[test]
-    fn test_deserialize_config_urls_kebeb_case() {
+    fn test_deserialize_config_urls_kebab_case() {
         let yaml = indoc! {r#"
             signer-config:
                 sidecar:
@@ -159,6 +170,7 @@ mod test {
                     redis-url: "redis://localhost:6379"
             fullnode-url: "https://api.devnet.iota.cafe"
             daily-gas-usage-cap: 1500000000000
+            max-gas-budget: 2000000000
         "#};
         let config: GasStationConfig = serde_yaml::from_str(yaml).unwrap();
         assert_eq!(
@@ -189,6 +201,7 @@ mod test {
                     redis_url: "redis://localhost:6379"
             fullnode-url: "https://api.devnet.iota.cafe"
             daily-gas-usage-cap: 1500000000000
+            max-gas-budget: 2000000000
         "#};
         let config: GasStationConfig = serde_yaml::from_str(yaml).unwrap();
         assert_eq!(

--- a/src/gas_station/gas_station_core.rs
+++ b/src/gas_station/gas_station_core.rs
@@ -5,7 +5,7 @@ use crate::gas_station::rescan_trigger::RescanGasObjectsTrigger;
 use crate::gas_station_initializer::NEW_COIN_BALANCE_FACTOR_THRESHOLD;
 use crate::iota_client::IotaClient;
 use crate::metrics::GasStationCoreMetrics;
-use crate::rpc::rpc_types::ExecuteTransactionRequestType;
+use crate::rpc::rpc_types::{ExecuteTransactionRequestType, ReserveGasRequest};
 use crate::storage::Storage;
 use crate::tx_signer::TxSigner;
 use crate::types::{GasCoin, ReservationID};
@@ -30,6 +30,9 @@ use super::gas_usage_cap::GasUsageCap;
 
 const EXPIRATION_JOB_INTERVAL: Duration = Duration::from_secs(1);
 
+// 10 mins.
+pub const RESERVE_GAS_MAX_DURATION_S: u64 = 10 * 60;
+
 pub struct GasStationContainer {
     inner: Arc<GasStation>,
     _coin_unlocker_task: JoinHandle<()>,
@@ -43,6 +46,7 @@ pub struct GasStation {
     iota_client: IotaClient,
     metrics: Arc<GasStationCoreMetrics>,
     gas_usage_cap: Arc<GasUsageCap>,
+    max_gas_budget: u64,
     rescan_config: RescanGasObjectsTrigger,
 }
 
@@ -53,6 +57,7 @@ impl GasStation {
         iota_client: IotaClient,
         metrics: Arc<GasStationCoreMetrics>,
         gas_usage_cap: Arc<GasUsageCap>,
+        max_gas_budget: u64,
         rescan_config: RescanGasObjectsTrigger,
     ) -> Arc<Self> {
         let pool = Self {
@@ -61,6 +66,7 @@ impl GasStation {
             iota_client,
             metrics,
             gas_usage_cap,
+            max_gas_budget,
             rescan_config,
         };
 
@@ -269,6 +275,31 @@ impl GasStation {
             .sum()
     }
 
+    /// Checks gas reservation request validity.
+    /// Note that this is intended as a pre-flight check in server request handling.
+    /// Calling `GasStation::reserve_gas` directly will allow to use values outside of the boundaries checked here.
+    pub fn check_reserve_gas_request_validity(
+        &self,
+        request: &ReserveGasRequest,
+    ) -> anyhow::Result<()> {
+        if request.gas_budget == 0 {
+            anyhow::bail!("Gas budget must be positive");
+        }
+        if request.gas_budget > self.max_gas_budget {
+            anyhow::bail!("Gas budget must be less than {}", self.max_gas_budget);
+        }
+        if request.reserve_duration_secs == 0 {
+            anyhow::bail!("Reserve duration must be positive");
+        }
+        if request.reserve_duration_secs > RESERVE_GAS_MAX_DURATION_S {
+            anyhow::bail!(
+                "Reserve duration must be less than {} seconds",
+                RESERVE_GAS_MAX_DURATION_S
+            );
+        }
+        Ok(())
+    }
+
     fn check_transaction_validity(tx_data: &TransactionData) -> anyhow::Result<()> {
         let mut all_args = vec![];
         for command in tx_data.kind().iter_commands() {
@@ -383,6 +414,7 @@ impl GasStationContainer {
         gas_station_store: Arc<dyn Storage>,
         iota_client: IotaClient,
         gas_usage_daily_cap: u64,
+        max_gas_budget: u64,
         metrics: Arc<GasStationCoreMetrics>,
         rescan_config: RescanGasObjectsTrigger,
     ) -> Self {
@@ -392,6 +424,7 @@ impl GasStationContainer {
             iota_client,
             metrics,
             Arc::new(GasUsageCap::new(gas_usage_daily_cap)),
+            max_gas_budget,
             rescan_config,
         )
         .await;

--- a/src/gas_station/mod.rs
+++ b/src/gas_station/mod.rs
@@ -21,7 +21,7 @@ mod tests {
     #[tokio::test]
     async fn test_station_reserve_gas() {
         let (_test_cluster, container) =
-            start_gas_station(vec![NANOS_PER_IOTA; 10], NANOS_PER_IOTA).await;
+            start_gas_station(vec![NANOS_PER_IOTA; 10], NANOS_PER_IOTA, None).await;
         let station = container.get_gas_station_arc();
         let (sponsor1, _res_id1, gas_coins) = station
             .reserve_gas(NANOS_PER_IOTA * 3, Duration::from_secs(10))
@@ -45,7 +45,7 @@ mod tests {
     #[tokio::test]
     async fn test_e2e_gas_station_flow() {
         let (test_cluster, container) =
-            start_gas_station(vec![NANOS_PER_IOTA], NANOS_PER_IOTA).await;
+            start_gas_station(vec![NANOS_PER_IOTA], NANOS_PER_IOTA, None).await;
         let station = container.get_gas_station_arc();
         assert!(station
             .reserve_gas(NANOS_PER_IOTA + 1, Duration::from_secs(10))
@@ -76,7 +76,7 @@ mod tests {
     async fn test_invalid_transaction() {
         telemetry_subscribers::init_for_testing();
         let (_test_cluster, container) =
-            start_gas_station(vec![NANOS_PER_IOTA], NANOS_PER_IOTA).await;
+            start_gas_station(vec![NANOS_PER_IOTA], NANOS_PER_IOTA, None).await;
         let station = container.get_gas_station_arc();
         let (sponsor, reservation_id, gas_coins) = station
             .reserve_gas(NANOS_PER_IOTA, Duration::from_secs(10))
@@ -103,7 +103,7 @@ mod tests {
     async fn test_coin_expiration() {
         telemetry_subscribers::init_for_testing();
         let (test_cluster, container) =
-            start_gas_station(vec![NANOS_PER_IOTA], NANOS_PER_IOTA).await;
+            start_gas_station(vec![NANOS_PER_IOTA], NANOS_PER_IOTA, None).await;
         let station = container.get_gas_station_arc();
         let (sponsor, reservation_id, gas_coins) = station
             .reserve_gas(NANOS_PER_IOTA, Duration::from_secs(1))
@@ -133,7 +133,7 @@ mod tests {
     #[tokio::test]
     async fn test_incomplete_gas_usage() {
         let (test_cluster, container) =
-            start_gas_station(vec![NANOS_PER_IOTA; 10], NANOS_PER_IOTA).await;
+            start_gas_station(vec![NANOS_PER_IOTA; 10], NANOS_PER_IOTA, None).await;
         let station = container.get_gas_station_arc();
         let (sponsor, reservation_id, gas_coins) = station
             .reserve_gas(NANOS_PER_IOTA * 3, Duration::from_secs(10))
@@ -164,7 +164,7 @@ mod tests {
     #[tokio::test]
     async fn test_mixed_up_gas_coins() {
         let (test_cluster, container) =
-            start_gas_station(vec![NANOS_PER_IOTA; 10], NANOS_PER_IOTA).await;
+            start_gas_station(vec![NANOS_PER_IOTA; 10], NANOS_PER_IOTA, None).await;
         let station = container.get_gas_station_arc();
         let (sponsor, reservation_id1, gas_coins1) = station
             .reserve_gas(NANOS_PER_IOTA * 3, Duration::from_secs(10))
@@ -193,5 +193,62 @@ mod tests {
             .await
             .unwrap();
         assert!(effects.status().is_ok());
+    }
+
+    mod check_reserve_gas_request_validity {
+        use super::*;
+
+        use crate::{config::DEFAULT_MAX_GAS_BUDGET, rpc::rpc_types::ReserveGasRequest};
+
+        struct Spec {
+            gas_budget: u64,
+            is_ok: bool,
+        }
+
+        impl Spec {
+            pub fn new(gas_budget: u64, is_ok: bool) -> Self {
+                Self { gas_budget, is_ok }
+            }
+        }
+
+        async fn run_test_for_max_gas_budget(max_gas_budget: u64) {
+            let test_set = vec![
+                Spec::new(max_gas_budget, true),
+                Spec::new(max_gas_budget - 1, true),
+                Spec::new(max_gas_budget + 1, false),
+                Spec::new(0, false),
+            ];
+            let (_test_cluster, container) = start_gas_station(
+                vec![NANOS_PER_IOTA; 10],
+                NANOS_PER_IOTA,
+                Some(max_gas_budget),
+            )
+            .await;
+            let station = container.get_gas_station_arc();
+
+            for Spec { gas_budget, is_ok } in test_set.into_iter() {
+                let request = ReserveGasRequest {
+                    gas_budget,
+                    reserve_duration_secs: 10,
+                };
+                let result = station.check_reserve_gas_request_validity(&request);
+                assert_eq!(result.is_ok(), is_ok);
+            }
+        }
+
+        #[tokio::test]
+        async fn with_default_max_gas_budget() {
+            run_test_for_max_gas_budget(DEFAULT_MAX_GAS_BUDGET).await;
+        }
+
+        #[tokio::test]
+        async fn with_lower_max_gas_budget() {
+            run_test_for_max_gas_budget(DEFAULT_MAX_GAS_BUDGET - 1000).await;
+        }
+
+        #[tokio::test]
+        async fn with_larger_gas_budget() {
+            run_test_for_max_gas_budget(DEFAULT_MAX_GAS_BUDGET + 1000).await;
+        }
     }
 }

--- a/src/rpc/rpc_types.rs
+++ b/src/rpc/rpc_types.rs
@@ -11,37 +11,10 @@ use iota_types::{
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-// 2 IOTA.
-pub const MAX_BUDGET: u64 = 2_000_000_000;
-
-// 10 mins.
-pub const MAX_DURATION_S: u64 = 10 * 60;
-
 #[derive(Clone, Debug, JsonSchema, Serialize, Deserialize)]
 pub struct ReserveGasRequest {
     pub gas_budget: u64,
     pub reserve_duration_secs: u64,
-}
-
-impl ReserveGasRequest {
-    pub fn check_validity(&self) -> anyhow::Result<()> {
-        if self.gas_budget == 0 {
-            anyhow::bail!("Gas budget must be positive");
-        }
-        if self.gas_budget > MAX_BUDGET {
-            anyhow::bail!("Gas budget must be less than {}", MAX_BUDGET);
-        }
-        if self.reserve_duration_secs == 0 {
-            anyhow::bail!("Reserve duration must be positive");
-        }
-        if self.reserve_duration_secs > MAX_DURATION_S {
-            anyhow::bail!(
-                "Reserve duration must be less than {} seconds",
-                MAX_DURATION_S
-            );
-        }
-        Ok(())
-    }
 }
 
 #[derive(Debug, JsonSchema, Serialize, Deserialize)]

--- a/src/rpc/server.rs
+++ b/src/rpc/server.rs
@@ -168,7 +168,10 @@ async fn reserve_gas(
     }
     server.metrics.num_authorized_reserve_gas_requests.inc();
     debug!("Received v1 reserve_gas request: {:?}", payload);
-    if let Err(err) = payload.check_validity() {
+    if let Err(err) = server
+        .gas_station
+        .check_reserve_gas_request_validity(&payload)
+    {
         debug!("Invalid reserve_gas request: {:?}", err);
         return (
             StatusCode::BAD_REQUEST,

--- a/src/test_env.rs
+++ b/src/test_env.rs
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::access_controller::AccessController;
-use crate::config::{CoinInitConfig, GasStationStorageConfig, DEFAULT_DAILY_GAS_USAGE_CAP};
+use crate::config::{
+    CoinInitConfig, GasStationStorageConfig, DEFAULT_DAILY_GAS_USAGE_CAP, DEFAULT_MAX_GAS_BUDGET,
+};
 use crate::gas_station::gas_station_core::GasStationContainer;
 use crate::gas_station::rescan_trigger::RescanGasObjectsTrigger;
 use crate::gas_station_initializer::GasStationInitializer;
@@ -56,6 +58,7 @@ pub async fn start_iota_cluster(init_gas_amounts: Vec<u64>) -> (TestCluster, Arc
 pub async fn start_gas_station(
     init_gas_amounts: Vec<u64>,
     target_init_coin_balance: u64,
+    max_gas_budget: Option<u64>,
 ) -> (TestCluster, GasStationContainer) {
     debug!("Starting Iota cluster..");
     let (test_cluster, signer) = start_iota_cluster(init_gas_amounts).await;
@@ -84,6 +87,7 @@ pub async fn start_gas_station(
         storage,
         iota_client,
         DEFAULT_DAILY_GAS_USAGE_CAP,
+        max_gas_budget.unwrap_or(DEFAULT_MAX_GAS_BUDGET),
         GasStationCoreMetrics::new_for_testing(),
         rescan_config,
     )
@@ -95,7 +99,8 @@ pub async fn start_rpc_server_for_testing(
     init_gas_amounts: Vec<u64>,
     target_init_balance: u64,
 ) -> (TestCluster, GasStationContainer, GasStationServer) {
-    let (test_cluster, container) = start_gas_station(init_gas_amounts, target_init_balance).await;
+    let (test_cluster, container) =
+        start_gas_station(init_gas_amounts, target_init_balance, None).await;
     let localhost = localhost_for_testing();
     let signer_address = container.get_signer_address();
     std::env::set_var(AUTH_ENV_NAME, "some secret");
@@ -117,7 +122,8 @@ pub async fn start_rpc_server_for_testing_no_auth(
     init_gas_amounts: Vec<u64>,
     target_init_balance: u64,
 ) -> (TestCluster, GasStationContainer, GasStationServer) {
-    let (test_cluster, container) = start_gas_station(init_gas_amounts, target_init_balance).await;
+    let (test_cluster, container) =
+        start_gas_station(init_gas_amounts, target_init_balance, None).await;
     let localhost = localhost_for_testing();
     let signer_address = container.get_signer_address();
 
@@ -138,7 +144,8 @@ pub async fn start_rpc_server_for_testing_empty_auth(
     init_gas_amounts: Vec<u64>,
     target_init_balance: u64,
 ) -> (TestCluster, GasStationContainer, GasStationServer) {
-    let (test_cluster, container) = start_gas_station(init_gas_amounts, target_init_balance).await;
+    let (test_cluster, container) =
+        start_gas_station(init_gas_amounts, target_init_balance, None).await;
     let localhost = localhost_for_testing();
     let signer_address = container.get_signer_address();
     std::env::set_var(AUTH_ENV_NAME, "");
@@ -161,7 +168,8 @@ pub async fn start_rpc_server_for_testing_with_access_controller(
     target_init_balance: u64,
     access_controller: AccessController,
 ) -> (TestCluster, GasStationContainer, GasStationServer) {
-    let (test_cluster, container) = start_gas_station(init_gas_amounts, target_init_balance).await;
+    let (test_cluster, container) =
+        start_gas_station(init_gas_amounts, target_init_balance, None).await;
     let localhost = localhost_for_testing();
     let signer_address = container.get_signer_address();
     std::env::set_var(AUTH_ENV_NAME, "some secret");


### PR DESCRIPTION
## Description

Allows to set a max value for reservable gas budget instead of using a hard-coded value. 

This new config property is optional and the previously hard-coded value is still used as a default value, so existing configs don't have to be updated and behavior will not change unless the value is set to another value than the default one.

Closes #153.