### PR TITLE
fix: docker build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -24,11 +24,11 @@ RUN apt-get update && apt-get install -y clang lld
 FROM chef AS builder
 WORKDIR /iota
 
-COPY Cargo.toml ./
+COPY Cargo.toml Cargo.lock ./
 COPY src ./src
 ARG ENTRY_BINARY=iota-gas-station
 
-RUN xx-cargo build --release --target-dir ./build
+RUN xx-cargo build --locked --release --target-dir ./build
 RUN xx-verify "./build/$(xx-cargo --print-target-triple)/release/${ENTRY_BINARY}"
 
 # move binary to a location we can access it more easily in `FROM` command


### PR DESCRIPTION
## Description
Fixes the following error when building in docker: 

```
45.90 error: failed to select a version for the requirement `core2 = "^0.4.0"`
45.90   version 0.4.0 is yanked
45.90 location searched: crates.io index
45.90 required by package `multihash v0.17.0`
45.90     ... which satisfies dependency `multihash = "^0.17"` of package `multiaddr v0.17.0`
45.90     ... which satisfies dependency `multiaddr = "^0.17.0"` of package `iota-network-stack v1.20.1 (https://github.com/iotaledger/iota?tag=v1.20.1#4b42f54d)`
45.90     ... which satisfies git dependency `iota-network-stack` of package `iota-types v1.20.1 (https://github.com/iotaledger/iota?tag=v1.20.1#4b42f54d)`
45.90     ... which satisfies git dependency `iota-types` of package `iota-gas-station v0.5.0 (/iota)`
```