### PR TITLE
feat: Migrate fullnode communication to gRPC via iota-rust-sdk

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,6 +63,9 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # Pin v4.1.1
 
+      - name: iota-rust-sdk rev matches the monorepo
+        run: ./scripts/sync-sdk-rev.sh --check
+
       ## Uncomment the following lines to enable swap space if needed.
       # - name: Set Swap Space
       #   uses: pierotofy/set-swap-space@master

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1024,22 +1024,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "bigdecimal"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d6867f1565b3aad85681f1015055b087fcfd840d6aeee6eee7f2da317603695"
-dependencies = [
- "autocfg",
- "libm",
- "num-bigint 0.4.8",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
 name = "bin-version"
 version = "1.29.0-alpha"
-source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
+source = "git+https://github.com/iotaledger/iota?rev=066018d705bd3a1e29d5e9634a80adf693439587#066018d705bd3a1e29d5e9634a80adf693439587"
 dependencies = [
  "const-str 0.5.7",
  "git-version",
@@ -2469,20 +2456,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ed25519-zebra"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "775765289f7c6336c18d3d66127527820dd45ffd9eb3b6b8ee4708590e6c20f5"
-dependencies = [
- "curve25519-dalek",
- "ed25519",
- "rand_core 0.6.4",
- "sha2 0.10.9",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "either"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2535,7 +2508,7 @@ dependencies = [
 [[package]]
 name = "enum-compat-util"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
+source = "git+https://github.com/iotaledger/iota?rev=066018d705bd3a1e29d5e9634a80adf693439587#066018d705bd3a1e29d5e9634a80adf693439587"
 dependencies = [
  "serde_yaml 0.8.26",
 ]
@@ -3902,15 +3875,6 @@ dependencies = [
 
 [[package]]
 name = "impl-codec"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba6a270039626615617f3f36d15fc827041df3b78c439da2cadfa47455a77f2f"
-dependencies = [
- "parity-scale-codec 3.7.5",
-]
-
-[[package]]
-name = "impl-codec"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d40b9d5e17727407e55028eafc22b2dc68781786e6d7eb8a21103f5058e3a14"
@@ -3923,15 +3887,6 @@ name = "impl-serde"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4551f042f3438e64dbd6226b20527fc84a6e1fe65688b58746a2f53623f25f5c"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "impl-serde"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc88fc67028ae3db0c853baa36269d398d5f45b6982f95549ff5def78c935cd"
 dependencies = [
  "serde",
 ]
@@ -4074,7 +4029,7 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 [[package]]
 name = "iota-adapter-latest"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
+source = "git+https://github.com/iotaledger/iota?rev=066018d705bd3a1e29d5e9634a80adf693439587#066018d705bd3a1e29d5e9634a80adf693439587"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4104,7 +4059,7 @@ dependencies = [
 [[package]]
 name = "iota-authority-aggregation"
 version = "1.29.0-alpha"
-source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
+source = "git+https://github.com/iotaledger/iota?rev=066018d705bd3a1e29d5e9634a80adf693439587#066018d705bd3a1e29d5e9634a80adf693439587"
 dependencies = [
  "futures",
  "iota-metrics",
@@ -4116,7 +4071,7 @@ dependencies = [
 [[package]]
 name = "iota-common"
 version = "1.29.0-alpha"
-source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
+source = "git+https://github.com/iotaledger/iota?rev=066018d705bd3a1e29d5e9634a80adf693439587#066018d705bd3a1e29d5e9634a80adf693439587"
 dependencies = [
  "futures",
  "getrandom 0.2.17",
@@ -4133,7 +4088,7 @@ dependencies = [
 [[package]]
 name = "iota-config"
 version = "1.29.0-alpha"
-source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
+source = "git+https://github.com/iotaledger/iota?rev=066018d705bd3a1e29d5e9634a80adf693439587#066018d705bd3a1e29d5e9634a80adf693439587"
 dependencies = [
  "anemo",
  "anyhow",
@@ -4165,7 +4120,7 @@ dependencies = [
 [[package]]
 name = "iota-core"
 version = "1.29.0-alpha"
-source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
+source = "git+https://github.com/iotaledger/iota?rev=066018d705bd3a1e29d5e9634a80adf693439587#066018d705bd3a1e29d5e9634a80adf693439587"
 dependencies = [
  "anemo",
  "anyhow",
@@ -4245,22 +4200,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "iota-crypto"
-version = "0.23.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98a38db844c910d78825e173c083f2ef416b69cb091bba8ac1055763c6db065b"
-dependencies = [
- "autocfg",
- "blake2",
- "digest 0.10.7",
- "ed25519-zebra",
- "zeroize",
-]
-
-[[package]]
 name = "iota-data-ingestion-core"
 version = "1.29.0-alpha"
-source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
+source = "git+https://github.com/iotaledger/iota?rev=066018d705bd3a1e29d5e9634a80adf693439587#066018d705bd3a1e29d5e9634a80adf693439587"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4296,7 +4238,7 @@ dependencies = [
 [[package]]
 name = "iota-enum-compat-util"
 version = "1.29.0-alpha"
-source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
+source = "git+https://github.com/iotaledger/iota?rev=066018d705bd3a1e29d5e9634a80adf693439587#066018d705bd3a1e29d5e9634a80adf693439587"
 dependencies = [
  "serde_yaml 0.8.26",
 ]
@@ -4304,7 +4246,7 @@ dependencies = [
 [[package]]
 name = "iota-execution"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
+source = "git+https://github.com/iotaledger/iota?rev=066018d705bd3a1e29d5e9634a80adf693439587#066018d705bd3a1e29d5e9634a80adf693439587"
 dependencies = [
  "iota-adapter-latest",
  "iota-move-natives-latest",
@@ -4328,7 +4270,7 @@ source = "git+https://github.com/iotaledger/flamegraph-svg?rev=ba681350dc9a72c9b
 [[package]]
 name = "iota-framework"
 version = "1.29.0-alpha"
-source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
+source = "git+https://github.com/iotaledger/iota?rev=066018d705bd3a1e29d5e9634a80adf693439587#066018d705bd3a1e29d5e9634a80adf693439587"
 dependencies = [
  "bcs",
  "iota-sdk-types",
@@ -4342,7 +4284,7 @@ dependencies = [
 [[package]]
 name = "iota-framework-snapshot"
 version = "1.29.0-alpha"
-source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
+source = "git+https://github.com/iotaledger/iota?rev=066018d705bd3a1e29d5e9634a80adf693439587#066018d705bd3a1e29d5e9634a80adf693439587"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4415,63 +4357,33 @@ dependencies = [
 [[package]]
 name = "iota-genesis-builder"
 version = "1.29.0-alpha"
-source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
+source = "git+https://github.com/iotaledger/iota?rev=066018d705bd3a1e29d5e9634a80adf693439587#066018d705bd3a1e29d5e9634a80adf693439587"
 dependencies = [
  "anyhow",
  "bcs",
- "bigdecimal",
  "camino",
- "clap",
- "csv",
  "fastcrypto",
- "flate2",
- "hex",
- "iota-adapter-latest",
  "iota-config",
  "iota-execution",
  "iota-framework",
  "iota-framework-snapshot",
  "iota-genesis-common",
- "iota-move-build",
- "iota-move-natives-latest",
  "iota-protocol-config",
  "iota-sdk-types",
- "iota-simulator",
- "iota-stardust-types",
  "iota-types",
- "itertools 0.13.0",
  "move-binary-format",
- "move-compiler",
  "move-core-types",
- "move-docgen",
- "move-package",
- "move-vm-runtime",
- "num-rational",
- "packable",
- "prefix-hex",
- "primitive-types 0.12.2",
  "prometheus-filtered",
- "rand 0.8.7",
- "rand_pcg 0.3.1",
- "rand_seeder",
- "regex",
- "reqwest 0.12.28",
  "serde",
- "serde_json",
  "serde_with",
  "serde_yaml 0.8.26",
- "tempfile",
- "thiserror 1.0.69",
- "tokio",
  "tracing",
- "tracing-subscriber",
- "url",
 ]
 
 [[package]]
 name = "iota-genesis-common"
 version = "1.29.0-alpha"
-source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
+source = "git+https://github.com/iotaledger/iota?rev=066018d705bd3a1e29d5e9634a80adf693439587#066018d705bd3a1e29d5e9634a80adf693439587"
 dependencies = [
  "iota-execution",
  "iota-protocol-config",
@@ -4483,7 +4395,7 @@ dependencies = [
 [[package]]
 name = "iota-grpc-server"
 version = "1.29.0-alpha"
-source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
+source = "git+https://github.com/iotaledger/iota?rev=066018d705bd3a1e29d5e9634a80adf693439587#066018d705bd3a1e29d5e9634a80adf693439587"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -4517,7 +4429,7 @@ dependencies = [
 [[package]]
 name = "iota-http"
 version = "1.29.0-alpha"
-source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
+source = "git+https://github.com/iotaledger/iota?rev=066018d705bd3a1e29d5e9634a80adf693439587#066018d705bd3a1e29d5e9634a80adf693439587"
 dependencies = [
  "bytes",
  "http 1.4.2",
@@ -4538,7 +4450,7 @@ dependencies = [
 [[package]]
 name = "iota-json"
 version = "1.29.0-alpha"
-source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
+source = "git+https://github.com/iotaledger/iota?rev=066018d705bd3a1e29d5e9634a80adf693439587#066018d705bd3a1e29d5e9634a80adf693439587"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4556,7 +4468,7 @@ dependencies = [
 [[package]]
 name = "iota-json-rpc"
 version = "1.29.0-alpha"
-source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
+source = "git+https://github.com/iotaledger/iota?rev=066018d705bd3a1e29d5e9634a80adf693439587#066018d705bd3a1e29d5e9634a80adf693439587"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4610,7 +4522,7 @@ dependencies = [
 [[package]]
 name = "iota-json-rpc-api"
 version = "1.29.0-alpha"
-source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
+source = "git+https://github.com/iotaledger/iota?rev=066018d705bd3a1e29d5e9634a80adf693439587#066018d705bd3a1e29d5e9634a80adf693439587"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -4631,7 +4543,7 @@ dependencies = [
 [[package]]
 name = "iota-json-rpc-types"
 version = "1.29.0-alpha"
-source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
+source = "git+https://github.com/iotaledger/iota?rev=066018d705bd3a1e29d5e9634a80adf693439587#066018d705bd3a1e29d5e9634a80adf693439587"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4668,7 +4580,7 @@ dependencies = [
 [[package]]
 name = "iota-keys"
 version = "1.29.0-alpha"
-source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
+source = "git+https://github.com/iotaledger/iota?rev=066018d705bd3a1e29d5e9634a80adf693439587#066018d705bd3a1e29d5e9634a80adf693439587"
 dependencies = [
  "anyhow",
  "bip32",
@@ -4690,7 +4602,7 @@ dependencies = [
 [[package]]
 name = "iota-macros"
 version = "1.29.0-alpha"
-source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
+source = "git+https://github.com/iotaledger/iota?rev=066018d705bd3a1e29d5e9634a80adf693439587#066018d705bd3a1e29d5e9634a80adf693439587"
 dependencies = [
  "futures",
  "iota-proc-macros",
@@ -4701,7 +4613,7 @@ dependencies = [
 [[package]]
 name = "iota-mainnet-unlocks"
 version = "1.29.0-alpha"
-source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
+source = "git+https://github.com/iotaledger/iota?rev=066018d705bd3a1e29d5e9634a80adf693439587#066018d705bd3a1e29d5e9634a80adf693439587"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4714,7 +4626,7 @@ dependencies = [
 [[package]]
 name = "iota-metrics"
 version = "1.29.0-alpha"
-source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
+source = "git+https://github.com/iotaledger/iota?rev=066018d705bd3a1e29d5e9634a80adf693439587#066018d705bd3a1e29d5e9634a80adf693439587"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -4742,7 +4654,7 @@ dependencies = [
 [[package]]
 name = "iota-metrics-push-client"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
+source = "git+https://github.com/iotaledger/iota?rev=066018d705bd3a1e29d5e9634a80adf693439587#066018d705bd3a1e29d5e9634a80adf693439587"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -4759,7 +4671,7 @@ dependencies = [
 [[package]]
 name = "iota-move-build"
 version = "1.29.0-alpha"
-source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
+source = "git+https://github.com/iotaledger/iota?rev=066018d705bd3a1e29d5e9634a80adf693439587#066018d705bd3a1e29d5e9634a80adf693439587"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -4782,7 +4694,7 @@ dependencies = [
 [[package]]
 name = "iota-move-natives-latest"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
+source = "git+https://github.com/iotaledger/iota?rev=066018d705bd3a1e29d5e9634a80adf693439587#066018d705bd3a1e29d5e9634a80adf693439587"
 dependencies = [
  "bcs",
  "better_any",
@@ -4807,7 +4719,7 @@ dependencies = [
 [[package]]
 name = "iota-names"
 version = "1.29.0-alpha"
-source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
+source = "git+https://github.com/iotaledger/iota?rev=066018d705bd3a1e29d5e9634a80adf693439587#066018d705bd3a1e29d5e9634a80adf693439587"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4820,7 +4732,7 @@ dependencies = [
 [[package]]
 name = "iota-network"
 version = "1.29.0-alpha"
-source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
+source = "git+https://github.com/iotaledger/iota?rev=066018d705bd3a1e29d5e9634a80adf693439587#066018d705bd3a1e29d5e9634a80adf693439587"
 dependencies = [
  "anemo",
  "anemo-build",
@@ -4861,7 +4773,7 @@ dependencies = [
 [[package]]
 name = "iota-network-stack"
 version = "1.29.0-alpha"
-source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
+source = "git+https://github.com/iotaledger/iota?rev=066018d705bd3a1e29d5e9634a80adf693439587#066018d705bd3a1e29d5e9634a80adf693439587"
 dependencies = [
  "anemo",
  "bcs",
@@ -4891,7 +4803,7 @@ dependencies = [
 [[package]]
 name = "iota-node"
 version = "1.29.0-alpha"
-source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
+source = "git+https://github.com/iotaledger/iota?rev=066018d705bd3a1e29d5e9634a80adf693439587#066018d705bd3a1e29d5e9634a80adf693439587"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -4943,7 +4855,7 @@ dependencies = [
 [[package]]
 name = "iota-node-storage"
 version = "1.29.0-alpha"
-source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
+source = "git+https://github.com/iotaledger/iota?rev=066018d705bd3a1e29d5e9634a80adf693439587#066018d705bd3a1e29d5e9634a80adf693439587"
 dependencies = [
  "iota-sdk-types",
  "iota-types",
@@ -4953,7 +4865,7 @@ dependencies = [
 [[package]]
 name = "iota-open-rpc"
 version = "1.29.0-alpha"
-source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
+source = "git+https://github.com/iotaledger/iota?rev=066018d705bd3a1e29d5e9634a80adf693439587#066018d705bd3a1e29d5e9634a80adf693439587"
 dependencies = [
  "schemars 0.8.22",
  "serde",
@@ -4964,7 +4876,7 @@ dependencies = [
 [[package]]
 name = "iota-open-rpc-macros"
 version = "1.29.0-alpha"
-source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
+source = "git+https://github.com/iotaledger/iota?rev=066018d705bd3a1e29d5e9634a80adf693439587#066018d705bd3a1e29d5e9634a80adf693439587"
 dependencies = [
  "derive-syn-parse",
  "itertools 0.13.0",
@@ -4977,7 +4889,7 @@ dependencies = [
 [[package]]
 name = "iota-package-management"
 version = "1.29.0-alpha"
-source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
+source = "git+https://github.com/iotaledger/iota?rev=066018d705bd3a1e29d5e9634a80adf693439587#066018d705bd3a1e29d5e9634a80adf693439587"
 dependencies = [
  "anyhow",
  "iota-framework-snapshot",
@@ -4993,7 +4905,7 @@ dependencies = [
 [[package]]
 name = "iota-package-resolver"
 version = "1.29.0-alpha"
-source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
+source = "git+https://github.com/iotaledger/iota?rev=066018d705bd3a1e29d5e9634a80adf693439587#066018d705bd3a1e29d5e9634a80adf693439587"
 dependencies = [
  "async-trait",
  "bcs",
@@ -5009,7 +4921,7 @@ dependencies = [
 [[package]]
 name = "iota-proc-macros"
 version = "1.29.0-alpha"
-source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
+source = "git+https://github.com/iotaledger/iota?rev=066018d705bd3a1e29d5e9634a80adf693439587#066018d705bd3a1e29d5e9634a80adf693439587"
 dependencies = [
  "msim-macros",
  "proc-macro2",
@@ -5020,7 +4932,7 @@ dependencies = [
 [[package]]
 name = "iota-protocol-config"
 version = "1.29.0-alpha"
-source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
+source = "git+https://github.com/iotaledger/iota?rev=066018d705bd3a1e29d5e9634a80adf693439587#066018d705bd3a1e29d5e9634a80adf693439587"
 dependencies = [
  "clap",
  "iota-protocol-config-macros",
@@ -5035,7 +4947,7 @@ dependencies = [
 [[package]]
 name = "iota-protocol-config-macros"
 version = "1.29.0-alpha"
-source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
+source = "git+https://github.com/iotaledger/iota?rev=066018d705bd3a1e29d5e9634a80adf693439587#066018d705bd3a1e29d5e9634a80adf693439587"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5045,7 +4957,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk"
 version = "1.29.0-alpha"
-source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
+source = "git+https://github.com/iotaledger/iota?rev=066018d705bd3a1e29d5e9634a80adf693439587#066018d705bd3a1e29d5e9634a80adf693439587"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5080,8 +4992,9 @@ dependencies = [
 [[package]]
 name = "iota-sdk-crypto"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=b77fcd5ac5fedb3dfbc77ba7d183140e43512339#b77fcd5ac5fedb3dfbc77ba7d183140e43512339"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=2f021d0556e47564e9b04bcd0b3e8347c41a0a26#2f021d0556e47564e9b04bcd0b3e8347c41a0a26"
 dependencies = [
+ "base64ct",
  "bech32 0.11.1",
  "fastcrypto",
  "iota-sdk-types",
@@ -5095,7 +5008,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-grpc-client"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=b77fcd5ac5fedb3dfbc77ba7d183140e43512339#b77fcd5ac5fedb3dfbc77ba7d183140e43512339"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=2f021d0556e47564e9b04bcd0b3e8347c41a0a26#2f021d0556e47564e9b04bcd0b3e8347c41a0a26"
 dependencies = [
  "async-stream",
  "base64 0.22.1",
@@ -5114,7 +5027,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-grpc-types"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=b77fcd5ac5fedb3dfbc77ba7d183140e43512339#b77fcd5ac5fedb3dfbc77ba7d183140e43512339"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=2f021d0556e47564e9b04bcd0b3e8347c41a0a26#2f021d0556e47564e9b04bcd0b3e8347c41a0a26"
 dependencies = [
  "bcs",
  "iota-sdk-types",
@@ -5130,7 +5043,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-transaction-builder"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=b77fcd5ac5fedb3dfbc77ba7d183140e43512339#b77fcd5ac5fedb3dfbc77ba7d183140e43512339"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=2f021d0556e47564e9b04bcd0b3e8347c41a0a26#2f021d0556e47564e9b04bcd0b3e8347c41a0a26"
 dependencies = [
  "base64ct",
  "bcs",
@@ -5149,7 +5062,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-types"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=b77fcd5ac5fedb3dfbc77ba7d183140e43512339#b77fcd5ac5fedb3dfbc77ba7d183140e43512339"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=2f021d0556e47564e9b04bcd0b3e8347c41a0a26#2f021d0556e47564e9b04bcd0b3e8347c41a0a26"
 dependencies = [
  "base64ct",
  "bcs",
@@ -5176,7 +5089,7 @@ dependencies = [
 [[package]]
 name = "iota-simulator"
 version = "1.29.0-alpha"
-source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
+source = "git+https://github.com/iotaledger/iota?rev=066018d705bd3a1e29d5e9634a80adf693439587#066018d705bd3a1e29d5e9634a80adf693439587"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -5199,7 +5112,7 @@ dependencies = [
 [[package]]
 name = "iota-snapshot"
 version = "1.29.0-alpha"
-source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
+source = "git+https://github.com/iotaledger/iota?rev=066018d705bd3a1e29d5e9634a80adf693439587#066018d705bd3a1e29d5e9634a80adf693439587"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5225,27 +5138,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "iota-stardust-types"
-version = "1.29.0-alpha"
-source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
-dependencies = [
- "bech32 0.9.1",
- "bitflags 2.13.1",
- "derive_more 1.0.0",
- "getset",
- "iota-crypto",
- "iterator-sorted",
- "packable",
- "prefix-hex",
- "primitive-types 0.12.2",
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "iota-storage"
 version = "1.29.0-alpha"
-source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
+source = "git+https://github.com/iotaledger/iota?rev=066018d705bd3a1e29d5e9634a80adf693439587#066018d705bd3a1e29d5e9634a80adf693439587"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5295,7 +5190,7 @@ dependencies = [
 [[package]]
 name = "iota-swarm"
 version = "1.29.0-alpha"
-source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
+source = "git+https://github.com/iotaledger/iota?rev=066018d705bd3a1e29d5e9634a80adf693439587#066018d705bd3a1e29d5e9634a80adf693439587"
 dependencies = [
  "anyhow",
  "futures",
@@ -5323,7 +5218,7 @@ dependencies = [
 [[package]]
 name = "iota-swarm-config"
 version = "1.29.0-alpha"
-source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
+source = "git+https://github.com/iotaledger/iota?rev=066018d705bd3a1e29d5e9634a80adf693439587#066018d705bd3a1e29d5e9634a80adf693439587"
 dependencies = [
  "anemo",
  "anyhow",
@@ -5349,7 +5244,7 @@ dependencies = [
 [[package]]
 name = "iota-test-transaction-builder"
 version = "1.29.0-alpha"
-source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
+source = "git+https://github.com/iotaledger/iota?rev=066018d705bd3a1e29d5e9634a80adf693439587#066018d705bd3a1e29d5e9634a80adf693439587"
 dependencies = [
  "iota-genesis-builder",
  "iota-move-build",
@@ -5365,7 +5260,7 @@ dependencies = [
 [[package]]
 name = "iota-tls"
 version = "1.29.0-alpha"
-source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
+source = "git+https://github.com/iotaledger/iota?rev=066018d705bd3a1e29d5e9634a80adf693439587#066018d705bd3a1e29d5e9634a80adf693439587"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -5387,7 +5282,7 @@ dependencies = [
 [[package]]
 name = "iota-transaction-builder"
 version = "1.29.0-alpha"
-source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
+source = "git+https://github.com/iotaledger/iota?rev=066018d705bd3a1e29d5e9634a80adf693439587#066018d705bd3a1e29d5e9634a80adf693439587"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5404,7 +5299,7 @@ dependencies = [
 [[package]]
 name = "iota-transaction-checks"
 version = "1.29.0-alpha"
-source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
+source = "git+https://github.com/iotaledger/iota?rev=066018d705bd3a1e29d5e9634a80adf693439587#066018d705bd3a1e29d5e9634a80adf693439587"
 dependencies = [
  "iota-config",
  "iota-execution",
@@ -5418,7 +5313,7 @@ dependencies = [
 [[package]]
 name = "iota-types"
 version = "1.29.0-alpha"
-source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
+source = "git+https://github.com/iotaledger/iota?rev=066018d705bd3a1e29d5e9634a80adf693439587#066018d705bd3a1e29d5e9634a80adf693439587"
 dependencies = [
  "anemo",
  "anyhow",
@@ -5475,7 +5370,7 @@ dependencies = [
 [[package]]
 name = "iota-verifier-latest"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
+source = "git+https://github.com/iotaledger/iota?rev=066018d705bd3a1e29d5e9634a80adf693439587#066018d705bd3a1e29d5e9634a80adf693439587"
 dependencies = [
  "bcs",
  "iota-sdk-types",
@@ -5500,12 +5395,6 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
-
-[[package]]
-name = "iterator-sorted"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed3c1d66191fc266439b989dc1a9a69d9c4156e803ce456221231398b84c35d1"
 
 [[package]]
 name = "itertools"
@@ -6252,7 +6141,7 @@ dependencies = [
 [[package]]
 name = "move-abstract-interpreter"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
+source = "git+https://github.com/iotaledger/iota?rev=066018d705bd3a1e29d5e9634a80adf693439587#066018d705bd3a1e29d5e9634a80adf693439587"
 dependencies = [
  "move-binary-format",
  "move-bytecode-verifier-meter",
@@ -6261,12 +6150,12 @@ dependencies = [
 [[package]]
 name = "move-abstract-stack"
 version = "0.0.1"
-source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
+source = "git+https://github.com/iotaledger/iota?rev=066018d705bd3a1e29d5e9634a80adf693439587#066018d705bd3a1e29d5e9634a80adf693439587"
 
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
+source = "git+https://github.com/iotaledger/iota?rev=066018d705bd3a1e29d5e9634a80adf693439587#066018d705bd3a1e29d5e9634a80adf693439587"
 dependencies = [
  "anyhow",
  "indexmap 2.14.0",
@@ -6279,12 +6168,12 @@ dependencies = [
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
+source = "git+https://github.com/iotaledger/iota?rev=066018d705bd3a1e29d5e9634a80adf693439587#066018d705bd3a1e29d5e9634a80adf693439587"
 
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
+source = "git+https://github.com/iotaledger/iota?rev=066018d705bd3a1e29d5e9634a80adf693439587#066018d705bd3a1e29d5e9634a80adf693439587"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6300,7 +6189,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
+source = "git+https://github.com/iotaledger/iota?rev=066018d705bd3a1e29d5e9634a80adf693439587#066018d705bd3a1e29d5e9634a80adf693439587"
 dependencies = [
  "anyhow",
  "indexmap 2.14.0",
@@ -6313,7 +6202,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
+source = "git+https://github.com/iotaledger/iota?rev=066018d705bd3a1e29d5e9634a80adf693439587#066018d705bd3a1e29d5e9634a80adf693439587"
 dependencies = [
  "move-abstract-interpreter",
  "move-abstract-stack",
@@ -6329,7 +6218,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier-meter"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
+source = "git+https://github.com/iotaledger/iota?rev=066018d705bd3a1e29d5e9634a80adf693439587#066018d705bd3a1e29d5e9634a80adf693439587"
 dependencies = [
  "move-binary-format",
  "move-core-types",
@@ -6339,7 +6228,7 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
+source = "git+https://github.com/iotaledger/iota?rev=066018d705bd3a1e29d5e9634a80adf693439587#066018d705bd3a1e29d5e9634a80adf693439587"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6359,7 +6248,7 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
+source = "git+https://github.com/iotaledger/iota?rev=066018d705bd3a1e29d5e9634a80adf693439587#066018d705bd3a1e29d5e9634a80adf693439587"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6392,7 +6281,7 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
+source = "git+https://github.com/iotaledger/iota?rev=066018d705bd3a1e29d5e9634a80adf693439587#066018d705bd3a1e29d5e9634a80adf693439587"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6416,7 +6305,7 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
+source = "git+https://github.com/iotaledger/iota?rev=066018d705bd3a1e29d5e9634a80adf693439587#066018d705bd3a1e29d5e9634a80adf693439587"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6437,7 +6326,7 @@ dependencies = [
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
+source = "git+https://github.com/iotaledger/iota?rev=066018d705bd3a1e29d5e9634a80adf693439587#066018d705bd3a1e29d5e9634a80adf693439587"
 dependencies = [
  "anyhow",
  "clap",
@@ -6457,7 +6346,7 @@ dependencies = [
 [[package]]
 name = "move-docgen"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
+source = "git+https://github.com/iotaledger/iota?rev=066018d705bd3a1e29d5e9634a80adf693439587#066018d705bd3a1e29d5e9634a80adf693439587"
 dependencies = [
  "anyhow",
  "clap",
@@ -6477,7 +6366,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
+source = "git+https://github.com/iotaledger/iota?rev=066018d705bd3a1e29d5e9634a80adf693439587#066018d705bd3a1e29d5e9634a80adf693439587"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -6495,7 +6384,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
+source = "git+https://github.com/iotaledger/iota?rev=066018d705bd3a1e29d5e9634a80adf693439587#066018d705bd3a1e29d5e9634a80adf693439587"
 dependencies = [
  "anyhow",
  "hex",
@@ -6508,7 +6397,7 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
+source = "git+https://github.com/iotaledger/iota?rev=066018d705bd3a1e29d5e9634a80adf693439587#066018d705bd3a1e29d5e9634a80adf693439587"
 dependencies = [
  "hex",
  "move-command-line-common",
@@ -6521,7 +6410,7 @@ dependencies = [
 [[package]]
 name = "move-model-2"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
+source = "git+https://github.com/iotaledger/iota?rev=066018d705bd3a1e29d5e9634a80adf693439587#066018d705bd3a1e29d5e9634a80adf693439587"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6537,7 +6426,7 @@ dependencies = [
 [[package]]
 name = "move-package"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
+source = "git+https://github.com/iotaledger/iota?rev=066018d705bd3a1e29d5e9634a80adf693439587#066018d705bd3a1e29d5e9634a80adf693439587"
 dependencies = [
  "anyhow",
  "clap",
@@ -6573,7 +6462,7 @@ dependencies = [
 [[package]]
 name = "move-proc-macros"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
+source = "git+https://github.com/iotaledger/iota?rev=066018d705bd3a1e29d5e9634a80adf693439587#066018d705bd3a1e29d5e9634a80adf693439587"
 dependencies = [
  "quote",
  "syn 2.0.119",
@@ -6582,7 +6471,7 @@ dependencies = [
 [[package]]
 name = "move-regex-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
+source = "git+https://github.com/iotaledger/iota?rev=066018d705bd3a1e29d5e9634a80adf693439587#066018d705bd3a1e29d5e9634a80adf693439587"
 dependencies = [
  "move-binary-format",
  "move-core-types",
@@ -6592,7 +6481,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib-natives"
 version = "0.1.1"
-source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
+source = "git+https://github.com/iotaledger/iota?rev=066018d705bd3a1e29d5e9634a80adf693439587#066018d705bd3a1e29d5e9634a80adf693439587"
 dependencies = [
  "hex",
  "move-binary-format",
@@ -6607,7 +6496,7 @@ dependencies = [
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
+source = "git+https://github.com/iotaledger/iota?rev=066018d705bd3a1e29d5e9634a80adf693439587#066018d705bd3a1e29d5e9634a80adf693439587"
 dependencies = [
  "once_cell",
  "phf 0.11.3",
@@ -6617,7 +6506,7 @@ dependencies = [
 [[package]]
 name = "move-trace-format"
 version = "0.0.1"
-source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
+source = "git+https://github.com/iotaledger/iota?rev=066018d705bd3a1e29d5e9634a80adf693439587#066018d705bd3a1e29d5e9634a80adf693439587"
 dependencies = [
  "move-binary-format",
  "move-core-types",
@@ -6628,7 +6517,7 @@ dependencies = [
 [[package]]
 name = "move-vm-config"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
+source = "git+https://github.com/iotaledger/iota?rev=066018d705bd3a1e29d5e9634a80adf693439587#066018d705bd3a1e29d5e9634a80adf693439587"
 dependencies = [
  "move-binary-format",
  "once_cell",
@@ -6637,7 +6526,7 @@ dependencies = [
 [[package]]
 name = "move-vm-profiler"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
+source = "git+https://github.com/iotaledger/iota?rev=066018d705bd3a1e29d5e9634a80adf693439587#066018d705bd3a1e29d5e9634a80adf693439587"
 dependencies = [
  "move-vm-config",
  "serde",
@@ -6646,7 +6535,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
+source = "git+https://github.com/iotaledger/iota?rev=066018d705bd3a1e29d5e9634a80adf693439587#066018d705bd3a1e29d5e9634a80adf693439587"
 dependencies = [
  "better_any",
  "fail",
@@ -6666,7 +6555,7 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
+source = "git+https://github.com/iotaledger/iota?rev=066018d705bd3a1e29d5e9634a80adf693439587#066018d705bd3a1e29d5e9634a80adf693439587"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -6680,7 +6569,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
+source = "git+https://github.com/iotaledger/iota?rev=066018d705bd3a1e29d5e9634a80adf693439587#066018d705bd3a1e29d5e9634a80adf693439587"
 dependencies = [
  "bcs",
  "move-binary-format",
@@ -7459,31 +7348,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "packable"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11259b086696fc9256f790485d8f14f11f0fa60a60351af9693e3d49fd24fdb6"
-dependencies = [
- "autocfg",
- "packable-derive",
- "primitive-types 0.12.2",
- "serde",
-]
-
-[[package]]
-name = "packable-derive"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9567693dd2f9a4339cb0a54adfcc0cb431c0ac88b2e46c6ddfb5f5d11a1cc4f"
-dependencies = [
- "proc-macro-crate 1.3.1",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "packed_struct"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7975,17 +7839,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prefix-hex"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f1799f398371ad6957951ec446d3ff322d35c46d9db2e217b67e828b311c249"
-dependencies = [
- "hex",
- "primitive-types 0.12.2",
- "uint 0.9.5",
-]
-
-[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8013,18 +7866,6 @@ dependencies = [
  "fixed-hash 0.7.0",
  "impl-codec 0.5.1",
  "impl-serde 0.3.2",
- "uint 0.9.5",
-]
-
-[[package]]
-name = "primitive-types"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b34d9fd68ae0b74a41b21c03c2f62847aa0ffea044eee893b4c140b37e244e2"
-dependencies = [
- "fixed-hash 0.8.0",
- "impl-codec 0.6.0",
- "impl-serde 0.4.0",
  "uint 0.9.5",
 ]
 
@@ -8123,7 +7964,7 @@ dependencies = [
 [[package]]
 name = "prometheus-closure-metric"
 version = "1.29.0-alpha"
-source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
+source = "git+https://github.com/iotaledger/iota?rev=066018d705bd3a1e29d5e9634a80adf693439587#066018d705bd3a1e29d5e9634a80adf693439587"
 dependencies = [
  "anyhow",
  "prometheus-filtered",
@@ -8132,7 +7973,7 @@ dependencies = [
 [[package]]
 name = "prometheus-filtered"
 version = "1.29.0-alpha"
-source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
+source = "git+https://github.com/iotaledger/iota?rev=066018d705bd3a1e29d5e9634a80adf693439587#066018d705bd3a1e29d5e9634a80adf693439587"
 dependencies = [
  "prometheus",
  "serde",
@@ -8331,7 +8172,7 @@ dependencies = [
  "getrandom 0.4.3",
  "lru-slab",
  "rand 0.10.2",
- "rand_pcg 0.10.2",
+ "rand_pcg",
  "ring",
  "rustc-hash 2.1.3",
  "rustls",
@@ -8519,29 +8360,11 @@ dependencies = [
 
 [[package]]
 name = "rand_pcg"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59cad018caf63deb318e5a4586d99a24424a364f40f1e5778c29aca23f4fc73e"
-dependencies = [
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_pcg"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
 dependencies = [
  "rand_core 0.10.1",
-]
-
-[[package]]
-name = "rand_seeder"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a9febe641d2842ffc76ee962668a17578767c4e01735e4802b21ed9a24b2e4e"
-dependencies = [
- "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -9834,7 +9657,7 @@ dependencies = [
 [[package]]
 name = "starfish-config"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
+source = "git+https://github.com/iotaledger/iota?rev=066018d705bd3a1e29d5e9634a80adf693439587#066018d705bd3a1e29d5e9634a80adf693439587"
 dependencies = [
  "blake3",
  "fastcrypto",
@@ -9849,7 +9672,7 @@ dependencies = [
 [[package]]
 name = "starfish-core"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
+source = "git+https://github.com/iotaledger/iota?rev=066018d705bd3a1e29d5e9634a80adf693439587#066018d705bd3a1e29d5e9634a80adf693439587"
 dependencies = [
  "ahash 0.8.12",
  "async-trait",
@@ -9862,6 +9685,7 @@ dependencies = [
  "eyre",
  "fastcrypto",
  "futures",
+ "hdrhistogram",
  "http 1.4.2",
  "iota-common",
  "iota-http",
@@ -10124,7 +9948,7 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 [[package]]
 name = "telemetry-subscribers"
 version = "1.29.0-alpha"
-source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
+source = "git+https://github.com/iotaledger/iota?rev=066018d705bd3a1e29d5e9634a80adf693439587#066018d705bd3a1e29d5e9634a80adf693439587"
 dependencies = [
  "atomic_float",
  "bytes",
@@ -10195,7 +10019,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 [[package]]
 name = "test-cluster"
 version = "1.29.0-alpha"
-source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
+source = "git+https://github.com/iotaledger/iota?rev=066018d705bd3a1e29d5e9634a80adf693439587#066018d705bd3a1e29d5e9634a80adf693439587"
 dependencies = [
  "anyhow",
  "fastcrypto-zkp",
@@ -10204,7 +10028,6 @@ dependencies = [
  "iota-config",
  "iota-core",
  "iota-framework",
- "iota-genesis-builder",
  "iota-json-rpc-api",
  "iota-json-rpc-types",
  "iota-keys",
@@ -10955,7 +10778,7 @@ dependencies = [
 [[package]]
 name = "typed-store"
 version = "1.29.0-alpha"
-source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
+source = "git+https://github.com/iotaledger/iota?rev=066018d705bd3a1e29d5e9634a80adf693439587#066018d705bd3a1e29d5e9634a80adf693439587"
 dependencies = [
  "backoff",
  "bcs",
@@ -10987,7 +10810,7 @@ dependencies = [
 [[package]]
 name = "typed-store-derive"
 version = "1.29.0-alpha"
-source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
+source = "git+https://github.com/iotaledger/iota?rev=066018d705bd3a1e29d5e9634a80adf693439587#066018d705bd3a1e29d5e9634a80adf693439587"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10997,7 +10820,7 @@ dependencies = [
 [[package]]
 name = "typed-store-error"
 version = "1.29.0-alpha"
-source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
+source = "git+https://github.com/iotaledger/iota?rev=066018d705bd3a1e29d5e9634a80adf693439587#066018d705bd3a1e29d5e9634a80adf693439587"
 dependencies = [
  "serde",
  "thiserror 1.0.69",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,7 +25,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "generic-array",
 ]
 
@@ -52,6 +52,32 @@ dependencies = [
  "ctr",
  "ghash",
  "subtle",
+]
+
+[[package]]
+name = "aes-gcm-siv"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae0784134ba9375416d469ec31e7c5f9fa94405049cf08c5ce5b4698be673e0d"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "polyval",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "ahash"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "version_check",
 ]
 
 [[package]]
@@ -101,7 +127,7 @@ dependencies = [
 [[package]]
 name = "anemo"
 version = "0.0.0"
-source = "git+https://github.com/mystenlabs/anemo.git?rev=c4e7e4cb4b624d7738c2016d7b7885c6774ff9c2#c4e7e4cb4b624d7738c2016d7b7885c6774ff9c2"
+source = "git+https://github.com/mystenlabs/anemo.git?rev=f8b708601d002a75955dafebae4f75628c6f42b4#f8b708601d002a75955dafebae4f75628c6f42b4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -110,13 +136,13 @@ dependencies = [
  "ed25519",
  "futures",
  "hex",
- "http 1.4.0",
+ "http 1.4.2",
  "matchit 0.5.0",
  "pin-project-lite",
- "pkcs8 0.10.2",
+ "pkcs8",
  "quinn",
  "quinn-proto",
- "rand 0.8.5",
+ "rand 0.8.7",
  "rcgen",
  "ring",
  "rustls",
@@ -127,7 +153,7 @@ dependencies = [
  "tap",
  "thiserror 1.0.69",
  "tokio",
- "tokio-util 0.7.18",
+ "tokio-util 0.7.19",
  "tower 0.4.13",
  "tracing",
  "x509-parser",
@@ -136,18 +162,18 @@ dependencies = [
 [[package]]
 name = "anemo-build"
 version = "0.0.0"
-source = "git+https://github.com/mystenlabs/anemo.git?rev=c4e7e4cb4b624d7738c2016d7b7885c6774ff9c2#c4e7e4cb4b624d7738c2016d7b7885c6774ff9c2"
+source = "git+https://github.com/mystenlabs/anemo.git?rev=f8b708601d002a75955dafebae4f75628c6f42b4#f8b708601d002a75955dafebae4f75628c6f42b4"
 dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "anemo-tower"
 version = "0.0.0"
-source = "git+https://github.com/mystenlabs/anemo.git?rev=c4e7e4cb4b624d7738c2016d7b7885c6774ff9c2#c4e7e4cb4b624d7738c2016d7b7885c6774ff9c2"
+source = "git+https://github.com/mystenlabs/anemo.git?rev=f8b708601d002a75955dafebae4f75628c6f42b4#f8b708601d002a75955dafebae4f75628c6f42b4"
 dependencies = [
  "anemo",
  "bytes",
@@ -214,9 +240,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "approx"
@@ -229,18 +255,18 @@ dependencies = [
 
 [[package]]
 name = "ar_archive_writer"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb93bbb63b9c227414f6eb3a0adfddca591a8ce1e9b60661bb08969b87e340b"
+checksum = "4087686b4b0a3427190bae57a1d9a478dbb2d40c5dc1bd6e2b6d797913bdd348"
 dependencies = [
  "object",
 ]
 
 [[package]]
 name = "arc-swap"
-version = "1.9.1"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
 dependencies = [
  "rustversion",
  "serde",
@@ -305,7 +331,7 @@ dependencies = [
  "derivative",
  "digest 0.10.7",
  "itertools 0.10.5",
- "num-bigint 0.4.6",
+ "num-bigint 0.4.8",
  "num-traits",
  "paste",
  "rustc_version",
@@ -328,7 +354,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
 dependencies = [
- "num-bigint 0.4.6",
+ "num-bigint 0.4.8",
  "num-traits",
  "proc-macro2",
  "quote",
@@ -375,6 +401,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-secp256k1"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c02e954eaeb4ddb29613fee20840c2bbc85ca4396d53e33837e11905363c5f2"
+dependencies = [
+ "ark-ec",
+ "ark-ff",
+ "ark-std",
+]
+
+[[package]]
 name = "ark-secp256r1"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -394,7 +431,7 @@ dependencies = [
  "ark-serialize-derive",
  "ark-std",
  "digest 0.10.7",
- "num-bigint 0.4.6",
+ "num-bigint 0.4.8",
 ]
 
 [[package]]
@@ -427,7 +464,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
 dependencies = [
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.7",
 ]
 
 [[package]]
@@ -438,23 +475,23 @@ checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.6"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
 name = "asn1-rs"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56624a96882bb8c26d61312ae18cb45868e5a9992ea73c58e45c3101e56a1e60"
+checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
 dependencies = [
  "asn1-rs-derive",
  "asn1-rs-impl",
  "displaydoc",
- "nom",
+ "nom 7.1.3",
  "num-traits",
  "rusticata-macros",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "time",
 ]
 
@@ -466,8 +503,8 @@ checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
- "synstructure 0.13.2",
+ "syn 2.0.119",
+ "synstructure",
 ]
 
 [[package]]
@@ -478,7 +515,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -567,7 +604,7 @@ version = "3.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
 dependencies = [
- "event-listener 5.4.1",
+ "event-listener 5.4.2",
  "event-listener-strategy",
  "pin-project-lite",
 ]
@@ -617,7 +654,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -628,13 +665,13 @@ checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
-version = "0.1.89"
+version = "0.1.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -663,9 +700,9 @@ checksum = "7460f7dd8e100147b82a63afca1a20eb6c231ee36b90ba7272e14951cb58af59"
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "axum"
@@ -710,8 +747,8 @@ dependencies = [
  "axum-core 0.4.5",
  "bytes",
  "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http 1.4.2",
+ "http-body 1.1.0",
  "http-body-util",
  "itoa",
  "matchit 0.7.3",
@@ -729,9 +766,9 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core 0.5.6",
  "axum-macros",
@@ -739,10 +776,10 @@ dependencies = [
  "bytes",
  "form_urlencoded",
  "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http 1.4.2",
+ "http-body 1.1.0",
  "http-body-util",
- "hyper 1.9.0",
+ "hyper 1.11.0",
  "hyper-util",
  "itoa",
  "matchit 0.8.4",
@@ -789,8 +826,8 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http 1.4.2",
+ "http-body 1.1.0",
  "http-body-util",
  "mime",
  "pin-project-lite",
@@ -808,8 +845,8 @@ checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http 1.4.2",
+ "http-body 1.1.0",
  "http-body-util",
  "mime",
  "pin-project-lite",
@@ -820,13 +857,13 @@ dependencies = [
 
 [[package]]
 name = "axum-macros"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "604fde5e028fea851ce1d8570bbdc034bec850d157f7569d10f347d06808c05c"
+checksum = "7aa268c23bfbbd2c4363b9cd302a4f504fb2a9dfe7e3451d66f35dd392e20aca"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -839,9 +876,9 @@ dependencies = [
  "bytes",
  "either",
  "fs-err",
- "http 1.4.0",
- "http-body 1.0.1",
- "hyper 1.9.0",
+ "http 1.4.2",
+ "http-body 1.1.0",
+ "hyper 1.11.0",
  "hyper-util",
  "pin-project-lite",
  "rustls",
@@ -861,7 +898,7 @@ dependencies = [
  "getrandom 0.2.17",
  "instant",
  "pin-project-lite",
- "rand 0.8.5",
+ "rand 0.8.7",
  "tokio",
 ]
 
@@ -886,6 +923,12 @@ dependencies = [
  "const-str 0.4.3",
  "match-lookup",
 ]
+
+[[package]]
+name = "base45"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240e56f4d3c453c36faacb695c535a4d5f8c7d23dac175014f32eb0a71012a03"
 
 [[package]]
 name = "base64"
@@ -929,6 +972,12 @@ name = "bech32"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
+
+[[package]]
+name = "bech32"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32637268377fc7b10a8c6d51de3e7fba1ce5dd371a96e342b34e6078db558e7f"
 
 [[package]]
 name = "bellpepper"
@@ -982,15 +1031,15 @@ checksum = "4d6867f1565b3aad85681f1015055b087fcfd840d6aeee6eee7f2da317603695"
 dependencies = [
  "autocfg",
  "libm",
- "num-bigint 0.4.6",
+ "num-bigint 0.4.8",
  "num-integer",
  "num-traits",
 ]
 
 [[package]]
 name = "bin-version"
-version = "1.20.1"
-source = "git+https://github.com/iotaledger/iota?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+version = "1.29.0-alpha"
+source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
 dependencies = [
  "const-str 0.5.7",
  "git-version",
@@ -1007,41 +1056,20 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.65.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfdf7b466f9a4903edc73f95d6d2bcd5baf8ae620638762244d3f60143643cc5"
-dependencies = [
- "bitflags 1.3.2",
- "cexpr",
- "clang-sys",
- "lazy_static",
- "lazycell",
- "peeking_take_while",
- "prettyplease",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash 1.1.0",
- "shlex",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "bindgen"
 version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash 2.1.2",
- "shlex",
- "syn 2.0.117",
+ "rustc-hash 2.1.3",
+ "shlex 1.3.0",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1101,9 +1129,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "bitmaps"
@@ -1128,9 +1156,9 @@ dependencies = [
 
 [[package]]
 name = "bitvec"
-version = "1.0.1"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+checksum = "ddcec3d12c579d40898fe0a9a358a803c23e9c52ca3c425707f81c9436211837"
 dependencies = [
  "funty 2.0.0",
  "radium 0.7.0",
@@ -1171,9 +1199,9 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "1.8.4"
+version = "1.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d2d5991425dfd0785aed03aedcf0b321d61975c9b5b3689c774a2610ae0b51e"
+checksum = "0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -1202,6 +1230,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "block-padding"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1225,9 +1262,9 @@ dependencies = [
 
 [[package]]
 name = "blst"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcdb4c7013139a150f9fc55d123186dbfaba0d912817466282c73ac49e71fb45"
+checksum = "c20659f9bbee16cbbd2f7393e40ab6309f5a98f76a2eb57a995ec508b72387fe"
 dependencies = [
  "cc",
  "glob",
@@ -1280,10 +1317,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "bumpalo"
-version = "3.20.2"
+name = "bulletproofs"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "012e2e5f88332083bd4235d445ae78081c00b2558443821a9ca5adfe1070073d"
+dependencies = [
+ "byteorder",
+ "clear_on_drop",
+ "curve25519-dalek",
+ "digest 0.10.7",
+ "group",
+ "merlin",
+ "rand 0.8.7",
+ "rand_core 0.6.4",
+ "serde",
+ "serde_derive",
+ "sha3 0.10.9",
+ "subtle",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "byte-slice-cast"
@@ -1299,9 +1357,9 @@ checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "bytemuck"
-version = "1.25.0"
+version = "1.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
 
 [[package]]
 name = "byteorder"
@@ -1311,9 +1369,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 dependencies = [
  "serde",
 ]
@@ -1323,6 +1381,15 @@ name = "bytes-varint"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e95ba58c659da9789048773ebecf5bd17fe7d3858b10f693bb579912f0d55ed"
+dependencies = [
+ "bytes",
+]
+
+[[package]]
+name = "bytestring"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86566c496f2f47d9b8147a4c8b02ffdb69c919fe0c2b2e7195d22cbba0e635c9"
 dependencies = [
  "bytes",
 ]
@@ -1377,9 +1444,9 @@ checksum = "ade8366b8bd5ba243f0a58f036cc0ca8a2f069cff1a2351ef1cac6b083e16fc0"
 
 [[package]]
 name = "camino"
-version = "1.2.2"
+version = "1.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
+checksum = "bb1307f12aa967b5a58416e87b3653360e0fd614a016b6e970db08fecbb1b80d"
 
 [[package]]
 name = "cbc"
@@ -1392,14 +1459,14 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.59"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
- "shlex",
+ "shlex 2.0.1",
 ]
 
 [[package]]
@@ -1414,7 +1481,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
- "nom",
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -1425,26 +1492,26 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -1497,7 +1564,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "inout",
 ]
 
@@ -1514,9 +1581,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1524,9 +1591,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1537,14 +1604,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1552,6 +1619,15 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "clear_on_drop"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38508a63f4979f0048febc9966fadbd48e5dab31fd0ec6a3f151bbf4a74f7423"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "codespan"
@@ -1607,7 +1683,7 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "tokio",
- "tokio-util 0.7.18",
+ "tokio-util 0.7.19",
 ]
 
 [[package]]
@@ -1620,71 +1696,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "consensus-config"
-version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
-dependencies = [
- "fastcrypto",
- "iota-network-stack",
- "iota-sdk-types",
- "rand 0.8.5",
- "serde",
- "tracing",
-]
-
-[[package]]
-name = "consensus-core"
-version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
-dependencies = [
- "async-trait",
- "base64 0.21.7",
- "bcs",
- "bytes",
- "cfg-if",
- "consensus-config",
- "enum_dispatch",
- "fastcrypto",
- "futures",
- "http 1.4.0",
- "iota-common",
- "iota-http",
- "iota-macros",
- "iota-metrics",
- "iota-network-stack",
- "iota-protocol-config",
- "iota-sdk-types",
- "iota-tls",
- "itertools 0.13.0",
- "lru",
- "nom",
- "parking_lot 0.12.5",
- "prometheus",
- "prost 0.14.3",
- "rand 0.8.5",
- "serde",
- "strum_macros 0.27.2",
- "tap",
- "thiserror 1.0.69",
- "tokio",
- "tokio-rustls",
- "tokio-stream",
- "tokio-util 0.7.18",
- "tonic 0.14.5",
- "tonic-build",
- "tonic-prost",
- "tonic-rustls",
- "tower 0.4.13",
- "tower-http 0.5.2",
- "tracing",
- "typed-store",
-]
-
-[[package]]
 name = "console"
-version = "0.16.3"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+checksum = "4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c"
 dependencies = [
  "encode_unicode",
  "libc",
@@ -1738,6 +1753,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "const-str"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1751,11 +1772,12 @@ checksum = "3618cccc083bb987a415d85c02ca6c9994ea5b44731ec28b9ecf09658655fba9"
 
 [[package]]
 name = "const_format"
-version = "0.2.35"
+version = "0.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7faa7469a93a566e9ccc1c73fe783b4a65c274c5ace346038dca9c39fe0030ad"
+checksum = "4481a617ad9a412be3b97c5d403fef8ed023103368908b9c50af598ff467cc1e"
 dependencies = [
  "const_format_proc_macros",
+ "konst",
 ]
 
 [[package]]
@@ -1780,6 +1802,15 @@ name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "core-foundation"
@@ -1808,15 +1839,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
-name = "core2"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "coset"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1832,7 +1854,7 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fef0a447ef2e9e6bd57e379f88702c58c4a4253ba82fb175bd7db012192311a"
 dependencies = [
- "rand 0.8.5",
+ "rand 0.8.7",
  "siphasher",
 ]
 
@@ -1865,18 +1887,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.15"
+version = "0.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -1884,18 +1906,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crossterm"
@@ -1952,6 +1974,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "csv"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1992,7 +2023,10 @@ dependencies = [
  "curve25519-dalek-derive",
  "digest 0.10.7",
  "fiat-crypto",
+ "group",
+ "rand_core 0.6.4",
  "rustc_version",
+ "serde",
  "subtle",
  "zeroize",
 ]
@@ -2005,7 +2039,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2065,7 +2099,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2087,7 +2121,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core 0.23.0",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2105,15 +2139,15 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "data-encoding-macro"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8142a83c17aa9461d637e649271eae18bf2edd00e91f2e105df36c3c16355bdb"
+checksum = "3259c913752a86488b501ed8680446a5ed2d5aeac6e596cb23ba3800768ea32c"
 dependencies = [
  "data-encoding",
  "data-encoding-macro-internal",
@@ -2121,12 +2155,12 @@ dependencies = [
 
 [[package]]
 name = "data-encoding-macro-internal"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
+checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2149,23 +2183,12 @@ checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
 name = "der"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
-dependencies = [
- "const-oid",
- "pem-rfc7468 0.6.0",
- "zeroize",
-]
-
-[[package]]
-name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
- "pem-rfc7468 0.7.0",
+ "const-oid 0.9.6",
+ "pem-rfc7468",
  "zeroize",
 ]
 
@@ -2177,8 +2200,8 @@ checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
 dependencies = [
  "asn1-rs",
  "displaydoc",
- "nom",
- "num-bigint 0.4.6",
+ "nom 7.1.3",
+ "num-bigint 0.4.8",
  "num-traits",
  "rusticata-macros",
 ]
@@ -2189,7 +2212,6 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
- "powerfmt",
  "serde_core",
 ]
 
@@ -2221,11 +2243,11 @@ version = "0.99.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
 dependencies = [
- "convert_case",
+ "convert_case 0.4.0",
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2234,7 +2256,16 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
 dependencies = [
- "derive_more-impl",
+ "derive_more-impl 1.0.0",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl 2.1.1",
 ]
 
 [[package]]
@@ -2245,7 +2276,21 @@ checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
+ "unicode-xid",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case 0.10.0",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.119",
  "unicode-xid",
 ]
 
@@ -2280,9 +2325,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
- "const-oid",
- "crypto-common",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -2328,14 +2384,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "displaydoc"
-version = "0.2.5"
+name = "dispatch2"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags 2.13.1",
+ "objc2",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2368,12 +2434,12 @@ version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
- "der 0.7.10",
+ "der",
  "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
  "signature 2.2.0",
- "spki 0.7.3",
+ "spki",
 ]
 
 [[package]]
@@ -2382,7 +2448,7 @@ version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
- "pkcs8 0.10.2",
+ "pkcs8",
  "signature 2.2.0",
  "zeroize",
 ]
@@ -2418,9 +2484,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "elliptic-curve"
@@ -2434,8 +2500,8 @@ dependencies = [
  "ff",
  "generic-array",
  "group",
- "pem-rfc7468 0.7.0",
- "pkcs8 0.10.2",
+ "pem-rfc7468",
+ "pkcs8",
  "rand_core 0.6.4",
  "sec1",
  "subtle",
@@ -2469,7 +2535,7 @@ dependencies = [
 [[package]]
 name = "enum-compat-util"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
 dependencies = [
  "serde_yaml 0.8.26",
 ]
@@ -2483,7 +2549,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2523,9 +2589,9 @@ dependencies = [
 
 [[package]]
 name = "ethnum"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
+checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 
 [[package]]
 name = "event-listener"
@@ -2535,11 +2601,10 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "event-listener"
-version = "5.4.1"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
- "concurrent-queue",
  "parking",
  "pin-project-lite",
 ]
@@ -2550,7 +2615,7 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
- "event-listener 5.4.1",
+ "event-listener 5.4.2",
  "pin-project-lite",
 ]
 
@@ -2588,37 +2653,43 @@ dependencies = [
 
 [[package]]
 name = "fastbloom"
-version = "0.14.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7f34442dbe69c60fe8eaf58a8cafff81a1f278816d8ab4db255b3bef4ac3c4"
+checksum = "ef975e30683b2d965054bb0a836f8973857c4ebf6acf274fe46617cd285060d8"
 dependencies = [
- "getrandom 0.3.4",
+ "foldhash 0.2.0",
  "libm",
- "rand 0.9.2",
+ "portable-atomic",
  "siphasher",
 ]
 
 [[package]]
 name = "fastcrypto"
-version = "0.1.8"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=69d496c71fb37e3d22fe85e5bbfd4256d61422b9#69d496c71fb37e3d22fe85e5bbfd4256d61422b9"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7ba8f556d75586dd5d9148df99ca02d8afbab9ba230a4f028de54eb0d3bfced"
 dependencies = [
  "aes",
  "aes-gcm",
+ "aes-gcm-siv",
  "ark-ec",
  "ark-ff",
+ "ark-secp256k1",
  "ark-secp256r1",
  "ark-serialize",
  "auto_ops",
  "base64ct",
- "bech32",
+ "bcs",
+ "bech32 0.9.1",
  "bincode",
  "blake2",
  "blst",
  "bs58 0.4.0",
+ "bulletproofs",
  "cbc",
+ "ciborium",
  "ctr",
- "curve25519-dalek-ng",
+ "curve25519-dalek",
  "derive_more 0.99.20",
  "digest 0.10.7",
  "ecdsa",
@@ -2626,36 +2697,44 @@ dependencies = [
  "elliptic-curve",
  "fastcrypto-derive",
  "generic-array",
+ "getrandom 0.2.17",
  "hex",
  "hex-literal",
  "hkdf",
+ "itertools 0.12.1",
  "lazy_static",
- "num-bigint 0.4.6",
+ "merlin",
+ "num-bigint 0.4.8",
  "once_cell",
  "p256",
- "rand 0.8.5",
+ "p384",
+ "rand 0.8.7",
  "readonly",
  "rfc6979",
  "rsa",
+ "rustls-pki-types",
  "schemars 0.8.22",
  "secp256k1",
  "serde",
  "serde_json",
  "serde_with",
  "sha2 0.10.9",
- "sha3",
+ "sha3 0.10.9",
  "signature 2.2.0",
  "static_assertions",
  "thiserror 1.0.69",
  "tokio",
+ "tracing",
  "typenum",
+ "x509-parser",
  "zeroize",
 ]
 
 [[package]]
 name = "fastcrypto-derive"
-version = "0.1.3"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=69d496c71fb37e3d22fe85e5bbfd4256d61422b9#69d496c71fb37e3d22fe85e5bbfd4256d61422b9"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea839b19e2241156eb78b1c33066df25266e893ba85a6b283ceb3bd8a1a6d21b"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -2664,16 +2743,17 @@ dependencies = [
 [[package]]
 name = "fastcrypto-tbls"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=69d496c71fb37e3d22fe85e5bbfd4256d61422b9#69d496c71fb37e3d22fe85e5bbfd4256d61422b9"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=47f8f6b747900bbc1662c4d4eecd2f7e7a29e16a#47f8f6b747900bbc1662c4d4eecd2f7e7a29e16a"
 dependencies = [
  "bcs",
  "digest 0.10.7",
  "fastcrypto",
  "hex",
  "itertools 0.10.5",
- "rand 0.8.5",
+ "rand 0.8.7",
+ "reed-solomon-erasure",
  "serde",
- "sha3",
+ "sha3 0.10.9",
  "tap",
  "tracing",
  "typenum",
@@ -2683,24 +2763,24 @@ dependencies = [
 [[package]]
 name = "fastcrypto-vdf"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=69d496c71fb37e3d22fe85e5bbfd4256d61422b9#69d496c71fb37e3d22fe85e5bbfd4256d61422b9"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=47f8f6b747900bbc1662c4d4eecd2f7e7a29e16a#47f8f6b747900bbc1662c4d4eecd2f7e7a29e16a"
 dependencies = [
  "bcs",
  "fastcrypto",
  "lazy_static",
- "num-bigint 0.4.6",
+ "num-bigint 0.4.8",
  "num-integer",
  "num-prime",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.7",
  "rand_chacha 0.3.1",
  "serde",
 ]
 
 [[package]]
 name = "fastcrypto-zkp"
-version = "0.1.3"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=69d496c71fb37e3d22fe85e5bbfd4256d61422b9#69d496c71fb37e3d22fe85e5bbfd4256d61422b9"
+version = "0.1.4"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=47f8f6b747900bbc1662c4d4eecd2f7e7a29e16a#47f8f6b747900bbc1662c4d4eecd2f7e7a29e16a"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -2718,7 +2798,7 @@ dependencies = [
  "itertools 0.12.1",
  "lazy_static",
  "neptune",
- "num-bigint 0.4.6",
+ "num-bigint 0.4.8",
  "once_cell",
  "regex",
  "reqwest 0.12.28",
@@ -2730,9 +2810,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "fdlimit"
@@ -2749,7 +2829,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
- "bitvec 1.0.1",
+ "bitvec 1.1.1",
  "byteorder",
  "ff_derive",
  "rand_core 0.6.4",
@@ -2778,6 +2858,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2790,7 +2880,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcf0ed7fe52a17a03854ec54a9f76d6d84508d1c0e66bc1793301c73fc8493c"
 dependencies = [
  "byteorder",
- "rand 0.8.5",
+ "rand 0.8.7",
  "rustc-hex",
  "static_assertions",
 ]
@@ -2802,7 +2892,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
 dependencies = [
  "byteorder",
- "rand 0.8.5",
+ "rand 0.8.7",
  "rustc-hex",
  "static_assertions",
 ]
@@ -2862,6 +2952,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "foreign-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2887,9 +2983,9 @@ dependencies = [
 
 [[package]]
 name = "fraction"
-version = "0.15.3"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f158e3ff0a1b334408dc9fb811cd99b446986f4d8b741bb08f9df1604085ae7"
+checksum = "e076045bb43dac435333ed5f04caf35c7463631d0dae2deb2638d94dd0a5b872"
 dependencies = [
  "lazy_static",
  "num",
@@ -2906,12 +3002,21 @@ dependencies = [
 
 [[package]]
 name = "fs-err"
-version = "3.3.0"
+version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73fde052dbfc920003cfd2c8e2c6e6d4cc7c1091538c3a24226cec0665ab08c0"
+checksum = "b91aa448ca50d7e79433bdf3ee8d99215430d2ec02ade5aefab2a073a1822e8a"
 dependencies = [
  "autocfg",
  "tokio",
+]
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -2928,9 +3033,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2943,9 +3048,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2953,15 +3058,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -2970,9 +3075,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
 
 [[package]]
 name = "futures-lite"
@@ -2989,42 +3094,42 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
 
 [[package]]
 name = "futures-timer"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
 dependencies = [
- "gloo-timers 0.2.6",
+ "gloo-timers 0.4.0",
  "send_wrapper",
 ]
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -3080,37 +3185,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
- "wasm-bindgen",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
- "rand_core 0.10.0",
- "wasip2",
- "wasip3",
+ "rand_core 0.10.1",
+ "wasm-bindgen",
 ]
 
 [[package]]
 name = "getset"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf0fc11e47561d47397154977bc219f4cf809b2974facc3ccb3b89e2436f912"
+checksum = "6cf442baaabe4213ce7d1239afc26c039180b6456da2cededa316ae2c8a77a77"
 dependencies = [
- "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3140,14 +3242,14 @@ checksum = "53010ccb100b96a67bc32c0175f0ed1426b31b655d562898e57325f81c023ac0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "glob"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "gloo-net"
@@ -3159,7 +3261,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "gloo-utils",
- "http 1.4.0",
+ "http 1.4.2",
  "js-sys",
  "pin-project",
  "serde",
@@ -3172,9 +3274,9 @@ dependencies = [
 
 [[package]]
 name = "gloo-timers"
-version = "0.2.6"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b995a66bb87bebce9a0f4a95aed01daca4872c050bfcb21653361c03bc35e5c"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -3184,9 +3286,9 @@ dependencies = [
 
 [[package]]
 name = "gloo-timers"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+checksum = "482ce8a491a501da4cd806bd190275363d674f2845005c6ddbd5d3e1dd54495d"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -3222,7 +3324,7 @@ dependencies = [
  "parking_lot 0.12.5",
  "portable-atomic",
  "quanta",
- "rand 0.8.5",
+ "rand 0.8.7",
  "smallvec",
  "spinning_top",
 ]
@@ -3234,7 +3336,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand 0.8.5",
+ "rand 0.8.7",
  "rand_core 0.6.4",
  "rand_xorshift",
  "subtle",
@@ -3252,29 +3354,29 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
- "tokio-util 0.7.18",
+ "tokio-util 0.7.19",
  "tracing",
 ]
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
 dependencies = [
  "atomic-waker",
  "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.4.0",
- "indexmap 2.13.1",
+ "http 1.4.2",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
- "tokio-util 0.7.18",
+ "tokio-util 0.7.19",
  "tracing",
 ]
 
@@ -3294,6 +3396,9 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash 0.7.8",
+]
 
 [[package]]
 name = "hashbrown"
@@ -3301,7 +3406,7 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
 ]
 
 [[package]]
@@ -3318,7 +3423,7 @@ checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -3326,18 +3431,29 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hdrhistogram"
-version = "7.5.4"
+version = "7.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "765c9198f173dd59ce26ff9f95ef0aafd0a0fe01fb9d72841bc5066a4c06511d"
+checksum = "f49d1053f4708f0af3cf9fc5bffc7e68a914a3c45becb231c80068c9c3f78bea"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
  "byteorder",
  "crossbeam-channel",
  "flate2",
- "nom",
+ "nom 8.0.0",
  "num-traits",
 ]
 
@@ -3446,9 +3562,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
 dependencies = [
  "bytes",
  "itoa",
@@ -3467,24 +3583,24 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
 dependencies = [
  "bytes",
- "http 1.4.0",
+ "http 1.4.2",
 ]
 
 [[package]]
 name = "http-body-util"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http 1.4.2",
+ "http-body 1.1.0",
  "pin-project-lite",
 ]
 
@@ -3502,9 +3618,18 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "humantime"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+checksum = "15cdd26707701c53297e2fa6afb323d55fbc1d0810c3aec078ae3ef0424c3c15"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -3532,17 +3657,17 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.9.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
 dependencies = [
  "atomic-waker",
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.13",
- "http 1.4.0",
- "http-body 1.0.1",
+ "h2 0.4.15",
+ "http 1.4.2",
+ "http-body 1.1.0",
  "httparse",
  "httpdate",
  "itoa",
@@ -3554,17 +3679,16 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http 1.4.0",
- "hyper 1.9.0",
+ "http 1.4.2",
+ "hyper 1.11.0",
  "hyper-util",
  "log",
  "rustls",
  "rustls-native-certs",
- "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -3577,7 +3701,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
- "hyper 1.9.0",
+ "hyper 1.11.0",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -3607,14 +3731,14 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
- "hyper 1.9.0",
+ "http 1.4.2",
+ "http-body 1.1.0",
+ "hyper 1.11.0",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.6.5",
  "tokio",
  "tower-service",
  "tracing",
@@ -3632,7 +3756,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -3727,12 +3851,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3751,9 +3869,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -3792,6 +3910,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "impl-codec"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d40b9d5e17727407e55028eafc22b2dc68781786e6d7eb8a21103f5058e3a14"
+dependencies = [
+ "parity-scale-codec 3.7.5",
+]
+
+[[package]]
 name = "impl-serde"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3810,6 +3937,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "impl-serde"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a143eada6a1ec4aefa5049037a26a6d597bfd64f8c026d07b77133e02b7dd0b"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "impl-trait-for-tuples"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3817,7 +3953,7 @@ checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3839,21 +3975,21 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.1"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
 
 [[package]]
 name = "indicatif"
-version = "0.18.4"
+version = "0.18.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
+checksum = "9433806cd6b4ec1aba79c021c7e4c58fb4c3b9977c085062e611ac929998fb0c"
 dependencies = [
  "console",
  "portable-atomic",
@@ -3878,6 +4014,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1804bdb6a9784758b200007273a8b84e2b0b0b97a8f1e18e763eceb3e9f98a"
 
 [[package]]
+name = "inotify"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
+dependencies = [
+ "bitflags 1.3.2",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c033f80b2c113cdf91ab7a33faa9cbc014726dcad99880c8609af2a370edf37d"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3889,9 +4045,9 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.47.2"
+version = "1.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4a6248eb93a4401ed2f37dfe8ea592d3cf05b7cf4f8efa867b6895af7e094e"
+checksum = "86f0f8fee8c926415c58d6ae43a08523a26faccb2323f5e6b644fe7dd4ef6b82"
 dependencies = [
  "console",
  "once_cell",
@@ -3918,14 +4074,16 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 [[package]]
 name = "iota-adapter-latest"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
 dependencies = [
  "anyhow",
  "bcs",
+ "iota-common",
  "iota-macros",
  "iota-metrics",
  "iota-move-natives-latest",
  "iota-protocol-config",
+ "iota-sdk-types",
  "iota-types",
  "iota-verifier-latest",
  "leb128",
@@ -3944,34 +4102,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "iota-archival"
-version = "1.20.1"
-source = "git+https://github.com/iotaledger/iota?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
-dependencies = [
- "anyhow",
- "byteorder",
- "bytes",
- "fastcrypto",
- "futures",
- "indicatif",
- "iota-config",
- "iota-simulator",
- "iota-storage",
- "iota-types",
- "num_enum",
- "object_store",
- "prometheus",
- "rand 0.8.5",
- "serde",
- "serde_json",
- "tokio",
- "tracing",
-]
-
-[[package]]
 name = "iota-authority-aggregation"
-version = "1.20.1"
-source = "git+https://github.com/iotaledger/iota?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+version = "1.29.0-alpha"
+source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
 dependencies = [
  "futures",
  "iota-metrics",
@@ -3982,22 +4115,16 @@ dependencies = [
 
 [[package]]
 name = "iota-common"
-version = "1.20.1"
-source = "git+https://github.com/iotaledger/iota?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+version = "1.29.0-alpha"
+source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
 dependencies = [
- "anyhow",
- "fastcrypto",
  "futures",
+ "getrandom 0.2.17",
  "iota-macros",
  "iota-metrics",
- "iota-tls",
- "iota-types",
  "once_cell",
  "parking_lot 0.12.5",
- "prometheus",
- "rand 0.8.5",
- "reqwest 0.12.28",
- "snap",
+ "rand 0.8.7",
  "tempfile",
  "tokio",
  "tracing",
@@ -4005,27 +4132,29 @@ dependencies = [
 
 [[package]]
 name = "iota-config"
-version = "1.20.1"
-source = "git+https://github.com/iotaledger/iota?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+version = "1.29.0-alpha"
+source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
 dependencies = [
  "anemo",
  "anyhow",
  "bcs",
  "clap",
- "consensus-config",
  "csv",
  "dirs",
  "fastcrypto",
  "iota-genesis-common",
  "iota-keys",
+ "iota-metrics",
  "iota-names",
- "iota-rest-api",
+ "iota-protocol-config",
+ "iota-sdk-crypto",
+ "iota-sdk-types",
  "iota-types",
  "move-vm-config",
  "object_store",
  "once_cell",
- "prometheus",
- "rand 0.8.5",
+ "prometheus-filtered",
+ "rand 0.8.7",
  "reqwest 0.12.28",
  "serde",
  "serde_yaml 0.8.26",
@@ -4035,19 +4164,17 @@ dependencies = [
 
 [[package]]
 name = "iota-core"
-version = "1.20.1"
-source = "git+https://github.com/iotaledger/iota?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+version = "1.29.0-alpha"
+source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
 dependencies = [
  "anemo",
  "anyhow",
  "arc-swap",
  "async-trait",
- "axum 0.8.8",
+ "axum 0.8.9",
  "bcs",
  "bincode",
  "bytes",
- "consensus-config",
- "consensus-core",
  "count-min-sketch",
  "dashmap",
  "diffy",
@@ -4056,31 +4183,28 @@ dependencies = [
  "eyre",
  "fastcrypto",
  "fastcrypto-tbls",
- "fastcrypto-zkp",
  "futures",
- "im",
- "iota-archival",
+ "http 1.4.2",
  "iota-authority-aggregation",
  "iota-common",
  "iota-config",
  "iota-execution",
  "iota-framework",
- "iota-genesis-builder",
  "iota-json-rpc-types",
  "iota-macros",
  "iota-metrics",
  "iota-network",
  "iota-network-stack",
+ "iota-node-storage",
  "iota-protocol-config",
  "iota-sdk-types",
  "iota-simulator",
  "iota-storage",
- "iota-swarm-config",
  "iota-tls",
  "iota-transaction-checks",
  "iota-types",
  "itertools 0.13.0",
- "lru",
+ "lru 0.12.5",
  "mockall",
  "moka",
  "move-binary-format",
@@ -4093,10 +4217,10 @@ dependencies = [
  "object_store",
  "once_cell",
  "parking_lot 0.12.5",
- "prometheus",
+ "pin-project-lite",
+ "prometheus-filtered",
  "quinn-proto",
- "rand 0.8.5",
- "rayon",
+ "rand 0.8.7",
  "reqwest 0.12.28",
  "roaring",
  "scopeguard",
@@ -4113,6 +4237,8 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
+ "tokio-util 0.7.19",
+ "tonic 0.14.6",
  "tracing",
  "twox-hash",
  "typed-store",
@@ -4132,9 +4258,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "iota-data-ingestion-core"
+version = "1.29.0-alpha"
+source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "backoff",
+ "bcs",
+ "byteorder",
+ "bytes",
+ "fastcrypto",
+ "futures",
+ "iota-config",
+ "iota-metrics",
+ "iota-protocol-config",
+ "iota-sdk-grpc-client",
+ "iota-sdk-grpc-types",
+ "iota-sdk-types",
+ "iota-storage",
+ "iota-types",
+ "notify",
+ "object_store",
+ "prometheus-filtered",
+ "serde",
+ "serde_json",
+ "tap",
+ "tempfile",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-stream",
+ "tokio-util 0.7.19",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "iota-enum-compat-util"
-version = "1.20.1"
-source = "git+https://github.com/iotaledger/iota?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+version = "1.29.0-alpha"
+source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
 dependencies = [
  "serde_yaml 0.8.26",
 ]
@@ -4142,11 +4304,12 @@ dependencies = [
 [[package]]
 name = "iota-execution"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
 dependencies = [
  "iota-adapter-latest",
  "iota-move-natives-latest",
  "iota-protocol-config",
+ "iota-sdk-types",
  "iota-types",
  "iota-verifier-latest",
  "move-binary-format",
@@ -4164,10 +4327,11 @@ source = "git+https://github.com/iotaledger/flamegraph-svg?rev=ba681350dc9a72c9b
 
 [[package]]
 name = "iota-framework"
-version = "1.20.1"
-source = "git+https://github.com/iotaledger/iota?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+version = "1.29.0-alpha"
+source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
 dependencies = [
  "bcs",
+ "iota-sdk-types",
  "iota-types",
  "move-binary-format",
  "move-core-types",
@@ -4177,14 +4341,15 @@ dependencies = [
 
 [[package]]
 name = "iota-framework-snapshot"
-version = "1.20.1"
-source = "git+https://github.com/iotaledger/iota?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+version = "1.29.0-alpha"
+source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
 dependencies = [
  "anyhow",
  "bcs",
  "bin-version",
  "iota-framework",
  "iota-protocol-config",
+ "iota-sdk-types",
  "iota-types",
  "serde",
  "serde_json",
@@ -4199,30 +4364,31 @@ dependencies = [
  "arc-swap",
  "async-trait",
  "axum 0.6.20",
+ "base64ct",
  "bcs",
  "chrono",
  "clap",
  "const-str 0.5.7",
  "eyre",
- "fastcrypto",
  "futures-util",
  "git-version",
+ "hex",
  "hostname",
+ "http 1.4.2",
  "humantime",
  "indoc",
- "iota-config",
- "iota-json-rpc-types",
- "iota-metrics",
- "iota-sdk",
+ "iota-sdk-crypto",
+ "iota-sdk-grpc-client",
+ "iota-sdk-grpc-types",
+ "iota-sdk-transaction-builder",
  "iota-sdk-types",
  "iota-swarm-config",
- "iota-types",
  "itertools 0.14.0",
  "lazy_static",
  "once_cell",
  "parking_lot 0.12.5",
  "prometheus",
- "rand 0.8.5",
+ "rand 0.8.7",
  "redis",
  "regorus",
  "reqwest 0.11.27",
@@ -4232,13 +4398,15 @@ dependencies = [
  "serde_json_canonicalizer",
  "serde_with",
  "serde_yaml 0.8.26",
+ "sha2 0.10.9",
  "tap",
- "telemetry-subscribers",
  "tempfile",
  "test-cluster",
  "tokio",
  "tokio-retry",
+ "tonic 0.14.6",
  "tracing",
+ "tracing-subscriber",
  "url",
  "uuid",
  "wiremock",
@@ -4246,8 +4414,8 @@ dependencies = [
 
 [[package]]
 name = "iota-genesis-builder"
-version = "1.20.1"
-source = "git+https://github.com/iotaledger/iota?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+version = "1.29.0-alpha"
+source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4275,15 +4443,16 @@ dependencies = [
  "move-binary-format",
  "move-compiler",
  "move-core-types",
+ "move-docgen",
  "move-package",
  "move-vm-runtime",
  "num-rational",
  "packable",
  "prefix-hex",
  "primitive-types 0.12.2",
- "prometheus",
- "rand 0.8.5",
- "rand_pcg",
+ "prometheus-filtered",
+ "rand 0.8.7",
+ "rand_pcg 0.3.1",
  "rand_seeder",
  "regex",
  "reqwest 0.12.28",
@@ -4301,92 +4470,80 @@ dependencies = [
 
 [[package]]
 name = "iota-genesis-common"
-version = "1.20.1"
-source = "git+https://github.com/iotaledger/iota?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+version = "1.29.0-alpha"
+source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
 dependencies = [
  "iota-execution",
  "iota-protocol-config",
+ "iota-sdk-types",
  "iota-types",
- "prometheus",
+ "prometheus-filtered",
 ]
 
 [[package]]
 name = "iota-grpc-server"
-version = "1.20.1"
-source = "git+https://github.com/iotaledger/iota?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+version = "1.29.0-alpha"
+source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
 dependencies = [
  "anyhow",
  "async-stream",
  "bcs",
  "futures",
- "http 1.4.0",
+ "http 1.4.2",
  "iota-config",
- "iota-grpc-types",
+ "iota-core",
  "iota-metrics",
+ "iota-node-storage",
  "iota-protocol-config",
+ "iota-sdk-grpc-types",
  "iota-sdk-types",
  "iota-types",
  "itertools 0.13.0",
  "move-core-types",
  "paste",
  "pin-project-lite",
- "prometheus",
- "prost 0.14.3",
- "prost-types 0.14.3",
+ "prometheus-filtered",
+ "prost 0.14.4",
+ "prost-types 0.14.4",
  "serde",
  "tokio",
  "tokio-stream",
- "tokio-util 0.7.18",
- "tonic 0.14.5",
+ "tokio-util 0.7.19",
+ "tonic 0.14.6",
  "tower 0.4.13",
  "tracing",
 ]
 
 [[package]]
-name = "iota-grpc-types"
-version = "1.20.1"
-source = "git+https://github.com/iotaledger/iota?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
-dependencies = [
- "bcs",
- "iota-sdk-types",
- "prost 0.14.3",
- "prost-types 0.14.3",
- "serde",
- "serde_json",
- "tap",
- "tonic 0.14.5",
- "tonic-prost",
-]
-
-[[package]]
 name = "iota-http"
-version = "1.20.1"
-source = "git+https://github.com/iotaledger/iota?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+version = "1.29.0-alpha"
+source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
 dependencies = [
  "bytes",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http 1.4.2",
+ "http-body 1.1.0",
  "http-body-util",
- "hyper 1.9.0",
+ "hyper 1.11.0",
  "hyper-util",
  "iota-tls",
  "pin-project-lite",
  "socket2 0.5.10",
  "tokio",
  "tokio-rustls",
- "tokio-util 0.7.18",
+ "tokio-util 0.7.19",
  "tower 0.4.13",
  "tracing",
 ]
 
 [[package]]
 name = "iota-json"
-version = "1.20.1"
-source = "git+https://github.com/iotaledger/iota?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+version = "1.29.0-alpha"
+source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
 dependencies = [
  "anyhow",
  "bcs",
  "fastcrypto",
+ "iota-sdk-types",
  "iota-types",
  "move-binary-format",
  "move-bytecode-utils",
@@ -4398,13 +4555,13 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc"
-version = "1.20.1"
-source = "git+https://github.com/iotaledger/iota?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+version = "1.29.0-alpha"
+source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
 dependencies = [
  "anyhow",
  "arc-swap",
  "async-trait",
- "axum 0.8.8",
+ "axum 0.8.9",
  "backoff",
  "bcs",
  "cached",
@@ -4412,9 +4569,9 @@ dependencies = [
  "eyre",
  "fastcrypto",
  "futures",
- "http-body 1.0.1",
- "hyper 1.9.0",
- "indexmap 2.13.1",
+ "http-body 1.1.0",
+ "hyper 1.11.0",
+ "indexmap 2.14.0",
  "iota-config",
  "iota-core",
  "iota-json",
@@ -4436,15 +4593,14 @@ dependencies = [
  "move-bytecode-utils",
  "move-core-types",
  "move-package",
- "prometheus",
+ "prometheus-filtered",
  "serde",
  "serde_json",
- "signature 1.6.4",
  "statrs",
  "tap",
  "thiserror 1.0.69",
  "tokio",
- "tokio-util 0.7.18",
+ "tokio-util 0.7.19",
  "tower 0.4.13",
  "tower-http 0.5.2",
  "tracing",
@@ -4453,8 +4609,8 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc-api"
-version = "1.20.1"
-source = "git+https://github.com/iotaledger/iota?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+version = "1.29.0-alpha"
+source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -4463,18 +4619,19 @@ dependencies = [
  "iota-metrics",
  "iota-open-rpc",
  "iota-open-rpc-macros",
+ "iota-sdk-types",
  "iota-types",
  "jsonrpsee",
  "once_cell",
- "prometheus",
+ "prometheus-filtered",
  "tap",
  "tracing",
 ]
 
 [[package]]
 name = "iota-json-rpc-types"
-version = "1.20.1"
-source = "git+https://github.com/iotaledger/iota?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+version = "1.29.0-alpha"
+source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4489,6 +4646,7 @@ dependencies = [
  "iota-names",
  "iota-package-resolver",
  "iota-protocol-config",
+ "iota-sdk-types",
  "iota-types",
  "itertools 0.13.0",
  "json_to_table",
@@ -4503,20 +4661,22 @@ dependencies = [
  "serde_with",
  "strum 0.27.2",
  "tabled",
+ "thiserror 1.0.69",
  "tracing",
 ]
 
 [[package]]
 name = "iota-keys"
-version = "1.20.1"
-source = "git+https://github.com/iotaledger/iota?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+version = "1.29.0-alpha"
+source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
 dependencies = [
  "anyhow",
  "bip32",
  "fastcrypto",
+ "iota-sdk-crypto",
  "iota-sdk-types",
  "iota-types",
- "rand 0.8.5",
+ "rand 0.8.7",
  "regex",
  "serde",
  "serde_json",
@@ -4529,8 +4689,8 @@ dependencies = [
 
 [[package]]
 name = "iota-macros"
-version = "1.20.1"
-source = "git+https://github.com/iotaledger/iota?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+version = "1.29.0-alpha"
+source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
 dependencies = [
  "futures",
  "iota-proc-macros",
@@ -4540,8 +4700,8 @@ dependencies = [
 
 [[package]]
 name = "iota-mainnet-unlocks"
-version = "1.20.1"
-source = "git+https://github.com/iotaledger/iota?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+version = "1.29.0-alpha"
+source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4553,21 +4713,23 @@ dependencies = [
 
 [[package]]
 name = "iota-metrics"
-version = "1.20.1"
-source = "git+https://github.com/iotaledger/iota?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+version = "1.29.0-alpha"
+source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
 dependencies = [
  "anemo",
  "anemo-tower",
  "async-trait",
- "axum 0.8.8",
+ "axum 0.8.9",
  "bytes",
  "dashmap",
  "futures",
+ "http 1.4.2",
  "once_cell",
  "parking_lot 0.12.5",
- "prometheus",
  "prometheus-closure-metric",
+ "prometheus-filtered",
  "scopeguard",
+ "serde",
  "simple-server-timing-header",
  "sysinfo",
  "tap",
@@ -4578,13 +4740,32 @@ dependencies = [
 ]
 
 [[package]]
-name = "iota-move-build"
-version = "1.20.1"
-source = "git+https://github.com/iotaledger/iota?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+name = "iota-metrics-push-client"
+version = "0.1.0"
+source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
 dependencies = [
  "anyhow",
  "fastcrypto",
+ "iota-metrics",
+ "iota-tls",
+ "iota-types",
+ "prometheus-filtered",
+ "reqwest 0.12.28",
+ "snap",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "iota-move-build"
+version = "1.29.0-alpha"
+source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
+dependencies = [
+ "anyhow",
+ "fastcrypto",
+ "iota-common",
  "iota-package-management",
+ "iota-sdk-types",
  "iota-types",
  "iota-verifier-latest",
  "move-binary-format",
@@ -4596,28 +4777,28 @@ dependencies = [
  "move-package",
  "move-symbol-pool",
  "serde-reflection",
- "tempfile",
 ]
 
 [[package]]
 name = "iota-move-natives-latest"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
 dependencies = [
  "bcs",
  "better_any",
  "fastcrypto",
  "fastcrypto-vdf",
  "fastcrypto-zkp",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "iota-protocol-config",
+ "iota-sdk-types",
  "iota-types",
  "move-binary-format",
  "move-core-types",
  "move-stdlib-natives",
  "move-vm-runtime",
  "move-vm-types",
- "rand 0.8.5",
+ "rand 0.8.7",
  "serde",
  "smallvec",
  "tracing",
@@ -4625,21 +4806,21 @@ dependencies = [
 
 [[package]]
 name = "iota-names"
-version = "1.20.1"
-source = "git+https://github.com/iotaledger/iota?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+version = "1.29.0-alpha"
+source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
 dependencies = [
  "anyhow",
  "bcs",
+ "iota-sdk-types",
  "iota-types",
- "move-core-types",
  "serde",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "iota-network"
-version = "1.20.1"
-source = "git+https://github.com/iotaledger/iota?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+version = "1.29.0-alpha"
+source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
 dependencies = [
  "anemo",
  "anemo-build",
@@ -4653,8 +4834,8 @@ dependencies = [
  "fastcrypto-tbls",
  "futures",
  "governor",
- "iota-archival",
  "iota-config",
+ "iota-data-ingestion-core",
  "iota-macros",
  "iota-metrics",
  "iota-network-stack",
@@ -4662,29 +4843,33 @@ dependencies = [
  "iota-simulator",
  "iota-storage",
  "iota-types",
- "prometheus",
- "rand 0.8.5",
+ "prometheus-filtered",
+ "prost 0.14.4",
+ "rand 0.8.7",
  "serde",
  "tap",
  "tokio",
- "tonic 0.14.5",
+ "tokio-util 0.7.19",
+ "tonic 0.14.6",
  "tonic-build",
+ "tonic-prost",
+ "tonic-prost-build",
  "tower 0.4.13",
  "tracing",
 ]
 
 [[package]]
 name = "iota-network-stack"
-version = "1.20.1"
-source = "git+https://github.com/iotaledger/iota?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+version = "1.29.0-alpha"
+source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
 dependencies = [
  "anemo",
  "bcs",
  "bytes",
  "eyre",
  "futures",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http 1.4.2",
+ "http-body 1.1.0",
  "hyper-rustls",
  "hyper-util",
  "idna",
@@ -4696,7 +4881,7 @@ dependencies = [
  "snap",
  "tokio",
  "tokio-rustls",
- "tonic 0.14.5",
+ "tonic 0.14.6",
  "tonic-health",
  "tower 0.4.13",
  "tower-http 0.5.2",
@@ -4705,23 +4890,20 @@ dependencies = [
 
 [[package]]
 name = "iota-node"
-version = "1.20.1"
-source = "git+https://github.com/iotaledger/iota?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+version = "1.29.0-alpha"
+source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
 dependencies = [
  "anemo",
  "anemo-tower",
  "anyhow",
  "arc-swap",
- "axum 0.8.8",
+ "axum 0.8.9",
  "base64 0.21.7",
  "bcs",
  "bin-version",
  "clap",
- "fastcrypto",
- "fastcrypto-zkp",
  "futures",
  "humantime",
- "iota-archival",
  "iota-common",
  "iota-config",
  "iota-core",
@@ -4731,11 +4913,11 @@ dependencies = [
  "iota-json-rpc-api",
  "iota-macros",
  "iota-metrics",
+ "iota-metrics-push-client",
  "iota-names",
  "iota-network",
  "iota-network-stack",
  "iota-protocol-config",
- "iota-rest-api",
  "iota-sdk-types",
  "iota-simulator",
  "iota-snapshot",
@@ -4743,15 +4925,15 @@ dependencies = [
  "iota-tls",
  "iota-types",
  "move-vm-profiler",
- "prometheus",
+ "prometheus-filtered",
  "reqwest 0.12.28",
  "rustc_version_runtime",
  "serde",
  "tap",
  "telemetry-subscribers",
  "tokio",
- "tokio-util 0.7.18",
- "tonic 0.14.5",
+ "tokio-util 0.7.19",
+ "tonic 0.14.6",
  "tower 0.4.13",
  "tracing",
  "typed-store",
@@ -4759,9 +4941,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "iota-node-storage"
+version = "1.29.0-alpha"
+source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
+dependencies = [
+ "iota-sdk-types",
+ "iota-types",
+ "move-core-types",
+]
+
+[[package]]
 name = "iota-open-rpc"
-version = "1.20.1"
-source = "git+https://github.com/iotaledger/iota?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+version = "1.29.0-alpha"
+source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
 dependencies = [
  "schemars 0.8.22",
  "serde",
@@ -4771,8 +4963,8 @@ dependencies = [
 
 [[package]]
 name = "iota-open-rpc-macros"
-version = "1.20.1"
-source = "git+https://github.com/iotaledger/iota?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+version = "1.29.0-alpha"
+source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
 dependencies = [
  "derive-syn-parse",
  "itertools 0.13.0",
@@ -4784,16 +4976,15 @@ dependencies = [
 
 [[package]]
 name = "iota-package-management"
-version = "1.20.1"
-source = "git+https://github.com/iotaledger/iota?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+version = "1.29.0-alpha"
+source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
 dependencies = [
  "anyhow",
  "iota-framework-snapshot",
  "iota-json-rpc-types",
  "iota-protocol-config",
  "iota-sdk",
- "iota-types",
- "move-core-types",
+ "iota-sdk-types",
  "move-package",
  "move-symbol-pool",
  "thiserror 1.0.69",
@@ -4801,35 +4992,35 @@ dependencies = [
 
 [[package]]
 name = "iota-package-resolver"
-version = "1.20.1"
-source = "git+https://github.com/iotaledger/iota?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+version = "1.29.0-alpha"
+source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
 dependencies = [
  "async-trait",
  "bcs",
+ "iota-sdk-types",
  "iota-types",
- "lru",
+ "lru 0.12.5",
  "move-binary-format",
  "move-command-line-common",
  "move-core-types",
  "thiserror 1.0.69",
- "tokio",
 ]
 
 [[package]]
 name = "iota-proc-macros"
-version = "1.20.1"
-source = "git+https://github.com/iotaledger/iota?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+version = "1.29.0-alpha"
+source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
 dependencies = [
  "msim-macros",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "iota-protocol-config"
-version = "1.20.1"
-source = "git+https://github.com/iotaledger/iota?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+version = "1.29.0-alpha"
+source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
 dependencies = [
  "clap",
  "iota-protocol-config-macros",
@@ -4843,8 +5034,8 @@ dependencies = [
 
 [[package]]
 name = "iota-protocol-config-macros"
-version = "1.20.1"
-source = "git+https://github.com/iotaledger/iota?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+version = "1.29.0-alpha"
+source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4852,36 +5043,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "iota-rest-api"
-version = "1.20.1"
-source = "git+https://github.com/iotaledger/iota?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
-dependencies = [
- "anyhow",
- "axum 0.8.8",
- "bcs",
- "fastcrypto",
- "iota-network-stack",
- "iota-protocol-config",
- "iota-sdk-types",
- "iota-types",
- "itertools 0.13.0",
- "mime",
- "move-binary-format",
- "openapiv3",
- "prometheus",
- "schemars 0.8.22",
- "serde",
- "serde_json",
- "serde_with",
- "serde_yaml 0.8.26",
- "tap",
- "tokio",
-]
-
-[[package]]
 name = "iota-sdk"
-version = "1.20.1"
-source = "git+https://github.com/iotaledger/iota?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+version = "1.29.0-alpha"
+source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4898,11 +5062,11 @@ dependencies = [
  "iota-json-rpc-api",
  "iota-json-rpc-types",
  "iota-keys",
+ "iota-sdk-grpc-client",
  "iota-sdk-types",
  "iota-transaction-builder",
  "iota-types",
  "jsonrpsee",
- "move-core-types",
  "reqwest 0.12.28",
  "rustls",
  "serde",
@@ -4914,33 +5078,105 @@ dependencies = [
 ]
 
 [[package]]
+name = "iota-sdk-crypto"
+version = "0.0.1-alpha.1"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=b77fcd5ac5fedb3dfbc77ba7d183140e43512339#b77fcd5ac5fedb3dfbc77ba7d183140e43512339"
+dependencies = [
+ "bech32 0.11.1",
+ "fastcrypto",
+ "iota-sdk-types",
+ "rand_core 0.6.4",
+ "sha2 0.10.9",
+ "signature 2.2.0",
+ "thiserror 2.0.19",
+ "zeroize",
+]
+
+[[package]]
+name = "iota-sdk-grpc-client"
+version = "0.0.1-alpha.1"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=b77fcd5ac5fedb3dfbc77ba7d183140e43512339#b77fcd5ac5fedb3dfbc77ba7d183140e43512339"
+dependencies = [
+ "async-stream",
+ "base64 0.22.1",
+ "futures",
+ "http 1.4.2",
+ "iota-sdk-grpc-types",
+ "iota-sdk-transaction-builder",
+ "iota-sdk-types",
+ "prost 0.14.4",
+ "serde",
+ "thiserror 2.0.19",
+ "tokio",
+ "tonic 0.14.6",
+]
+
+[[package]]
+name = "iota-sdk-grpc-types"
+version = "0.0.1-alpha.1"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=b77fcd5ac5fedb3dfbc77ba7d183140e43512339#b77fcd5ac5fedb3dfbc77ba7d183140e43512339"
+dependencies = [
+ "bcs",
+ "iota-sdk-types",
+ "prost 0.14.4",
+ "prost-types 0.14.4",
+ "serde",
+ "serde_json",
+ "tap",
+ "tonic 0.14.6",
+ "tonic-prost",
+]
+
+[[package]]
+name = "iota-sdk-transaction-builder"
+version = "0.0.1-alpha.1"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=b77fcd5ac5fedb3dfbc77ba7d183140e43512339#b77fcd5ac5fedb3dfbc77ba7d183140e43512339"
+dependencies = [
+ "base64ct",
+ "bcs",
+ "derive_more 2.1.1",
+ "iota-sdk-crypto",
+ "iota-sdk-types",
+ "primitive-types 0.14.0",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.19",
+ "tokio",
+ "variadics_please",
+]
+
+[[package]]
 name = "iota-sdk-types"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=e19c78a1bee17e0bf85fcd5b16a2f080cef26274#e19c78a1bee17e0bf85fcd5b16a2f080cef26274"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=b77fcd5ac5fedb3dfbc77ba7d183140e43512339#b77fcd5ac5fedb3dfbc77ba7d183140e43512339"
 dependencies = [
  "base64ct",
  "bcs",
  "blake2",
  "bnum",
  "bs58 0.5.1",
+ "bytestring",
+ "derive_more 2.1.1",
+ "filetime",
+ "getrandom 0.2.17",
  "hex",
- "itertools 0.13.0",
  "paste",
+ "rand_core 0.6.4",
  "roaring",
- "schemars 0.8.22",
  "serde",
  "serde_json",
  "serde_repr",
  "serde_with",
  "strum 0.27.2",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "winnow 0.7.15",
 ]
 
 [[package]]
 name = "iota-simulator"
-version = "1.20.1"
-source = "git+https://github.com/iotaledger/iota?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+version = "1.29.0-alpha"
+source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -4949,10 +5185,10 @@ dependencies = [
  "iota-framework",
  "iota-move-build",
  "iota-types",
- "lru",
+ "lru 0.12.5",
  "move-package",
  "msim",
- "rand 0.8.5",
+ "rand 0.8.7",
  "serde",
  "telemetry-subscribers",
  "tempfile",
@@ -4962,8 +5198,8 @@ dependencies = [
 
 [[package]]
 name = "iota-snapshot"
-version = "1.20.1"
-source = "git+https://github.com/iotaledger/iota?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+version = "1.29.0-alpha"
+source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4976,11 +5212,12 @@ dependencies = [
  "iota-common",
  "iota-config",
  "iota-core",
+ "iota-sdk-types",
  "iota-storage",
  "iota-types",
  "num_enum",
  "object_store",
- "prometheus",
+ "prometheus-filtered",
  "serde",
  "tokio",
  "tokio-stream",
@@ -4989,11 +5226,11 @@ dependencies = [
 
 [[package]]
 name = "iota-stardust-types"
-version = "1.20.1"
-source = "git+https://github.com/iotaledger/iota?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+version = "1.29.0-alpha"
+source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
 dependencies = [
- "bech32",
- "bitflags 2.11.0",
+ "bech32 0.9.1",
+ "bitflags 2.13.1",
  "derive_more 1.0.0",
  "getset",
  "iota-crypto",
@@ -5003,17 +5240,16 @@ dependencies = [
  "primitive-types 0.12.2",
  "serde",
  "serde_json",
- "zeroize",
 ]
 
 [[package]]
 name = "iota-storage"
-version = "1.20.1"
-source = "git+https://github.com/iotaledger/iota?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+version = "1.29.0-alpha"
+source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
 dependencies = [
  "anyhow",
  "async-trait",
- "axum 0.8.8",
+ "axum 0.8.9",
  "backoff",
  "base64-url",
  "bcs",
@@ -5024,22 +5260,23 @@ dependencies = [
  "eyre",
  "fastcrypto",
  "futures",
- "hyper 1.9.0",
+ "hyper 1.11.0",
  "indicatif",
  "integer-encoding",
  "iota-config",
  "iota-metrics",
  "iota-protocol-config",
+ "iota-sdk-types",
  "iota-simulator",
  "iota-types",
  "itertools 0.13.0",
- "lru",
+ "lru 0.12.5",
  "moka",
  "num_enum",
  "object_store",
  "parking_lot 0.12.5",
  "percent-encoding",
- "prometheus",
+ "prometheus-filtered",
  "reqwest 0.12.28",
  "rustls",
  "serde",
@@ -5057,8 +5294,8 @@ dependencies = [
 
 [[package]]
 name = "iota-swarm"
-version = "1.20.1"
-source = "git+https://github.com/iotaledger/iota?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+version = "1.29.0-alpha"
+source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
 dependencies = [
  "anyhow",
  "futures",
@@ -5073,8 +5310,8 @@ dependencies = [
  "iota-swarm-config",
  "iota-tls",
  "iota-types",
- "prometheus",
- "rand 0.8.5",
+ "prometheus-filtered",
+ "rand 0.8.7",
  "tap",
  "telemetry-subscribers",
  "tempfile",
@@ -5085,8 +5322,8 @@ dependencies = [
 
 [[package]]
 name = "iota-swarm-config"
-version = "1.20.1"
-source = "git+https://github.com/iotaledger/iota?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+version = "1.29.0-alpha"
+source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
 dependencies = [
  "anemo",
  "anyhow",
@@ -5097,12 +5334,12 @@ dependencies = [
  "iota-genesis-builder",
  "iota-names",
  "iota-protocol-config",
- "iota-rest-api",
+ "iota-sdk-crypto",
  "iota-sdk-types",
  "iota-simulator",
  "iota-types",
- "prometheus",
- "rand 0.8.5",
+ "prometheus-filtered",
+ "rand 0.8.7",
  "serde",
  "serde_with",
  "serde_yaml 0.8.26",
@@ -5111,30 +5348,32 @@ dependencies = [
 
 [[package]]
 name = "iota-test-transaction-builder"
-version = "1.20.1"
-source = "git+https://github.com/iotaledger/iota?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+version = "1.29.0-alpha"
+source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
 dependencies = [
- "bcs",
  "iota-genesis-builder",
  "iota-move-build",
  "iota-sdk",
+ "iota-sdk-crypto",
+ "iota-sdk-grpc-client",
+ "iota-sdk-transaction-builder",
  "iota-sdk-types",
  "iota-types",
- "move-core-types",
+ "rand 0.8.7",
 ]
 
 [[package]]
 name = "iota-tls"
-version = "1.20.1"
-source = "git+https://github.com/iotaledger/iota?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+version = "1.29.0-alpha"
+source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
 dependencies = [
  "anyhow",
  "arc-swap",
- "axum 0.8.8",
+ "axum 0.8.9",
  "axum-server",
  "ed25519",
  "fastcrypto",
- "pkcs8 0.10.2",
+ "pkcs8",
  "rcgen",
  "reqwest 0.12.28",
  "rustls",
@@ -5147,8 +5386,8 @@ dependencies = [
 
 [[package]]
 name = "iota-transaction-builder"
-version = "1.20.1"
-source = "git+https://github.com/iotaledger/iota?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+version = "1.29.0-alpha"
+source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5157,29 +5396,29 @@ dependencies = [
  "iota-json",
  "iota-json-rpc-types",
  "iota-protocol-config",
+ "iota-sdk-types",
  "iota-types",
  "move-binary-format",
- "move-core-types",
 ]
 
 [[package]]
 name = "iota-transaction-checks"
-version = "1.20.1"
-source = "git+https://github.com/iotaledger/iota?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+version = "1.29.0-alpha"
+source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
 dependencies = [
- "fastcrypto-zkp",
  "iota-config",
  "iota-execution",
  "iota-macros",
  "iota-protocol-config",
+ "iota-sdk-types",
  "iota-types",
  "tracing",
 ]
 
 [[package]]
 name = "iota-types"
-version = "1.20.1"
-source = "git+https://github.com/iotaledger/iota?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+version = "1.29.0-alpha"
+source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
 dependencies = [
  "anemo",
  "anyhow",
@@ -5190,53 +5429,45 @@ dependencies = [
  "better_any",
  "bincode",
  "byteorder",
- "consensus-config",
  "derive_more 1.0.0",
  "either",
  "enum_dispatch",
  "eyre",
  "fastcrypto",
  "fastcrypto-tbls",
- "fastcrypto-zkp",
  "futures",
  "hex",
- "im",
- "indexmap 2.13.1",
- "iota-enum-compat-util",
+ "indexmap 2.14.0",
  "iota-macros",
  "iota-network-stack",
  "iota-protocol-config",
+ "iota-sdk-crypto",
  "iota-sdk-types",
  "itertools 0.13.0",
- "lru",
+ "lru 0.12.5",
  "move-binary-format",
  "move-bytecode-utils",
  "move-core-types",
  "move-vm-profiler",
  "move-vm-test-utils",
  "nonempty",
- "num-bigint 0.4.6",
- "num-traits",
  "once_cell",
  "parking_lot 0.12.5",
  "passkey-types",
- "prometheus",
- "prost-types 0.14.3",
- "rand 0.8.5",
+ "prometheus-filtered",
+ "prost-types 0.14.4",
+ "rand 0.8.7",
  "roaring",
- "schemars 0.8.22",
  "serde",
  "serde-name",
  "serde_json",
  "serde_with",
- "signature 1.6.4",
  "starfish-config",
  "static_assertions",
  "strum 0.27.2",
- "strum_macros 0.27.2",
  "tap",
  "thiserror 1.0.69",
- "tonic 0.14.5",
+ "tonic 0.14.6",
  "tracing",
  "typed-store-error",
 ]
@@ -5244,9 +5475,10 @@ dependencies = [
 [[package]]
 name = "iota-verifier-latest"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
 dependencies = [
  "bcs",
+ "iota-sdk-types",
  "iota-types",
  "move-abstract-interpreter",
  "move-abstract-stack",
@@ -5262,16 +5494,6 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
-
-[[package]]
-name = "iri-string"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
-dependencies = [
- "memchr",
- "serde",
-]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -5377,28 +5599,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "jobserver"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.94"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
@@ -5413,9 +5634,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee"
-version = "0.24.10"
+version = "0.24.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e281ae70cc3b98dac15fced3366a880949e65fc66e345ce857a5682d152f3e62"
+checksum = "72c4b1f204b655b36b24dc4939af20366c649431d4711863bbbae5c495f3eeb4"
 dependencies = [
  "jsonrpsee-client-transport",
  "jsonrpsee-core",
@@ -5431,15 +5652,15 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-client-transport"
-version = "0.24.10"
+version = "0.24.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc4280b709ac3bb5e16cf3bad5056a0ec8df55fa89edfe996361219aadc2c7ea"
+checksum = "b3e1420b1792cff778e2a1ebaa44115f156ee62a94dd106eaa51163f037d2023"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
  "futures-util",
  "gloo-net",
- "http 1.4.0",
+ "http 1.4.2",
  "jsonrpsee-core",
  "pin-project",
  "rustls",
@@ -5449,29 +5670,29 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tokio-rustls",
- "tokio-util 0.7.18",
+ "tokio-util 0.7.19",
  "tracing",
  "url",
 ]
 
 [[package]]
 name = "jsonrpsee-core"
-version = "0.24.10"
+version = "0.24.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "348ee569eaed52926b5e740aae20863762b16596476e943c9e415a6479021622"
+checksum = "f49bfa9334963e1c85866b39dff3ffcc81f1c286eb23334267c5cb97677543a4"
 dependencies = [
  "async-trait",
  "bytes",
  "futures-timer",
  "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http 1.4.2",
+ "http-body 1.1.0",
  "http-body-util",
  "jsonrpsee-types",
  "parking_lot 0.12.5",
  "pin-project",
- "rand 0.8.5",
- "rustc-hash 2.1.2",
+ "rand 0.8.7",
+ "rustc-hash 2.1.3",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -5483,14 +5704,14 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-http-client"
-version = "0.24.10"
+version = "0.24.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50c389d6e6a52eb7c3548a6600c90cf74d9b71cb5912209833f00a5479e9a01"
+checksum = "c215647e43482d478a6c21f021a013b50d64cf63431c1176eda9ef925dc54ec8"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
- "http-body 1.0.1",
- "hyper 1.9.0",
+ "http-body 1.1.0",
+ "hyper 1.11.0",
  "hyper-rustls",
  "hyper-util",
  "jsonrpsee-core",
@@ -5508,28 +5729,28 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-proc-macros"
-version = "0.24.10"
+version = "0.24.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7398cddf5013cca4702862a2692b66c48a3bd6cf6ec681a47453c93d63cf8de5"
+checksum = "f5248249c016692f1465a753057ae8347681995dd490c2cb65c48b14b46215a8"
 dependencies = [
  "heck 0.5.0",
  "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "jsonrpsee-server"
-version = "0.24.10"
+version = "0.24.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21429bcdda37dcf2d43b68621b994adede0e28061f816b038b0f18c70c143d51"
+checksum = "c625c78b8d545478370b6e7a2a191b0d921f831a9eef38dc1e7efb57e7a5472f"
 dependencies = [
  "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http 1.4.2",
+ "http-body 1.1.0",
  "http-body-util",
- "hyper 1.9.0",
+ "hyper 1.11.0",
  "hyper-util",
  "jsonrpsee-core",
  "jsonrpsee-types",
@@ -5541,18 +5762,18 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
- "tokio-util 0.7.18",
+ "tokio-util 0.7.19",
  "tower 0.4.13",
  "tracing",
 ]
 
 [[package]]
 name = "jsonrpsee-types"
-version = "0.24.10"
+version = "0.24.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0f05e0028e55b15dbd2107163b3c744cd3bb4474f193f95d9708acbf5677e44"
+checksum = "41d86fc943f81dab0ecdd6c0240b6e0f55ad57a2ea9ad8ad7efe8456fb9cc7a4"
 dependencies = [
- "http 1.4.0",
+ "http 1.4.2",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -5560,9 +5781,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-wasm-client"
-version = "0.24.10"
+version = "0.24.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9d745e4f543fc10fc0e2b11aa1f3be506b1e475d412167e7191a65ecd239f1c"
+checksum = "735df2088674c87f7fecdf51c80878a7aa19a8116b32d703b000f5b1a7acf95a"
 dependencies = [
  "jsonrpsee-client-transport",
  "jsonrpsee-core",
@@ -5571,11 +5792,11 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-ws-client"
-version = "0.24.10"
+version = "0.24.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78fc744f17e7926d57f478cf9ca6e1ee5d8332bf0514860b1a3cdf1742e614cc"
+checksum = "9df5bd5c38c0906a6e8b3a38c8c22cc8525fda25fd1a03a3fe010686aea66b70"
 dependencies = [
- "http 1.4.0",
+ "http 1.4.2",
  "jsonrpsee-client-transport",
  "jsonrpsee-core",
  "jsonrpsee-types",
@@ -5588,7 +5809,7 @@ version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "161c33c3ec738cfea3288c5c53dfcdb32fd4fc2954de86ea06f71b5a1a40bfcd"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "base64 0.22.1",
  "bytecount",
  "email_address",
@@ -5628,6 +5849,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "keccak"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
+name = "konst"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "128133ed7824fcd73d6e7b17957c5eb7bacb885649bd8c69708b2331a10bcefb"
+dependencies = [
+ "konst_macro_rules",
+]
+
+[[package]]
+name = "konst_macro_rules"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
+
+[[package]]
+name = "kqueue"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "273c0752728918e0ac4976f2b275b6fefb9ecd400585dec929419f3844cd87b5"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
+dependencies = [
+ "bitflags 2.13.1",
+ "libc",
+]
+
+[[package]]
 name = "kv-log-macro"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5646,28 +5912,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
 name = "leb128"
-version = "0.2.5"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
-
-[[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+checksum = "c83bff1d572d6b9aeef67ddfc8448e4a3737909cb28e81f97c791b9018703e52"
 
 [[package]]
 name = "libc"
-version = "0.2.184"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libloading"
@@ -5686,27 +5940,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
-name = "libredox"
-version = "0.1.15"
+name = "libp2p-identity"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
+checksum = "9525f3831544f7ae497bde79adf114ef127b0fbbb97edbbf692a80408636421c"
 dependencies = [
- "bitflags 2.11.0",
+ "bs58 0.5.1",
+ "hkdf",
+ "multihash",
+ "sha2 0.10.9",
+ "thiserror 2.0.19",
+ "tracing",
+]
+
+[[package]]
+name = "libredox"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
+dependencies = [
+ "bitflags 2.13.1",
  "libc",
  "plain",
- "redox_syscall 0.7.3",
+ "redox_syscall 0.9.1",
 ]
 
 [[package]]
 name = "librocksdb-sys"
-version = "0.11.0+8.1.1"
+version = "0.17.3+10.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3386f101bcb4bd252d8e9d2fb41ec3b0862a15a62b478c355b2982efa469e3e"
+checksum = "cef2a00ee60fe526157c9023edab23943fae1ce2ab6f4abb2a807c1746835de9"
 dependencies = [
- "bindgen 0.65.1",
+ "bindgen",
  "bzip2-sys",
  "cc",
- "glob",
  "libc",
  "libz-sys",
  "lz4-sys",
@@ -5715,9 +5982,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.28"
+version = "1.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc3a226e576f50782b3305c5ccf458698f92798987f551c6a02efe8276721e22"
+checksum = "85bc9657773828b90eeb625adff10eeac83cc21bbfd8e23a03eaa8a33c9e28d9"
 dependencies = [
  "cc",
  "pkg-config",
@@ -5753,12 +6020,21 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 dependencies = [
  "serde_core",
  "value-bag",
+]
+
+[[package]]
+name = "lru"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999beba7b6e8345721bd280141ed958096a2e4abdf74f67ff4ce49b4b54e47a"
+dependencies = [
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -5768,6 +6044,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
  "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "lru"
+version = "0.16.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
+dependencies = [
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -5807,7 +6092,7 @@ checksum = "757aee279b8bdbb9f9e676796fd459e4207a1f986e87886700abf589f5abf771"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5839,9 +6124,9 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "matrixmultiply"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
+checksum = "3f607c237553f086e7043417a51df26b2eb899d3caff94e6a67592ff992fedc7"
 dependencies = [
  "autocfg",
  "rawpointer",
@@ -5859,9 +6144,21 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "merlin"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58c38e2799fc0978b65dfff8023ec7843e2330bb462f19198840b34b6582397d"
+dependencies = [
+ "byteorder",
+ "keccak 0.1.6",
+ "rand_core 0.6.4",
+ "zeroize",
+]
 
 [[package]]
 name = "mime"
@@ -5899,9 +6196,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
@@ -5955,7 +6252,7 @@ dependencies = [
 [[package]]
 name = "move-abstract-interpreter"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
 dependencies = [
  "move-binary-format",
  "move-bytecode-verifier-meter",
@@ -5964,18 +6261,16 @@ dependencies = [
 [[package]]
 name = "move-abstract-stack"
 version = "0.0.1"
-source = "git+https://github.com/iotaledger/iota?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
 
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/iotaledger/iota?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
 dependencies = [
  "anyhow",
- "enum-compat-util",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "move-core-types",
- "move-proc-macros",
  "ref-cast",
  "serde",
  "variant_count",
@@ -5984,12 +6279,12 @@ dependencies = [
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/iotaledger/iota?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
 
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6005,21 +6300,20 @@ dependencies = [
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
 dependencies = [
  "anyhow",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "move-binary-format",
  "move-core-types",
- "petgraph",
- "serde",
+ "petgraph 0.5.1",
  "serde-reflection",
 ]
 
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
 dependencies = [
  "move-abstract-interpreter",
  "move-abstract-stack",
@@ -6027,14 +6321,15 @@ dependencies = [
  "move-borrow-graph",
  "move-bytecode-verifier-meter",
  "move-core-types",
+ "move-regex-borrow-graph",
  "move-vm-config",
- "petgraph",
+ "petgraph 0.5.1",
 ]
 
 [[package]]
 name = "move-bytecode-verifier-meter"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
 dependencies = [
  "move-binary-format",
  "move-core-types",
@@ -6044,7 +6339,7 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6064,7 +6359,7 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/iotaledger/iota?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6072,7 +6367,6 @@ dependencies = [
  "codespan-reporting",
  "dunce",
  "hex",
- "insta",
  "lsp-types",
  "move-binary-format",
  "move-borrow-graph",
@@ -6085,21 +6379,20 @@ dependencies = [
  "move-proc-macros",
  "move-symbol-pool",
  "once_cell",
- "petgraph",
+ "petgraph 0.5.1",
  "rayon",
  "regex",
  "serde",
  "serde_json",
  "similar",
  "stacker",
- "tempfile",
  "vfs",
 ]
 
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/iotaledger/iota?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6111,43 +6404,42 @@ dependencies = [
  "num",
  "once_cell",
  "primitive-types 0.10.1",
- "rand 0.8.5",
+ "rand 0.8.7",
  "ref-cast",
  "serde",
  "serde_bytes",
  "serde_with",
  "thiserror 1.0.69",
- "uint",
+ "uint 0.9.5",
 ]
 
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
 dependencies = [
  "anyhow",
  "bcs",
  "clap",
  "codespan",
  "colored",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "move-abstract-interpreter",
  "move-binary-format",
  "move-bytecode-source-map",
  "move-command-line-common",
  "move-core-types",
  "move-ir-types",
- "petgraph",
+ "petgraph 0.5.1",
  "serde",
 ]
 
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
 dependencies = [
  "anyhow",
- "bcs",
  "clap",
  "hex",
  "inline_colorization",
@@ -6165,21 +6457,18 @@ dependencies = [
 [[package]]
 name = "move-docgen"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
 dependencies = [
  "anyhow",
  "clap",
  "codespan",
- "codespan-reporting",
  "itertools 0.10.5",
- "log",
  "move-binary-format",
  "move-compiler",
  "move-core-types",
  "move-ir-types",
  "move-model-2",
  "move-symbol-pool",
- "num",
  "once_cell",
  "regex",
  "serde",
@@ -6188,7 +6477,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -6206,7 +6495,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
 dependencies = [
  "anyhow",
  "hex",
@@ -6219,7 +6508,7 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
 dependencies = [
  "hex",
  "move-command-line-common",
@@ -6232,28 +6521,23 @@ dependencies = [
 [[package]]
 name = "move-model-2"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
 dependencies = [
  "anyhow",
  "bcs",
- "codespan-reporting",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "move-binary-format",
  "move-bytecode-source-map",
- "move-command-line-common",
  "move-compiler",
  "move-core-types",
  "move-ir-types",
  "move-symbol-pool",
- "num",
- "serde",
- "vfs",
 ]
 
 [[package]]
 name = "move-package"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
 dependencies = [
  "anyhow",
  "clap",
@@ -6272,7 +6556,7 @@ dependencies = [
  "move-symbol-pool",
  "named-lock",
  "once_cell",
- "petgraph",
+ "petgraph 0.5.1",
  "regex",
  "serde",
  "serde_yaml 0.8.26",
@@ -6289,16 +6573,26 @@ dependencies = [
 [[package]]
 name = "move-proc-macros"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "move-regex-borrow-graph"
+version = "0.0.1"
+source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
+dependencies = [
+ "move-binary-format",
+ "move-core-types",
+ "petgraph 0.5.1",
 ]
 
 [[package]]
 name = "move-stdlib-natives"
 version = "0.1.1"
-source = "git+https://github.com/iotaledger/iota?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
 dependencies = [
  "hex",
  "move-binary-format",
@@ -6306,14 +6600,14 @@ dependencies = [
  "move-vm-runtime",
  "move-vm-types",
  "sha2 0.10.9",
- "sha3",
+ "sha3 0.11.0",
  "smallvec",
 ]
 
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
 dependencies = [
  "once_cell",
  "phf 0.11.3",
@@ -6323,7 +6617,7 @@ dependencies = [
 [[package]]
 name = "move-trace-format"
 version = "0.0.1"
-source = "git+https://github.com/iotaledger/iota?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
 dependencies = [
  "move-binary-format",
  "move-core-types",
@@ -6334,7 +6628,7 @@ dependencies = [
 [[package]]
 name = "move-vm-config"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
 dependencies = [
  "move-binary-format",
  "once_cell",
@@ -6343,17 +6637,16 @@ dependencies = [
 [[package]]
 name = "move-vm-profiler"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
 dependencies = [
  "move-vm-config",
- "once_cell",
  "serde",
 ]
 
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
 dependencies = [
  "better_any",
  "fail",
@@ -6373,7 +6666,7 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -6387,7 +6680,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
 dependencies = [
  "bcs",
  "move-binary-format",
@@ -6400,9 +6693,9 @@ dependencies = [
 [[package]]
 name = "msim"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota-sim.git?branch=tokio-1.49.0#b8604de3e34a1b2a47601f3003ab98e5d7889c0e"
+source = "git+https://github.com/iotaledger/iota-sim.git?branch=tokio-1.52.2#2d1ddbb6e2d07f2d3541c4ee5710c725819ec917"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "async-task",
  "bytes",
  "cc",
@@ -6414,12 +6707,12 @@ dependencies = [
  "msim-macros",
  "naive-timer",
  "pin-project-lite",
- "rand 0.8.5",
+ "rand 0.8.7",
  "real_tokio",
  "serde",
  "socket2 0.5.10",
  "tap",
- "tokio-util 0.7.17",
+ "tokio-util 0.7.18",
  "toml 0.8.23",
  "tracing",
  "tracing-subscriber",
@@ -6428,7 +6721,7 @@ dependencies = [
 [[package]]
 name = "msim-macros"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota-sim.git?branch=tokio-1.49.0#b8604de3e34a1b2a47601f3003ab98e5d7889c0e"
+source = "git+https://github.com/iotaledger/iota-sim.git?branch=tokio-1.52.2#2d1ddbb6e2d07f2d3541c4ee5710c725819ec917"
 dependencies = [
  "darling 0.14.4",
  "proc-macro2",
@@ -6438,14 +6731,14 @@ dependencies = [
 
 [[package]]
 name = "multiaddr"
-version = "0.17.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b36f567c7099511fa8612bbbb52dda2419ce0bdbacf31714e3a5ffdb766d3bd"
+checksum = "fe6351f60b488e04c1d21bc69e56b89cb3f5e8f5d22557d6e8031bdfd79b6961"
 dependencies = [
  "arrayref",
  "byteorder",
  "data-encoding",
- "log",
+ "libp2p-identity",
  "multibase",
  "multihash",
  "percent-encoding",
@@ -6457,40 +6750,31 @@ dependencies = [
 
 [[package]]
 name = "multibase"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8694bb4835f452b0e3bb06dbebb1d6fc5385b6ca1caf2e55fd165c042390ec77"
+checksum = "7e0e4a371cbf1dfd666b658ba137763edb23c45beb43cfe369b5593cd6b437b6"
 dependencies = [
  "base-x",
  "base256emoji",
+ "base45",
  "data-encoding",
  "data-encoding-macro",
 ]
 
 [[package]]
 name = "multihash"
-version = "0.17.0"
+version = "0.19.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "835d6ff01d610179fbce3de1694d007e500bf33a7f29689838941d6bf783ae40"
+checksum = "577c63b00ad74d57e8c9aa870b5fccebf2fd64a308a5aee9f1bb88e4aea19447"
 dependencies = [
- "core2",
- "multihash-derive",
  "unsigned-varint",
 ]
 
 [[package]]
-name = "multihash-derive"
-version = "0.8.0"
+name = "multimap"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc076939022111618a5026d3be019fd8b366e76314538ff9a1b59ffbcbf98bcd"
-dependencies = [
- "proc-macro-crate 1.3.1",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "synstructure 0.12.6",
-]
+checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "naive-timer"
@@ -6510,7 +6794,7 @@ dependencies = [
  "num-complex",
  "num-rational",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.7",
  "rand_distr",
  "simba",
  "typenum",
@@ -6524,7 +6808,7 @@ checksum = "254a5372af8fc138e36684761d3c0cdb758a4410e938babcff1c860ce14ddbfc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6594,6 +6878,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "nonempty"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6610,6 +6903,25 @@ name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
+name = "notify"
+version = "6.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
+dependencies = [
+ "bitflags 2.13.1",
+ "crossbeam-channel",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio 0.8.11",
+ "walkdir",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "ntapi"
@@ -6645,7 +6957,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
 dependencies = [
- "num-bigint 0.4.6",
+ "num-bigint 0.4.8",
  "num-complex",
  "num-integer",
  "num-iter",
@@ -6666,13 +6978,13 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.6"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
 dependencies = [
  "num-integer",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.7",
  "serde",
 ]
 
@@ -6687,7 +6999,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.7",
  "smallvec",
  "zeroize",
 ]
@@ -6709,9 +7021,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -6724,40 +7036,39 @@ dependencies = [
 
 [[package]]
 name = "num-iter"
-version = "0.1.45"
+version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
 dependencies = [
- "autocfg",
  "num-integer",
  "num-traits",
 ]
 
 [[package]]
 name = "num-modular"
-version = "0.5.1"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64a5fe11d4135c3bcdf3a95b18b194afa9608a5f6ff034f5d857bc9a27fb0119"
+checksum = "17bb261bf36fa7d83f4c294f834e91256769097b3cb505d44831e0a179ac647f"
 dependencies = [
- "num-bigint 0.4.6",
+ "num-bigint 0.4.8",
  "num-integer",
  "num-traits",
 ]
 
 [[package]]
 name = "num-prime"
-version = "0.4.4"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e238432a7881ec7164503ccc516c014bf009be7984cde1ba56837862543bdec3"
+checksum = "b285c575532a33ef6fdd3a57640d0b1c70e6ca48644d6df7bbd4b7a0cfbbb12d"
 dependencies = [
- "bitvec 1.0.1",
+ "bitvec 1.1.1",
  "either",
- "lru",
- "num-bigint 0.4.6",
+ "lru 0.16.4",
+ "num-bigint 0.4.8",
  "num-integer",
  "num-modular",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.7",
 ]
 
 [[package]]
@@ -6766,7 +7077,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
 dependencies = [
- "num-bigint 0.4.6",
+ "num-bigint 0.4.8",
  "num-integer",
  "num-traits",
 ]
@@ -6810,7 +7121,64 @@ dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags 2.13.1",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags 2.13.1",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-io-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
+dependencies = [
+ "libc",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-open-directory"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb82bed227edf5201dfedf072bba4015a33d3d4a98519837295a90f0a23f676d"
+dependencies = [
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -6836,24 +7204,24 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body-util",
  "httparse",
  "humantime",
- "hyper 1.9.0",
+ "hyper 1.11.0",
  "itertools 0.14.0",
  "md-5",
  "parking_lot 0.12.5",
  "percent-encoding",
  "quick-xml",
- "rand 0.10.0",
+ "rand 0.10.2",
  "reqwest 0.12.28",
  "ring",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
  "url",
@@ -6890,27 +7258,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
-name = "openapiv3"
-version = "2.0.0"
-source = "git+https://github.com/bmwill/openapiv3.git?rev=ca4b4845b7c159a39f5c68ad8f7f76cb6f4d6963#ca4b4845b7c159a39f5c68ad8f7f76cb6f4d6963"
-dependencies = [
- "indexmap 2.13.1",
- "schemars 0.8.22",
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "openssl"
-version = "0.10.76"
+version = "0.10.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "cfg-if",
  "foreign-types",
  "libc",
- "once_cell",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -6923,7 +7279,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6934,9 +7290,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.112"
+version = "0.9.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
 dependencies = [
  "cc",
  "libc",
@@ -6966,7 +7322,7 @@ checksum = "91cf61a1868dacc576bf2b2a1c3e9ab150af7272909e80085c3173384fe11f76"
 dependencies = [
  "async-trait",
  "futures-core",
- "http 1.4.0",
+ "http 1.4.2",
  "opentelemetry",
  "opentelemetry-proto",
  "opentelemetry_sdk",
@@ -7004,7 +7360,7 @@ dependencies = [
  "glob",
  "opentelemetry",
  "percent-encoding",
- "rand 0.8.5",
+ "rand 0.8.7",
  "serde_json",
  "thiserror 1.0.69",
  "tokio",
@@ -7050,7 +7406,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -7063,7 +7419,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -7083,6 +7439,18 @@ name = "p256"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "p384"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -7121,7 +7489,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36b29691432cc9eff8b282278473b63df73bea49bc3ec5e67f31a3ae9c3ec190"
 dependencies = [
- "bitvec 1.0.1",
+ "bitvec 1.1.1",
  "packed_struct_codegen",
  "serde",
 ]
@@ -7178,7 +7546,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "799781ae679d79a948e13d4824a40970bfa500058d245760dd857301059810fa"
 dependencies = [
  "arrayvec",
- "bitvec 1.0.1",
+ "bitvec 1.1.1",
  "byte-slice-cast",
  "const_format",
  "impl-trait-for-tuples",
@@ -7208,7 +7576,7 @@ dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -7271,14 +7639,14 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77144664f6aac5f629d7efa815f5098a054beeeca6ccafee5ec453fd2b0c53f9"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "ciborium",
  "coset",
  "data-encoding",
  "getrandom 0.2.17",
  "hmac",
- "indexmap 2.13.1",
- "rand 0.8.5",
+ "indexmap 2.14.0",
+ "rand 0.8.7",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -7289,16 +7657,16 @@ dependencies = [
 
 [[package]]
 name = "pasta_curves"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e57598f73cc7e1b2ac63c79c517b31a0877cd7c402cdcaa311b5208de7a095"
+checksum = "3437083215c505e867eea5478371feba43d7689d6d15ec0a209eb46fb0d4cda6"
 dependencies = [
  "blake2b_simd",
  "ff",
  "group",
  "hex",
  "lazy_static",
- "rand 0.8.5",
+ "rand 0.8.7",
  "serde",
  "static_assertions",
  "subtle",
@@ -7330,12 +7698,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "peeking_take_while"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
-
-[[package]]
 name = "pem"
 version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7343,15 +7705,6 @@ checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
  "base64 0.22.1",
  "serde_core",
-]
-
-[[package]]
-name = "pem-rfc7468"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d159833a9105500e0398934e205e0773f0b27529557134ecfc51c27646adac"
-dependencies = [
- "base64ct",
 ]
 
 [[package]]
@@ -7380,6 +7733,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset 0.5.7",
+ "hashbrown 0.15.5",
+ "indexmap 2.14.0",
+]
+
+[[package]]
 name = "phf"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7405,7 +7769,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared 0.11.3",
- "rand 0.8.5",
+ "rand 0.8.7",
 ]
 
 [[package]]
@@ -7418,7 +7782,7 @@ dependencies = [
  "phf_shared 0.11.3",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -7441,22 +7805,22 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.11"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.11"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -7484,24 +7848,13 @@ dependencies = [
 
 [[package]]
 name = "pkcs1"
-version = "0.4.1"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eff33bdbdfc54cc98a2eca766ebdec3e1b8fb7387523d5c9c9a2891da856f719"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
 dependencies = [
- "der 0.6.1",
- "pkcs8 0.9.0",
- "spki 0.6.0",
- "zeroize",
-]
-
-[[package]]
-name = "pkcs8"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
-dependencies = [
- "der 0.6.1",
- "spki 0.6.0",
+ "der",
+ "pkcs8",
+ "spki",
 ]
 
 [[package]]
@@ -7510,15 +7863,15 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der 0.7.10",
- "spki 0.7.3",
+ "der",
+ "spki",
 ]
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plain"
@@ -7558,14 +7911,14 @@ version = "0.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a63d338dec139f56dacc692ca63ad35a6be6a797442479b55acd611d79e906"
 dependencies = [
- "nom",
+ "nom 7.1.3",
 ]
 
 [[package]]
 name = "portable-atomic"
-version = "1.13.1"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
 
 [[package]]
 name = "potential_utf"
@@ -7629,7 +7982,7 @@ checksum = "1f1799f398371ad6957951ec446d3ff322d35c46d9db2e217b67e828b311c249"
 dependencies = [
  "hex",
  "primitive-types 0.12.2",
- "uint",
+ "uint 0.9.5",
 ]
 
 [[package]]
@@ -7639,7 +7992,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -7660,7 +8013,7 @@ dependencies = [
  "fixed-hash 0.7.0",
  "impl-codec 0.5.1",
  "impl-serde 0.3.2",
- "uint",
+ "uint 0.9.5",
 ]
 
 [[package]]
@@ -7672,7 +8025,19 @@ dependencies = [
  "fixed-hash 0.8.0",
  "impl-codec 0.6.0",
  "impl-serde 0.4.0",
- "uint",
+ "uint 0.9.5",
+]
+
+[[package]]
+name = "primitive-types"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "721a1da530b5a2633218dc9f75713394c983c352be88d2d7c9ee85e2c4c21794"
+dependencies = [
+ "fixed-hash 0.8.0",
+ "impl-codec 0.7.1",
+ "impl-serde 0.5.0",
+ "uint 0.10.0",
 ]
 
 [[package]]
@@ -7691,7 +8056,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.11+spec-1.1.0",
+ "toml_edit 0.25.13+spec-1.1.0",
 ]
 
 [[package]]
@@ -7719,32 +8084,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error-attr2"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "proc-macro-error2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
-dependencies = [
- "proc-macro-error-attr2",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
@@ -7757,7 +8100,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
  "version_check",
  "yansi",
 ]
@@ -7774,16 +8117,26 @@ dependencies = [
  "memchr",
  "parking_lot 0.12.5",
  "protobuf",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
 name = "prometheus-closure-metric"
-version = "1.20.1"
-source = "git+https://github.com/iotaledger/iota?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+version = "1.29.0-alpha"
+source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
 dependencies = [
  "anyhow",
+ "prometheus-filtered",
+]
+
+[[package]]
+name = "prometheus-filtered"
+version = "1.29.0-alpha"
+source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
+dependencies = [
  "prometheus",
+ "serde",
+ "tracing",
 ]
 
 [[package]]
@@ -7798,12 +8151,33 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
+checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
 dependencies = [
  "bytes",
- "prost-derive 0.14.3",
+ "prost-derive 0.14.4",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
+dependencies = [
+ "heck 0.5.0",
+ "itertools 0.14.0",
+ "log",
+ "multimap",
+ "petgraph 0.8.3",
+ "prettyplease",
+ "prost 0.14.4",
+ "prost-types 0.14.4",
+ "pulldown-cmark",
+ "pulldown-cmark-to-cmark",
+ "regex",
+ "syn 2.0.119",
+ "tempfile",
 ]
 
 [[package]]
@@ -7816,20 +8190,20 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "prost-derive"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -7843,11 +8217,11 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
+checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
 dependencies = [
- "prost 0.14.3",
+ "prost 0.14.4",
 ]
 
 [[package]]
@@ -7872,12 +8246,32 @@ dependencies = [
 
 [[package]]
 name = "psm"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3852766467df634d74f0b2d7819bf8dc483a0eb2e3b0f50f756f9cfe8b0d18d8"
+checksum = "645dbe486e346d9b5de3ef16ede18c26e6c70ad97418f4874b8b1889d6e761ea"
 dependencies = [
  "ar_archive_writer",
  "cc",
+]
+
+[[package]]
+name = "pulldown-cmark"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9f068eba8e7071c5f9511831b44f32c740d5adf574e990f946ddb53db2f314e"
+dependencies = [
+ "bitflags 2.13.1",
+ "memchr",
+ "unicase",
+]
+
+[[package]]
+name = "pulldown-cmark-to-cmark"
+version = "22.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50793def1b900256624a709439404384204a5dc3a6ec580281bfaac35e882e90"
+dependencies = [
+ "pulldown-cmark",
 ]
 
 [[package]]
@@ -7897,9 +8291,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.39.2"
+version = "0.39.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
 dependencies = [
  "memchr",
  "serde",
@@ -7907,9 +8301,9 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.11.9"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -7917,10 +8311,10 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 2.1.2",
+ "rustc-hash 2.1.3",
  "rustls",
- "socket2 0.6.3",
- "thiserror 2.0.18",
+ "socket2 0.6.5",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
  "web-time",
@@ -7928,21 +8322,22 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
  "bytes",
  "fastbloom",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.10.2",
+ "rand_pcg 0.10.2",
  "ring",
- "rustc-hash 2.1.2",
+ "rustc-hash 2.1.3",
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tinyvec",
  "tracing",
  "web-time",
@@ -7950,23 +8345,23 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
 dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.6.5",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -8010,9 +8405,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -8021,9 +8416,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -8031,13 +8426,13 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
  "chacha20",
- "getrandom 0.4.2",
- "rand_core 0.10.0",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -8099,9 +8494,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_distr"
@@ -8110,7 +8505,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
 dependencies = [
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.7",
 ]
 
 [[package]]
@@ -8129,6 +8524,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59cad018caf63deb318e5a4586d99a24424a364f40f1e5778c29aca23f4fc73e"
 dependencies = [
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -8164,7 +8568,7 @@ version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -8175,9 +8579,9 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -8214,36 +8618,36 @@ checksum = "08ad765b21a08b1a8e5cdce052719188a23772bcbefb3c439f0baaf62c56ceac"
 
 [[package]]
 name = "readonly"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2a62d85ed81ca5305dc544bd42c8804c5060b78ffa5ad3c64b0fb6a8c13d062"
+checksum = "67a77cd6f1a55ff3cb1969c2618f73107efaa6de1daf796ad60ce8f737ae97c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "real_tokio"
-version = "1.49.0"
-source = "git+https://github.com/iotaledger/tokio-madsim-fork.git?rev=6b1da10b18f9a4b1d42b1432415a0b3092908c77#6b1da10b18f9a4b1d42b1432415a0b3092908c77"
+version = "1.52.2"
+source = "git+https://github.com/iotaledger/tokio-madsim-fork.git?rev=2892d62df4a95d629aede23af941303566828b9f#2892d62df4a95d629aede23af941303566828b9f"
 dependencies = [
  "bytes",
  "libc",
- "mio 1.2.0",
+ "mio 1.2.2",
  "parking_lot 0.12.5",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.3",
- "tokio-macros 2.6.0",
+ "socket2 0.6.5",
+ "tokio-macros",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "redis"
-version = "0.24.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c580d9cbbe1d1b479e8d67cf9daf6a62c957e6846048408b80b43ac3f6af84cd"
+checksum = "9e23805debcc4435229c51187c0023a4d04499d354c101490e60744c087e973a"
 dependencies = [
  "arc-swap",
  "async-std",
@@ -8260,7 +8664,7 @@ dependencies = [
  "socket2 0.4.10",
  "tokio",
  "tokio-retry",
- "tokio-util 0.7.18",
+ "tokio-util 0.7.19",
  "url",
 ]
 
@@ -8279,16 +8683,16 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.3"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
+checksum = "07507be7b4a5f9f26eeb41eeaebb1f5a7ff29dfb29739facc21d35bf8b11c21e"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -8300,6 +8704,19 @@ dependencies = [
  "getrandom 0.2.17",
  "libredox",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "reed-solomon-erasure"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7263373d500d4d4f505d43a2a662d475a894aa94503a1ee28e9188b5f3960d4f"
+dependencies = [
+ "libm",
+ "lru 0.7.8",
+ "parking_lot 0.11.2",
+ "smallvec",
+ "spin",
 ]
 
 [[package]]
@@ -8316,22 +8733,22 @@ dependencies = [
 
 [[package]]
 name = "ref-cast"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -8340,7 +8757,7 @@ version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40a64b3a635fad9000648b4d8a59c8710c523ab61a23d392a7d91d47683f5adc"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "fluent-uri",
  "once_cell",
  "parking_lot 0.12.5",
@@ -8350,9 +8767,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -8362,9 +8779,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -8373,9 +8790,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "regorus"
@@ -8393,7 +8810,7 @@ dependencies = [
  "jsonschema",
  "lazy_static",
  "md-5",
- "rand 0.9.2",
+ "rand 0.9.5",
  "regex",
  "scientific",
  "semver",
@@ -8457,11 +8874,11 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.4.13",
- "http 1.4.0",
- "http-body 1.0.1",
+ "h2 0.4.15",
+ "http 1.4.2",
+ "http-body 1.1.0",
  "http-body-util",
- "hyper 1.9.0",
+ "hyper 1.11.0",
  "hyper-rustls",
  "hyper-util",
  "js-sys",
@@ -8478,9 +8895,9 @@ dependencies = [
  "sync_wrapper 1.0.2",
  "tokio",
  "tokio-rustls",
- "tokio-util 0.7.18",
+ "tokio-util 0.7.19",
  "tower 0.5.3",
- "tower-http 0.6.8",
+ "tower-http 0.6.11",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -8525,9 +8942,9 @@ dependencies = [
 
 [[package]]
 name = "roaring"
-version = "0.11.3"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ba9ce64a8f45d7fc86358410bb1a82e8c987504c0d4900e9141d69a9f26c885"
+checksum = "1dedc5658c6ecb3bdb5ef5f3295bb9253f42dcf3fd1402c03f6b1f7659c3c4a9"
 dependencies = [
  "bytemuck",
  "byteorder",
@@ -8535,9 +8952,9 @@ dependencies = [
 
 [[package]]
 name = "rocksdb"
-version = "0.21.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb6f170a4041d50a0ce04b0d2e14916d6ca863ea2e422689a5b694395d299ffe"
+checksum = "ddb7af00d2b17dbd07d82c0063e25411959748ff03e8d4f96134c2ff41fce34f"
 dependencies = [
  "libc",
  "librocksdb-sys",
@@ -8560,21 +8977,21 @@ dependencies = [
 
 [[package]]
 name = "rsa"
-version = "0.8.2"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55a77d189da1fee555ad95b7e50e7457d91c0e089ec68ca69ad2989413bbdab4"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
 dependencies = [
- "byteorder",
+ "const-oid 0.9.6",
  "digest 0.10.7",
  "num-bigint-dig",
  "num-integer",
- "num-iter",
  "num-traits",
  "pkcs1",
- "pkcs8 0.9.0",
+ "pkcs8",
  "rand_core 0.6.4",
  "sha2 0.10.9",
  "signature 2.2.0",
+ "spki",
  "subtle",
  "zeroize",
 ]
@@ -8587,9 +9004,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustc-hex"
@@ -8622,7 +9039,7 @@ version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
 dependencies = [
- "nom",
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -8631,7 +9048,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -8640,9 +9057,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
 dependencies = [
  "log",
  "once_cell",
@@ -8655,9 +9072,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
 dependencies = [
  "openssl-probe",
  "rustls-pki-types",
@@ -8676,9 +9093,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
  "web-time",
  "zeroize",
@@ -8713,9 +9130,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -8724,9 +9141,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "ryu"
@@ -8736,9 +9153,9 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "ryu-js"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd29631678d6fb0903b69223673e122c32e9ae559d0960a38d574695ebc0ea15"
+checksum = "04d056b875a9d2e6cb9a61d127afee9ac5999b9f87bcb32079d1318e505be714"
 
 [[package]]
 name = "safe_arch"
@@ -8794,9 +9211,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+checksum = "687274d293b6cdc6e73e0fee520bf2049650090d7164f87672d212a3c530cf4a"
 dependencies = [
  "dyn-clone",
  "ref-cast",
@@ -8813,7 +9230,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -8833,7 +9250,7 @@ checksum = "d2ee4885492bb655bfa05d039cd9163eb8fe9f79ddebf00ca23a1637510c2fd2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -8849,9 +9266,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
  "base16ct",
- "der 0.7.10",
+ "der",
  "generic-array",
- "pkcs8 0.10.2",
+ "pkcs8",
  "subtle",
  "zeroize",
 ]
@@ -8863,7 +9280,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25996b82292a7a57ed3508f052cfff8640d38d32018784acd714758b43da9c8f"
 dependencies = [
  "bitcoin_hashes",
- "rand 0.8.5",
+ "rand 0.8.7",
  "secp256k1-sys",
 ]
 
@@ -8882,7 +9299,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -8907,15 +9324,15 @@ checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "send_wrapper"
-version = "0.4.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f638d531eccd6e23b980caf34876660d38e265409d8e99b397ab71eb3612fad0"
+checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -8967,22 +9384,22 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -8993,16 +9410,16 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "itoa",
  "memchr",
  "serde",
@@ -9034,13 +9451,13 @@ dependencies = [
 
 [[package]]
 name = "serde_repr"
-version = "0.1.20"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -9066,17 +9483,18 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.18.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
 dependencies = [
  "base64 0.22.1",
+ "bs58 0.5.1",
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "schemars 0.9.0",
- "schemars 1.2.1",
+ "schemars 1.2.2",
  "serde_core",
  "serde_json",
  "serde_with_macros",
@@ -9085,14 +9503,14 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.18.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
+checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -9113,7 +9531,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "itoa",
  "ryu",
  "serde",
@@ -9122,9 +9540,9 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
@@ -9163,12 +9581,22 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
+checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
 dependencies = [
  "digest 0.10.7",
- "keccak",
+ "keccak 0.1.6",
+]
+
+[[package]]
+name = "sha3"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
+dependencies = [
+ "digest 0.11.3",
+ "keccak 0.2.0",
 ]
 
 [[package]]
@@ -9185,6 +9613,12 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook"
@@ -9248,9 +9682,9 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "similar"
@@ -9266,9 +9700,9 @@ checksum = "16e78919e05c9b8e123d435a4ad104b488ad1585631830e413830985c214086e"
 
 [[package]]
 name = "siphasher"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "sized-chunks"
@@ -9297,15 +9731,15 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "snap"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
+checksum = "199905e6153d6405f9728fe44daace35f8f837bbf830bb6e85fbd5828709a886"
 
 [[package]]
 name = "socket2"
@@ -9329,9 +9763,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -9346,18 +9780,18 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures",
- "http 1.4.0",
+ "http 1.4.2",
  "httparse",
  "log",
- "rand 0.8.5",
+ "rand 0.8.7",
  "sha1",
 ]
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 
 [[package]]
 name = "spinning_top"
@@ -9370,22 +9804,12 @@ dependencies = [
 
 [[package]]
 name = "spki"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
-dependencies = [
- "base64ct",
- "der 0.6.1",
-]
-
-[[package]]
-name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der 0.7.10",
+ "der",
 ]
 
 [[package]]
@@ -9396,27 +9820,27 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stacker"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d74a23609d509411d10e2176dc2a4346e3b4aea2e7b1869f19fdedbc71c013"
+checksum = "640c8cdd92b6b12f5bcb1803ca3bbf5ab96e5e6b6b96b9ab77dabe9e880b3190"
 dependencies = [
  "cc",
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "starfish-config"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
 dependencies = [
  "blake3",
  "fastcrypto",
  "iota-network-stack",
  "iota-sdk-types",
- "rand 0.8.5",
+ "rand 0.8.7",
  "rs_merkle",
  "serde",
  "tracing",
@@ -9425,9 +9849,9 @@ dependencies = [
 [[package]]
 name = "starfish-core"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "async-trait",
  "base64 0.21.7",
  "bcs",
@@ -9435,9 +9859,10 @@ dependencies = [
  "cfg-if",
  "dashmap",
  "enum_dispatch",
+ "eyre",
  "fastcrypto",
  "futures",
- "http 1.4.0",
+ "http 1.4.2",
  "iota-common",
  "iota-http",
  "iota-macros",
@@ -9447,25 +9872,24 @@ dependencies = [
  "iota-sdk-types",
  "iota-tls",
  "itertools 0.13.0",
- "lru",
- "nom",
+ "lru 0.12.5",
+ "nom 7.1.3",
  "parking_lot 0.12.5",
- "prometheus",
- "prost 0.14.3",
- "rand 0.8.5",
+ "prometheus-filtered",
+ "prost 0.14.4",
+ "rand 0.8.7",
  "reed-solomon-simd",
  "rs_merkle",
- "rustls",
  "serde",
  "starfish-config",
  "strum_macros 0.27.2",
  "tap",
+ "tempfile",
  "thiserror 1.0.69",
  "tokio",
- "tokio-rustls",
  "tokio-stream",
- "tokio-util 0.7.18",
- "tonic 0.14.5",
+ "tokio-util 0.7.19",
+ "tonic 0.14.6",
  "tonic-build",
  "tonic-prost",
  "tonic-rustls",
@@ -9490,7 +9914,7 @@ dependencies = [
  "approx",
  "nalgebra",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.7",
 ]
 
 [[package]]
@@ -9533,7 +9957,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -9545,7 +9969,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -9561,6 +9985,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
 
 [[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9573,9 +10003,20 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9599,38 +10040,27 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "unicode-xid",
-]
-
-[[package]]
-name = "synstructure"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "sysinfo"
-version = "0.33.1"
+version = "0.39.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fc858248ea01b66f19d8e8a6d55f41deaf91e9d495246fd01368d99935c6c01"
+checksum = "d2071df9448915b71c4fe6d25deaf1c22f12bd234f01540b77312bb8e41361e6"
 dependencies = [
- "core-foundation-sys",
  "libc",
  "memchr",
  "ntapi",
- "rayon",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "objc2-open-directory",
  "windows",
 ]
 
@@ -9693,8 +10123,8 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "telemetry-subscribers"
-version = "1.20.1"
-source = "git+https://github.com/iotaledger/iota?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+version = "1.29.0-alpha"
+source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
 dependencies = [
  "atomic_float",
  "bytes",
@@ -9710,9 +10140,9 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "parking_lot 0.12.5",
- "prometheus",
+ "prometheus-filtered",
  "prost 0.13.5",
- "rand 0.8.5",
+ "rand 0.8.7",
  "rustc_version_runtime",
  "serde",
  "thiserror 1.0.69",
@@ -9731,7 +10161,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -9764,8 +10194,8 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "test-cluster"
-version = "1.20.1"
-source = "git+https://github.com/iotaledger/iota?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+version = "1.29.0-alpha"
+source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
 dependencies = [
  "anyhow",
  "fastcrypto-zkp",
@@ -9781,6 +10211,9 @@ dependencies = [
  "iota-node",
  "iota-protocol-config",
  "iota-sdk",
+ "iota-sdk-grpc-client",
+ "iota-sdk-transaction-builder",
+ "iota-sdk-types",
  "iota-simulator",
  "iota-swarm",
  "iota-swarm-config",
@@ -9788,8 +10221,8 @@ dependencies = [
  "iota-types",
  "jsonrpsee",
  "move-binary-format",
- "prometheus",
- "rand 0.8.5",
+ "prometheus-filtered",
+ "rand 0.8.7",
  "tokio",
  "tracing",
 ]
@@ -9805,11 +10238,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
- "thiserror-impl 2.0.18",
+ "thiserror-impl 2.0.19",
 ]
 
 [[package]]
@@ -9820,25 +10253,25 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
 ]
@@ -9854,12 +10287,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "3e1d5e639ff6bab73cb6885cc7e7b1de96c3f32c68ec55f3952614bec1092244"
 dependencies = [
  "deranged",
- "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -9869,15 +10301,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
 dependencies = [
  "num-conv",
  "time-core",
@@ -9893,7 +10325,7 @@ dependencies = [
  "hmac",
  "once_cell",
  "pbkdf2 0.11.0",
- "rand 0.8.5",
+ "rand 0.8.7",
  "rustc-hash 1.1.0",
  "sha2 0.10.9",
  "thiserror 1.0.69",
@@ -9914,9 +10346,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -9929,41 +10361,31 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.51.0"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bd1c4c0fc4a7ab90fc15ef6daaa3ec3b893f004f915f2392557ed23237820cd"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
- "mio 1.2.0",
+ "mio 1.2.2",
  "parking_lot 0.12.5",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.3",
- "tokio-macros 2.7.0",
+ "socket2 0.6.5",
+ "tokio-macros",
  "tracing",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
-source = "git+https://github.com/iotaledger/tokio-madsim-fork.git?rev=6b1da10b18f9a4b1d42b1432415a0b3092908c77#6b1da10b18f9a4b1d42b1432415a0b3092908c77"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "tokio-macros"
-version = "2.7.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+checksum = "6328af13490e73a9b4694030fafd93f8c8c6a9dede33e821c3fc63eddf8042ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -9978,12 +10400,12 @@ dependencies = [
 
 [[package]]
 name = "tokio-retry"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f57eb36ecbe0fc510036adff84824dd3c24bb781e21bfa67b69d556aa85214f"
+checksum = "4a129d95275ebf4c493ec53bf0f8cd95f5ac161bc4f381700809a54f595d4470"
 dependencies = [
- "pin-project",
- "rand 0.8.5",
+ "pin-project-lite",
+ "rand 0.10.2",
  "tokio",
 ]
 
@@ -9999,21 +10421,21 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+checksum = "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
 dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
- "tokio-util 0.7.18",
+ "tokio-util 0.7.19",
 ]
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
 dependencies = [
  "futures-util",
  "log",
@@ -10023,8 +10445,8 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.17"
-source = "git+https://github.com/iotaledger/tokio-madsim-fork.git?rev=6b1da10b18f9a4b1d42b1432415a0b3092908c77#6b1da10b18f9a4b1d42b1432415a0b3092908c77"
+version = "0.7.18"
+source = "git+https://github.com/iotaledger/tokio-madsim-fork.git?rev=2892d62df4a95d629aede23af941303566828b9f#2892d62df4a95d629aede23af941303566828b9f"
 dependencies = [
  "bytes",
  "futures-core",
@@ -10039,15 +10461,16 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-io",
  "futures-sink",
  "futures-util",
+ "libc",
  "pin-project-lite",
  "tokio",
 ]
@@ -10097,7 +10520,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "toml_datetime 0.6.11",
  "winnow 0.5.40",
 ]
@@ -10108,7 +10531,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "serde",
  "serde_spanned",
  "toml_datetime 0.6.11",
@@ -10118,23 +10541,23 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.11+spec-1.1.0"
+version = "0.25.13+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
 dependencies = [
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow 1.0.1",
+ "winnow 1.0.4",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
- "winnow 1.0.1",
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -10154,11 +10577,11 @@ dependencies = [
  "axum 0.7.9",
  "base64 0.22.1",
  "bytes",
- "h2 0.4.13",
- "http 1.4.0",
- "http-body 1.0.1",
+ "h2 0.4.15",
+ "http 1.4.2",
+ "http-body 1.1.0",
  "http-body-util",
- "hyper 1.9.0",
+ "hyper 1.11.0",
  "hyper-timeout",
  "hyper-util",
  "percent-encoding",
@@ -10175,24 +10598,25 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
+checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
 dependencies = [
  "async-trait",
- "axum 0.8.8",
+ "axum 0.8.9",
  "base64 0.22.1",
  "bytes",
- "h2 0.4.13",
- "http 1.4.0",
- "http-body 1.0.1",
+ "h2 0.4.15",
+ "http 1.4.2",
+ "http-body 1.1.0",
  "http-body-util",
- "hyper 1.9.0",
+ "hyper 1.11.0",
  "hyper-timeout",
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "socket2 0.6.3",
+ "rustls-native-certs",
+ "socket2 0.6.5",
  "sync_wrapper 1.0.2",
  "tokio",
  "tokio-rustls",
@@ -10206,38 +10630,54 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1882ac3bf5ef12877d7ed57aad87e75154c11931c2ba7e6cde5e22d63522c734"
+checksum = "c68f61875ac5293cf72e6c8cf0158086428c82c37229e98c840878f1706b0322"
 dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "tonic-health"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4ff0636fef47afb3ec02818f5bceb4377b8abb9d6a386aeade18bd6212f8eb7"
+checksum = "fcfab99db777fba2802f0dfa861d1628d1ae916fb199d29819941f139ae85082"
 dependencies = [
- "prost 0.14.3",
+ "prost 0.14.4",
  "tokio",
  "tokio-stream",
- "tonic 0.14.5",
+ "tonic 0.14.6",
  "tonic-prost",
 ]
 
 [[package]]
 name = "tonic-prost"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
+checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
 dependencies = [
  "bytes",
- "prost 0.14.3",
- "tonic 0.14.5",
+ "prost 0.14.4",
+ "tonic 0.14.6",
+]
+
+[[package]]
+name = "tonic-prost-build"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "654e5643eff75d7f8c99197ce1440ed19a3474eada74c12bbac488b2cafdae27"
+dependencies = [
+ "prettyplease",
+ "proc-macro2",
+ "prost-build",
+ "prost-types 0.14.4",
+ "quote",
+ "syn 2.0.119",
+ "tempfile",
+ "tonic-build",
 ]
 
 [[package]]
@@ -10248,11 +10688,11 @@ checksum = "9b2874b26095e47313b6126f9e8144580a916af2151f778a4fec01a0120fed85"
 dependencies = [
  "async-stream",
  "bytes",
- "h2 0.4.13",
- "http 1.4.0",
- "http-body 1.0.1",
+ "h2 0.4.15",
+ "http 1.4.2",
+ "http-body 1.1.0",
  "http-body-util",
- "hyper 1.9.0",
+ "hyper 1.11.0",
  "hyper-timeout",
  "hyper-util",
  "pin-project",
@@ -10260,7 +10700,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-stream",
- "tonic 0.14.5",
+ "tonic 0.14.6",
  "tower 0.5.3",
  "tower-layer",
  "tower-service",
@@ -10279,10 +10719,10 @@ dependencies = [
  "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
- "rand 0.8.5",
+ "rand 0.8.7",
  "slab",
  "tokio",
- "tokio-util 0.7.18",
+ "tokio-util 0.7.19",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -10296,12 +10736,12 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "pin-project-lite",
  "slab",
  "sync_wrapper 1.0.2",
  "tokio",
- "tokio-util 0.7.18",
+ "tokio-util 0.7.19",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -10313,10 +10753,10 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "bytes",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http 1.4.2",
+ "http-body 1.1.0",
  "http-body-util",
  "pin-project-lite",
  "tokio",
@@ -10327,20 +10767,20 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "bytes",
  "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
- "iri-string",
+ "http 1.4.2",
+ "http-body 1.1.0",
  "pin-project-lite",
  "tower 0.5.3",
  "tower-layer",
  "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -10369,12 +10809,13 @@ dependencies = [
 
 [[package]]
 name = "tracing-appender"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "786d480bce6247ab75f005b14ae1624ad978d3029d9113f0a22fa1ac773faeaf"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
 dependencies = [
  "crossbeam-channel",
- "thiserror 2.0.18",
+ "symlink",
+ "thiserror 2.0.19",
  "time",
  "tracing-subscriber",
 ]
@@ -10387,7 +10828,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -10486,19 +10927,18 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
 dependencies = [
  "bytes",
  "data-encoding",
- "http 1.4.0",
+ "http 1.4.2",
  "httparse",
  "log",
- "rand 0.9.2",
+ "rand 0.9.5",
  "sha1",
- "thiserror 2.0.18",
- "utf-8",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -10508,32 +10948,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
- "rand 0.8.5",
+ "rand 0.8.7",
  "static_assertions",
 ]
 
 [[package]]
 name = "typed-store"
-version = "1.20.1"
-source = "git+https://github.com/iotaledger/iota?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+version = "1.29.0-alpha"
+source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
 dependencies = [
  "backoff",
  "bcs",
  "bincode",
  "collectable",
  "eyre",
+ "fastcrypto",
  "fdlimit",
  "hdrhistogram",
+ "iota-common",
  "iota-macros",
+ "iota-metrics",
  "msim",
+ "num_cpus",
  "once_cell",
  "ouroboros 0.18.5",
- "prometheus",
- "rand 0.8.5",
+ "prometheus-filtered",
+ "rand 0.8.7",
  "rocksdb",
  "serde",
+ "sysinfo",
  "tap",
- "thiserror 1.0.69",
  "tokio",
  "tracing",
  "typed-store-derive",
@@ -10542,8 +10986,8 @@ dependencies = [
 
 [[package]]
 name = "typed-store-derive"
-version = "1.20.1"
-source = "git+https://github.com/iotaledger/iota?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+version = "1.29.0-alpha"
+source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10552,8 +10996,8 @@ dependencies = [
 
 [[package]]
 name = "typed-store-error"
-version = "1.20.1"
-source = "git+https://github.com/iotaledger/iota?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+version = "1.29.0-alpha"
+source = "git+https://github.com/iotaledger/iota?rev=f47b4448f7efaa50ae79156c163fed11b926c7da#f47b4448f7efaa50ae79156c163fed11b926c7da"
 dependencies = [
  "serde",
  "thiserror 1.0.69",
@@ -10567,9 +11011,9 @@ checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "typeshare"
@@ -10590,7 +11034,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "621963e302416b389a1ec177397e9e62de849a78bd8205d428608553def75350"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -10606,10 +11050,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "uint"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "909988d098b2f738727b161a106cfc7cab00c539c2687a8836f8e565976fb53e"
+dependencies = [
+ "byteorder",
+ "crunchy",
+ "hex",
+ "static_assertions",
+]
+
+[[package]]
 name = "unescape"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccb97dac3243214f8d8507998906ca3e2e0b900bf9bf4870477f125b82e68f6e"
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"
@@ -10625,6 +11087,12 @@ checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-width"
@@ -10656,7 +11124,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "subtle",
 ]
 
@@ -10668,9 +11136,9 @@ checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "unsigned-varint"
-version = "0.7.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6889a77d49f1f013504cec6bf97a2c730394adedaeb1deb5ea08949a50541105"
+checksum = "eb066959b24b5196ae73cb057f45598450d2c5f71460e98c49b738086eff9c06"
 
 [[package]]
 name = "untrusted"
@@ -10692,12 +11160,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "utf-8"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
-
-[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10711,13 +11173,13 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.0"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
 dependencies = [
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "js-sys",
- "rand 0.10.0",
+ "rand 0.10.2",
  "wasm-bindgen",
 ]
 
@@ -10740,19 +11202,30 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "value-bag"
-version = "1.12.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba6f5989077681266825251a52748b8c1d8a4ad098cc37e440103d0ea717fc0"
+checksum = "ef73bfbaf3216cb59c205d7176bee1194e0d84348979da31f4a71fefe3c2054e"
 
 [[package]]
-name = "variant_count"
-version = "1.2.0"
+name = "variadics_please"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1935e10c6f04d22688d07c0790f2fc0e1b1c5c2c55bc0cc87ed67656e587dd8"
+checksum = "41b6d82be61465f97d42bd1d15bf20f3b0a3a0905018f38f9d6f6962055b0b5c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "variant_count"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17c13b28baa922722e35ded153b394d0247b4942b4ad54f85713a7de672cdf0e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -10774,7 +11247,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee97e1d97bd593fb513912a07691b742361b3dd64ad56f2c694ea2dbfe0665d3"
 dependencies = [
  "itertools 0.10.5",
- "nom",
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -10822,18 +11295,9 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
-dependencies = [
- "wit-bindgen",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
  "wit-bindgen",
 ]
@@ -10846,9 +11310,9 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.117"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -10859,9 +11323,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.67"
+version = "0.4.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03623de6905b7206edd0a75f69f747f134b7f0a2323392d664448bf2d3c5d87e"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -10869,9 +11333,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.117"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -10879,46 +11343,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.117"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.117"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap 2.13.1",
- "wasm-encoder",
- "wasmparser",
 ]
 
 [[package]]
@@ -10935,18 +11377,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags 2.11.0",
- "hashbrown 0.15.5",
- "indexmap 2.13.1",
- "semver",
-]
-
-[[package]]
 name = "wax"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10954,7 +11384,7 @@ checksum = "8d12a78aa0bab22d2f26ed1a96df7ab58e8a93506a3e20adb47c51a93b4e1357"
 dependencies = [
  "const_format",
  "itertools 0.11.0",
- "nom",
+ "nom 7.1.3",
  "pori",
  "regex",
  "thiserror 1.0.69",
@@ -10962,9 +11392,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.94"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -10986,23 +11416,23 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75c7f0ef91146ebfb530314f5f1d24528d7f0767efbfd31dce919275413e393e"
 dependencies = [
- "webpki-root-certs 1.0.6",
+ "webpki-root-certs 1.0.9",
 ]
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.6"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
 dependencies = [
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.6"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -11067,24 +11497,23 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.57.0"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
- "windows-core 0.57.0",
- "windows-targets 0.52.6",
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
 ]
 
 [[package]]
-name = "windows-core"
-version = "0.57.0"
+name = "windows-collections"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
- "windows-implement 0.57.0",
- "windows-interface 0.57.0",
- "windows-result 0.1.2",
- "windows-targets 0.52.6",
+ "windows-core",
 ]
 
 [[package]]
@@ -11093,22 +11522,22 @@ version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement 0.60.2",
- "windows-interface 0.59.3",
+ "windows-implement",
+ "windows-interface",
  "windows-link",
- "windows-result 0.4.1",
+ "windows-result",
  "windows-strings",
 ]
 
 [[package]]
-name = "windows-implement"
-version = "0.57.0"
+name = "windows-future"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
+ "windows-core",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -11119,18 +11548,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.57.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -11141,7 +11559,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -11151,12 +11569,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
-name = "windows-result"
-version = "0.1.2"
+name = "windows-numerics"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-core",
+ "windows-link",
 ]
 
 [[package]]
@@ -11215,15 +11634,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -11270,7 +11680,7 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
+ "windows_i686_gnullvm",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
@@ -11278,20 +11688,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-targets"
-version = "0.53.5"
+name = "windows-threading"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
 dependencies = [
  "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -11313,12 +11715,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11335,12 +11731,6 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -11361,22 +11751,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -11397,12 +11775,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11419,12 +11791,6 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -11445,12 +11811,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11467,12 +11827,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -11494,9 +11848,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.1"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 dependencies = [
  "memchr",
 ]
@@ -11521,9 +11875,9 @@ dependencies = [
  "base64 0.22.1",
  "deadpool",
  "futures",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body-util",
- "hyper 1.9.0",
+ "hyper 1.11.0",
  "hyper-util",
  "log",
  "once_cell",
@@ -11536,91 +11890,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.51.0"
+version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck 0.5.0",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck 0.5.0",
- "indexmap 2.13.1",
- "prettyplease",
- "syn 2.0.117",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags 2.11.0",
- "indexmap 2.13.1",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap 2.13.1",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "writeable"
@@ -11653,10 +11925,11 @@ dependencies = [
  "data-encoding",
  "der-parser",
  "lazy_static",
- "nom",
+ "nom 7.1.3",
  "oid-registry",
+ "ring",
  "rusticata-macros",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "time",
 ]
 
@@ -11686,9 +11959,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -11703,35 +11976,35 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
- "synstructure 0.13.2",
+ "syn 2.0.119",
+ "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]
@@ -11744,29 +12017,28 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
- "synstructure 0.13.2",
+ "syn 2.0.119",
+ "synstructure",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 dependencies = [
- "serde",
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -11799,14 +12071,14 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
 
 [[package]]
 name = "zstd"
@@ -11832,7 +12104,6 @@ version = "2.0.16+zstd.1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
 dependencies = [
- "bindgen 0.72.1",
  "cc",
  "pkg-config",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,32 +8,43 @@ repository = "https://github.com/iotaledger/gas-station"
 
 [dependencies]
 
-fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "69d496c71fb37e3d22fe85e5bbfd4256d61422b9" }
-
-iota-metrics = { git = "https://github.com/iotaledger/iota", tag = "v1.20.1", package = "iota-metrics" }
-iota-config = { git = "https://github.com/iotaledger/iota", tag = "v1.20.1", package = "iota-config" }
-iota-json-rpc-types = { git = "https://github.com/iotaledger/iota", tag = "v1.20.1", package = "iota-json-rpc-types" }
-iota-sdk = { git = "https://github.com/iotaledger/iota", tag = "v1.20.1", package = "iota-sdk" }
-iota-sdk-types = { package = "iota-sdk-types", git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "e19c78a1bee17e0bf85fcd5b16a2f080cef26274", features = [
+iota-sdk-types = { package = "iota-sdk-types", git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "b77fcd5ac5fedb3dfbc77ba7d183140e43512339", features = [
   "hash",
   "serde",
-  "schemars",
+  "rand",
 ] }
-iota-types = { git = "https://github.com/iotaledger/iota", tag = "v1.20.1", package = "iota-types" }
-telemetry-subscribers = { git = "https://github.com/iotaledger/iota", tag = "v1.20.1", package = "telemetry-subscribers" }
+iota-sdk-crypto = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "b77fcd5ac5fedb3dfbc77ba7d183140e43512339", features = [
+  "ed25519",
+  "secp256k1",
+  "secp256r1",
+  "bech32",
+] }
+iota-sdk-grpc-client = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "b77fcd5ac5fedb3dfbc77ba7d183140e43512339" }
+iota-sdk-grpc-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "b77fcd5ac5fedb3dfbc77ba7d183140e43512339" }
+iota-sdk-transaction-builder = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "b77fcd5ac5fedb3dfbc77ba7d183140e43512339" }
 
 
 anyhow = "1.0.75"
 async-trait = "0.1.51"
 arc-swap = { version = "1.7.1" }
 axum = { version = "0.6.6", features = ["headers"] }
+base64ct = { version = "1.6", features = ["alloc", "std"] }
 bcs = "0.1.6"
-clap = { version = "4.4.10", features = ["env"] }
+# "derive"/"wrap_help" used to be pulled in transitively (this crate itself never
+# requested them) via the now-removed `iota-config`'s `clap.workspace = true`,
+# whose monorepo workspace `[workspace.dependencies]` set `clap = { features =
+# ["derive", "wrap_help"] }`. Removing `iota-config` exposed that this crate's
+# own `#[derive(Parser)]`/`#[derive(ValueEnum)]`/`#[command]`/`#[arg]` usage
+# (`src/command.rs`, `src/bin/tool.rs`, `src/main.rs`, `src/benchmarks/mod.rs`)
+# was silently relying on someone else's feature request the whole time; now
+# declared explicitly and directly by the crate that actually needs it.
+clap = { version = "4.4.10", features = ["env", "derive", "wrap_help"] }
 chrono = "0.4.19"
 const-str = "0.5.6"
 eyre = "0.6.9"
 futures-util = "0.3.30"
 git-version = "0.3.9"
+hex = "0.4"
 hostname = "0.4.0"
 itertools = "0.14.0"
 once_cell = "1.19.0"
@@ -49,9 +60,18 @@ reqwest = { version = "0.11.22", features = ["json"] }
 serde = { version = "1.0.193", features = ["derive", "rc"] }
 serde_with = "3.4.0"
 schemars = "0.8.16"
+sha2 = "0.10"
 tap = "1.0.1"
 tempfile = "3.2.0"
+tonic = { version = "0.14", default-features = false }
 tracing = "0.1.40"
+tracing-subscriber = { version = "0.3", features = [
+  "env-filter",
+  "fmt",
+  "json",
+  "ansi",
+  "registry",
+] }
 tokio = { version = "1.46", features = ["full"] }
 tokio-retry = "0.3.0"
 serde_json = "1.0.95"
@@ -68,8 +88,42 @@ url = { version = "2.5.7", features = ["serde"] }
 indoc = "2"
 rand = "0.8.5"
 wiremock = "0.6.3"
-iota-swarm-config = { git = "https://github.com/iotaledger/iota", tag = "v1.20.1", package = "iota-swarm-config" }
-test-cluster = { git = "https://github.com/iotaledger/iota", tag = "v1.20.1", package = "test-cluster" }
+iota-swarm-config = { git = "https://github.com/iotaledger/iota", rev = "f47b4448f7efaa50ae79156c163fed11b926c7da", package = "iota-swarm-config" }
+test-cluster = { git = "https://github.com/iotaledger/iota", rev = "f47b4448f7efaa50ae79156c163fed11b926c7da", package = "test-cluster" }
+# Used only by the `sponsored_transaction` example to build `HeaderName`/`HeaderValue`
+# values for `TransactionBuilder::add_gas_station_header`. That method's signature is
+# pinned to `iota-sdk-transaction-builder`'s own `reqwest` (0.12, i.e. `http` 1.x), which
+# is a different major version than this crate's own direct `reqwest = "0.11.22"` (i.e.
+# `http` 0.2.x) used everywhere in src/ -- the two are separate, non-interchangeable
+# types, so the example needs its own `http` 1.x handle. Both versions already coexist
+# in the dependency graph regardless (iota-sdk-transaction-builder pulls reqwest 0.12
+# transitively), so this adds no new dependency, just a direct name for one already
+# being built.
+http = "1"
+
+# `test-cluster`/`iota-swarm-config` above are pinned to the monorepo's `develop`
+# HEAD (rev f47b4448...). On that rev, the monorepo's own root `Cargo.toml` pins
+# `fastcrypto` itself to the crates.io release (`0.1.11`), but `fastcrypto-tbls`/
+# `-vdf`/`-zkp` are still resolved from a git rev (`47f8f6b7...`) that pulls its
+# own copy of `fastcrypto` via an in-repo *path* dependency -- which Cargo treats
+# as a separate, non-unifiable crate from the crates.io one, causing "multiple
+# different versions of crate `fastcrypto`" trait-impl errors wherever both meet
+# (e.g. `fastcrypto_tbls::dkg_v1::Message<G2Element, ...>`). The monorepo papers
+# over this internally with the exact patch table below (see `develop`'s root
+# `Cargo.toml`, `[patch."https://github.com/MystenLabs/fastcrypto"]`), redirecting
+# that git-path `fastcrypto` to the same crates.io release. Cargo patches don't
+# propagate to external consumers of a git dependency, so this crate needs its
+# own copy of that same patch to get the same fix for its `test-cluster`/
+# `iota-swarm-config` dev-dependencies.
+#
+# This is safe to add now (and not before) because this crate's own former
+# `fastcrypto` dependency (a *different*, older git rev,
+# `69d496c71fb37e3d22fe85e5bbfd4256d61422b9`) has just been removed above --
+# adding this patch while that dependency was still present would have silently
+# redirected it to crates.io `0.1.11` too, an unintended crate-wide behavior
+# change this migration is specifically trying to avoid.
+[patch."https://github.com/MystenLabs/fastcrypto"]
+fastcrypto = "=0.1.11"
 
 [profile.release]
 panic = "abort"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,14 +30,6 @@ arc-swap = { version = "1.7.1" }
 axum = { version = "0.6.6", features = ["headers"] }
 base64ct = { version = "1.6", features = ["alloc", "std"] }
 bcs = "0.1.6"
-# "derive"/"wrap_help" used to be pulled in transitively (this crate itself never
-# requested them) via the now-removed `iota-config`'s `clap.workspace = true`,
-# whose monorepo workspace `[workspace.dependencies]` set `clap = { features =
-# ["derive", "wrap_help"] }`. Removing `iota-config` exposed that this crate's
-# own `#[derive(Parser)]`/`#[derive(ValueEnum)]`/`#[command]`/`#[arg]` usage
-# (`src/command.rs`, `src/bin/tool.rs`, `src/main.rs`, `src/benchmarks/mod.rs`)
-# was silently relying on someone else's feature request the whole time; now
-# declared explicitly and directly by the crate that actually needs it.
 clap = { version = "4.4.10", features = ["env", "derive", "wrap_help"] }
 chrono = "0.4.19"
 const-str = "0.5.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,27 +101,8 @@ test-cluster = { git = "https://github.com/iotaledger/iota", rev = "f47b4448f7ef
 # being built.
 http = "1"
 
-# `test-cluster`/`iota-swarm-config` above are pinned to the monorepo's `develop`
-# HEAD (rev f47b4448...). On that rev, the monorepo's own root `Cargo.toml` pins
-# `fastcrypto` itself to the crates.io release (`0.1.11`), but `fastcrypto-tbls`/
-# `-vdf`/`-zkp` are still resolved from a git rev (`47f8f6b7...`) that pulls its
-# own copy of `fastcrypto` via an in-repo *path* dependency -- which Cargo treats
-# as a separate, non-unifiable crate from the crates.io one, causing "multiple
-# different versions of crate `fastcrypto`" trait-impl errors wherever both meet
-# (e.g. `fastcrypto_tbls::dkg_v1::Message<G2Element, ...>`). The monorepo papers
-# over this internally with the exact patch table below (see `develop`'s root
-# `Cargo.toml`, `[patch."https://github.com/MystenLabs/fastcrypto"]`), redirecting
-# that git-path `fastcrypto` to the same crates.io release. Cargo patches don't
-# propagate to external consumers of a git dependency, so this crate needs its
-# own copy of that same patch to get the same fix for its `test-cluster`/
-# `iota-swarm-config` dev-dependencies.
-#
-# This is safe to add now (and not before) because this crate's own former
-# `fastcrypto` dependency (a *different*, older git rev,
-# `69d496c71fb37e3d22fe85e5bbfd4256d61422b9`) has just been removed above --
-# adding this patch while that dependency was still present would have silently
-# redirected it to crates.io `0.1.11` too, an unintended crate-wide behavior
-# change this migration is specifically trying to avoid.
+# Patch fastcrypto to the same version the monorepo pins in its own
+# [patch] table; kept in sync by scripts/sync-sdk-rev.sh --with-monorepo.
 [patch."https://github.com/MystenLabs/fastcrypto"]
 fastcrypto = "=0.1.11"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,20 +8,20 @@ repository = "https://github.com/iotaledger/gas-station"
 
 [dependencies]
 
-iota-sdk-types = { package = "iota-sdk-types", git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "b77fcd5ac5fedb3dfbc77ba7d183140e43512339", features = [
+iota-sdk-types = { package = "iota-sdk-types", git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "2f021d0556e47564e9b04bcd0b3e8347c41a0a26", features = [
   "hash",
   "serde",
   "rand",
 ] }
-iota-sdk-crypto = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "b77fcd5ac5fedb3dfbc77ba7d183140e43512339", features = [
+iota-sdk-crypto = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "2f021d0556e47564e9b04bcd0b3e8347c41a0a26", features = [
   "ed25519",
   "secp256k1",
   "secp256r1",
   "bech32",
 ] }
-iota-sdk-grpc-client = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "b77fcd5ac5fedb3dfbc77ba7d183140e43512339" }
-iota-sdk-grpc-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "b77fcd5ac5fedb3dfbc77ba7d183140e43512339" }
-iota-sdk-transaction-builder = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "b77fcd5ac5fedb3dfbc77ba7d183140e43512339" }
+iota-sdk-grpc-client = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "2f021d0556e47564e9b04bcd0b3e8347c41a0a26" }
+iota-sdk-grpc-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "2f021d0556e47564e9b04bcd0b3e8347c41a0a26" }
+iota-sdk-transaction-builder = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "2f021d0556e47564e9b04bcd0b3e8347c41a0a26" }
 
 
 anyhow = "1.0.75"
@@ -80,8 +80,8 @@ url = { version = "2.5.7", features = ["serde"] }
 indoc = "2"
 rand = "0.8.5"
 wiremock = "0.6.3"
-iota-swarm-config = { git = "https://github.com/iotaledger/iota", rev = "f47b4448f7efaa50ae79156c163fed11b926c7da", package = "iota-swarm-config" }
-test-cluster = { git = "https://github.com/iotaledger/iota", rev = "f47b4448f7efaa50ae79156c163fed11b926c7da", package = "test-cluster" }
+iota-swarm-config = { git = "https://github.com/iotaledger/iota", rev = "066018d705bd3a1e29d5e9634a80adf693439587", package = "iota-swarm-config" }
+test-cluster = { git = "https://github.com/iotaledger/iota", rev = "066018d705bd3a1e29d5e9634a80adf693439587", package = "test-cluster" }
 http = "1"
 
 # Patch fastcrypto to the same version the monorepo pins in its own

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,15 +82,6 @@ rand = "0.8.5"
 wiremock = "0.6.3"
 iota-swarm-config = { git = "https://github.com/iotaledger/iota", rev = "f47b4448f7efaa50ae79156c163fed11b926c7da", package = "iota-swarm-config" }
 test-cluster = { git = "https://github.com/iotaledger/iota", rev = "f47b4448f7efaa50ae79156c163fed11b926c7da", package = "test-cluster" }
-# Used only by the `sponsored_transaction` example to build `HeaderName`/`HeaderValue`
-# values for `TransactionBuilder::add_gas_station_header`. That method's signature is
-# pinned to `iota-sdk-transaction-builder`'s own `reqwest` (0.12, i.e. `http` 1.x), which
-# is a different major version than this crate's own direct `reqwest = "0.11.22"` (i.e.
-# `http` 0.2.x) used everywhere in src/ -- the two are separate, non-interchangeable
-# types, so the example needs its own `http` 1.x handle. Both versions already coexist
-# in the dependency graph regardless (iota-sdk-transaction-builder pulls reqwest 0.12
-# transitively), so this adds no new dependency, just a direct name for one already
-# being built.
 http = "1"
 
 # Patch fastcrypto to the same version the monorepo pins in its own

--- a/README.md
+++ b/README.md
@@ -109,54 +109,30 @@ access-controller:
 
 ### Configuration parameters
 
-| Parameter                               | Db rebuild required?| Description                                                               | Example                                                                                         |
-| --------------------------------------- |---------------------|---------------------------------------------------------------------------| ----------------------------------------------------------------------------------------------- |
-| `signer-config`                         | no                  | Configuration of signer. It can be a local or an external KMS.            | See [down below](#signer-configuration)                                                         |
-| `rpc-host-ip`                           | no                  | IP address for the RPC server                                             | `0.0.0.0`                                                                                       |
-| `rpc-port`                              | no                  | Port for the RPC server                                                   | `9527`                                                                                          |
-| `metrics-port`                          | no                  | Port for collecting and exposing metrics                                  | `9184`                                                                                          |
-| `storage-config.redis.redis-url`        | no                  | Redis connection URL                                                      | `redis://127.0.0.1`                                                                             |
-| `fullnode-url`                          | yes ⚠               | **gRPC** endpoint of the IOTA full node. See [Upgrading from JSON-RPC to gRPC](#upgrading-from-json-rpc-to-grpc) if you are updating an existing deployment. | `https://grpc.testnet.iota.cafe`                                                            |
-| `coin-init-config.target-init-balance`  | yes ⚠               | Target balance for the new coins when we splitting new gas coins in NANOs | `100000000`                                                                                     |
-| `coin-init-config.refresh-interval-sec` | no                  | Interval in seconds to refresh balance and check for new coins to split   | `86400`                                                                                         |
-| `daily-gas-usage-cap`                   | no                  | Maximum allowed daily gas usage                                           | `1500000000000`                                                                                 |
-| `max-gas-budget`                        | no                  | Maximum allowed reservable gas budget                                     | `2000000000`                                                                                    |
-| `checkpoint-inclusion-timeout-ms`       | no                  | Milliseconds the full node should wait for a transaction to reach checkpoint inclusion (local execution) before responding, when a request asks to wait for local execution. Passed through as the gRPC `execute_transaction` call's `checkpoint_inclusion_timeout_ms`. Defaults to `10000` if omitted. | `10000` |
-| `access-controller.access-policy`       | no                  | Access policy mode.                                                       | `disabled`, `allow-all`, `deny-all`. See [this link](./docs/access-controller.md) to learn more |
+| Parameter | Db rebuild required? | Description | Example |
+| --- | --- | --- | --- |
+| `signer-config` | no | Configuration of signer. It can be a local or an external KMS. | See [down below](#signer-configuration) |
+| `rpc-host-ip` | no | IP address for the RPC server | `0.0.0.0` |
+| `rpc-port` | no | Port for the RPC server | `9527` |
+| `metrics-port` | no | Port for collecting and exposing metrics | `9184` |
+| `storage-config.redis.redis-url` | no | Redis connection URL | `redis://127.0.0.1` |
+| `fullnode-url` | yes ⚠ | **gRPC** endpoint of the IOTA full node. See [Upgrading from JSON-RPC to gRPC](./docs/common-issues.md#upgrading-from-json-rpc-to-grpc) if you are updating an existing deployment. | `https://grpc.testnet.iota.cafe` |
+| `coin-init-config.target-init-balance` | yes ⚠ | Target balance for the new coins when we splitting new gas coins in NANOs | `100000000` |
+| `coin-init-config.refresh-interval-sec` | no | Interval in seconds to refresh balance and check for new coins to split | `86400` |
+| `daily-gas-usage-cap` | no | Maximum allowed daily gas usage | `1500000000000` |
+| `max-gas-budget` | no | Maximum allowed reservable gas budget | `2000000000` |
+| `checkpoint-inclusion-timeout-ms` | no | Milliseconds the full node should wait for a transaction to reach checkpoint inclusion (local execution) before responding, when a request asks to wait for local execution. Passed through as the gRPC `execute_transaction` call's `checkpoint_inclusion_timeout_ms`. Defaults to `10000` if omitted. | `10000` |
+| `access-controller.access-policy` | no | Access policy mode. | `disabled`, `allow-all`, `deny-all`. See [this link](./docs/access-controller.md) to learn more |
 
 ### Upgrading from JSON-RPC to gRPC
 
-> **Operator-visible breaking change:** the Gas Station now talks to the IOTA full node over **gRPC** instead of JSON-RPC.
+> **Operator-visible breaking change:** the Gas Station now talks to the IOTA full node over **gRPC** instead of JSON-RPC. See [Upgrading from JSON-RPC to gRPC](./docs/common-issues.md#upgrading-from-json-rpc-to-grpc) for the migration steps when updating an existing deployment.
 
-**What changes:** `fullnode-url` must now point at the full node's **gRPC** endpoint instead of its JSON-RPC endpoint. The field is still a plain URL string; only the host/port/scheme you put there changes. For the public IOTA networks, that means:
-
-| Network  | Old JSON-RPC URL                    | New gRPC URL                        |
-| -------- | ------------------------------------ | ------------------------------------ |
-| Mainnet  | `https://api.mainnet.iota.cafe`     | `https://grpc.mainnet.iota.cafe` |
-| Testnet  | `https://api.testnet.iota.cafe`     | `https://grpc.testnet.iota.cafe` |
-| Devnet   | `https://api.devnet.iota.cafe`      | `https://grpc.devnet.iota.cafe`  |
-
-If you run your own full node, use its gRPC address instead.
-
-If `fullnode-url` still points at one of the three public JSON-RPC endpoints above, the Gas Station **automatically connects to the matching gRPC endpoint instead** and logs a warning at startup, so an existing deployment keeps working unmodified. This redirect only covers the well-known public hosts — a self-hosted JSON-RPC URL cannot be guessed and will simply fail at the first RPC call.
-
-**Why:** JSON-RPC is being retired upstream in favor of gRPC as the full node transport, so the Gas Station has moved to the [iota-rust-sdk](https://github.com/iotaledger/iota-rust-sdk) gRPC client ahead of that deprecation.
-
-**What you need to do when upgrading an existing deployment:**
-
-1. Repoint `fullnode-url` at your full node's gRPC endpoint (see table above, or the equivalent for your own node).
-2. Make sure the full node you're pointing at actually has its gRPC API enabled: `enable-grpc-api: true` in the node's own config (`grpc-api-config` can be left at its defaults unless you need to tune message-size or timeout limits). A node that only serves JSON-RPC will refuse the connection, or requests against it will fail.
-3. `fullnode-basic-auth`, if you use it, is unaffected and passed through the same way.
-
-**Changing `fullnode-url` changes the Redis storage namespace.** The Gas Station namespaces all of its Redis state (coin registry, reservations, daily gas usage counter) by the configured full node host, so repointing the URL makes it start from a fresh, empty namespace: the coin pool is re-initialized from the sponsor's on-chain coins, in-flight reservations are dropped, and the daily gas usage counter resets. The old namespace's keys are left behind in Redis and can be cleaned up manually. Because of this, update the URL on **all instances at once during a full stop** — in a rolling deploy, old and new instances would track the same on-chain coins in two independent namespaces and could hand out the same coin twice (equivocation). The automatic redirect described above deliberately does *not* change the namespace, so you can defer the config edit to a convenient maintenance window.
-
-Note also that the new gRPC client connects lazily, so a bad or unreachable `fullnode-url` will now surface as a connection error at startup or on first use, rather than at config-load time.
-
-#### Gas Station reinitialization
+### Gas Station reinitialization
 
 The configuration parameter `target-init-balance` requires the Redis database to be cleared (flushed) before any changes to those settings can take effect safely. If you modify these parameters, you will typically be notified that a reinitialization is required. To prevent accidental or unintended reinitializations — which may take a significant amount of time — you must explicitly start the gas station with the `--allow-reinit` flag to allow automatic reinitialization. Alternatively, you can revert the changed parameters to their original values and plan the reinitialization for a more convenient time.
 
-#### Signer Configuration
+### Signer Configuration
 
 You can configure the signer in two ways:
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ metrics-port: 9184
 storage-config:
   redis:
     redis-url: "redis://127.0.0.1"
-fullnode-url: "https://grpc.testnet.iota.cafe:443" # requires redis to be cleared, gRPC endpoint (see "Upgrading from JSON-RPC to gRPC" below)
+fullnode-url: "https://grpc.testnet.iota.cafe" # requires redis to be cleared, gRPC endpoint (see "Upgrading from JSON-RPC to gRPC" below)
 coin-init-config:
   target-init-balance: 100000000 # requires redis to be cleared
   refresh-interval-sec: 86400
@@ -116,7 +116,7 @@ access-controller:
 | `rpc-port`                              | no                  | Port for the RPC server                                                   | `9527`                                                                                          |
 | `metrics-port`                          | no                  | Port for collecting and exposing metrics                                  | `9184`                                                                                          |
 | `storage-config.redis.redis-url`        | no                  | Redis connection URL                                                      | `redis://127.0.0.1`                                                                             |
-| `fullnode-url`                          | yes ⚠               | **gRPC** endpoint of the IOTA full node. See [Upgrading from JSON-RPC to gRPC](#upgrading-from-json-rpc-to-grpc) if you are updating an existing deployment. | `https://grpc.testnet.iota.cafe:443`                                                            |
+| `fullnode-url`                          | yes ⚠               | **gRPC** endpoint of the IOTA full node. See [Upgrading from JSON-RPC to gRPC](#upgrading-from-json-rpc-to-grpc) if you are updating an existing deployment. | `https://grpc.testnet.iota.cafe`                                                            |
 | `coin-init-config.target-init-balance`  | yes ⚠               | Target balance for the new coins when we splitting new gas coins in NANOs | `100000000`                                                                                     |
 | `coin-init-config.refresh-interval-sec` | no                  | Interval in seconds to refresh balance and check for new coins to split   | `86400`                                                                                         |
 | `daily-gas-usage-cap`                   | no                  | Maximum allowed daily gas usage                                           | `1500000000000`                                                                                 |
@@ -132,9 +132,9 @@ access-controller:
 
 | Network  | Old JSON-RPC URL                    | New gRPC URL                        |
 | -------- | ------------------------------------ | ------------------------------------ |
-| Mainnet  | `https://api.mainnet.iota.cafe`     | `https://grpc.mainnet.iota.cafe:443` |
-| Testnet  | `https://api.testnet.iota.cafe`     | `https://grpc.testnet.iota.cafe:443` |
-| Devnet   | `https://api.devnet.iota.cafe`      | `https://grpc.devnet.iota.cafe:443`  |
+| Mainnet  | `https://api.mainnet.iota.cafe`     | `https://grpc.mainnet.iota.cafe` |
+| Testnet  | `https://api.testnet.iota.cafe`     | `https://grpc.testnet.iota.cafe` |
+| Devnet   | `https://api.devnet.iota.cafe`      | `https://grpc.devnet.iota.cafe`  |
 
 If you run your own full node, use its gRPC address instead.
 

--- a/README.md
+++ b/README.md
@@ -138,6 +138,8 @@ access-controller:
 
 If you run your own full node, use its gRPC address instead.
 
+If `fullnode-url` still points at one of the three public JSON-RPC endpoints above, the Gas Station **automatically connects to the matching gRPC endpoint instead** and logs a warning at startup, so an existing deployment keeps working unmodified. This redirect only covers the well-known public hosts — a self-hosted JSON-RPC URL cannot be guessed and will simply fail at the first RPC call.
+
 **Why:** JSON-RPC is being retired upstream in favor of gRPC as the full node transport, so the Gas Station has moved to the [iota-rust-sdk](https://github.com/iotaledger/iota-rust-sdk) gRPC client ahead of that deprecation.
 
 **What you need to do when upgrading an existing deployment:**
@@ -146,7 +148,9 @@ If you run your own full node, use its gRPC address instead.
 2. Make sure the full node you're pointing at actually has its gRPC API enabled: `enable-grpc-api: true` in the node's own config (`grpc-api-config` can be left at its defaults unless you need to tune message-size or timeout limits). A node that only serves JSON-RPC will refuse the connection, or requests against it will fail.
 3. `fullnode-basic-auth`, if you use it, is unaffected and passed through the same way.
 
-No Redis flush is required for this change by itself — the gas coin pool doesn't depend on the transport used to talk to the full node. Note also that the new gRPC client connects lazily, so a bad or unreachable `fullnode-url` will now surface as a connection error at startup or on first use, rather than at config-load time.
+**Changing `fullnode-url` changes the Redis storage namespace.** The Gas Station namespaces all of its Redis state (coin registry, reservations, daily gas usage counter) by the configured full node host, so repointing the URL makes it start from a fresh, empty namespace: the coin pool is re-initialized from the sponsor's on-chain coins, in-flight reservations are dropped, and the daily gas usage counter resets. The old namespace's keys are left behind in Redis and can be cleaned up manually. Because of this, update the URL on **all instances at once during a full stop** — in a rolling deploy, old and new instances would track the same on-chain coins in two independent namespaces and could hand out the same coin twice (equivocation). The automatic redirect described above deliberately does *not* change the namespace, so you can defer the config edit to a convenient maintenance window.
+
+Note also that the new gRPC client connects lazily, so a bad or unreachable `fullnode-url` will now surface as a connection error at startup or on first use, rather than at config-load time.
 
 #### Gas Station reinitialization
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ access-controller:
 | `coin-init-config.refresh-interval-sec` | no                  | Interval in seconds to refresh balance and check for new coins to split   | `86400`                                                                                         |
 | `daily-gas-usage-cap`                   | no                  | Maximum allowed daily gas usage                                           | `1500000000000`                                                                                 |
 | `max-gas-budget`                        | no                  | Maximum allowed reservable gas budget                                     | `2000000000`                                                                                    |
-| `checkpoint-inclusion-timeout-ms`       | no                  | Milliseconds the full node should wait for a transaction to reach checkpoint inclusion (local execution) before responding, when a request asks to wait for local execution. Passed through as the gRPC `execute_transaction` call's `checkpoint_inclusion_timeout_ms`. Defaults to `5000` if omitted. | `5000` |
+| `checkpoint-inclusion-timeout-ms`       | no                  | Milliseconds the full node should wait for a transaction to reach checkpoint inclusion (local execution) before responding, when a request asks to wait for local execution. Passed through as the gRPC `execute_transaction` call's `checkpoint_inclusion_timeout_ms`. Defaults to `10000` if omitted. | `10000` |
 | `access-controller.access-policy`       | no                  | Access policy mode.                                                       | `disabled`, `allow-all`, `deny-all`. See [this link](./docs/access-controller.md) to learn more |
 
 ### Upgrading from JSON-RPC to gRPC

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ access-controller:
 | `coin-init-config.refresh-interval-sec` | no                  | Interval in seconds to refresh balance and check for new coins to split   | `86400`                                                                                         |
 | `daily-gas-usage-cap`                   | no                  | Maximum allowed daily gas usage                                           | `1500000000000`                                                                                 |
 | `max-gas-budget`                        | no                  | Maximum allowed reservable gas budget                                     | `2000000000`                                                                                    |
-| `checkpoint-wait-ms`                    | no                  | Milliseconds the full node should wait for a transaction to reach checkpoint inclusion (local execution) before responding, when a request asks to wait for local execution. Passed through as the gRPC `execute_transaction` call's `checkpoint_inclusion_timeout_ms`. Defaults to `5000` if omitted. | `5000` |
+| `checkpoint-inclusion-timeout-ms`       | no                  | Milliseconds the full node should wait for a transaction to reach checkpoint inclusion (local execution) before responding, when a request asks to wait for local execution. Passed through as the gRPC `execute_transaction` call's `checkpoint_inclusion_timeout_ms`. Defaults to `5000` if omitted. | `5000` |
 | `access-controller.access-policy`       | no                  | Access policy mode.                                                       | `disabled`, `allow-all`, `deny-all`. See [this link](./docs/access-controller.md) to learn more |
 
 ### Upgrading from JSON-RPC to gRPC

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ metrics-port: 9184
 storage-config:
   redis:
     redis-url: "redis://127.0.0.1"
-fullnode-url: "https://api.testnet.iota.cafe" # requires redis to be cleared
+fullnode-url: "https://grpc.testnet.iota.cafe:443" # requires redis to be cleared, gRPC endpoint (see "Upgrading from JSON-RPC to gRPC" below)
 coin-init-config:
   target-init-balance: 100000000 # requires redis to be cleared
   refresh-interval-sec: 86400
@@ -116,13 +116,37 @@ access-controller:
 | `rpc-port`                              | no                  | Port for the RPC server                                                   | `9527`                                                                                          |
 | `metrics-port`                          | no                  | Port for collecting and exposing metrics                                  | `9184`                                                                                          |
 | `storage-config.redis.redis-url`        | no                  | Redis connection URL                                                      | `redis://127.0.0.1`                                                                             |
-| `fullnode-url`                          | yes ⚠               | URL of the IOTA full node                                                 | `https://api.testnet.iota.cafe`                                                                 |
+| `fullnode-url`                          | yes ⚠               | **gRPC** endpoint of the IOTA full node. See [Upgrading from JSON-RPC to gRPC](#upgrading-from-json-rpc-to-grpc) if you are updating an existing deployment. | `https://grpc.testnet.iota.cafe:443`                                                            |
 | `coin-init-config.target-init-balance`  | yes ⚠               | Target balance for the new coins when we splitting new gas coins in NANOs | `100000000`                                                                                     |
 | `coin-init-config.refresh-interval-sec` | no                  | Interval in seconds to refresh balance and check for new coins to split   | `86400`                                                                                         |
 | `daily-gas-usage-cap`                   | no                  | Maximum allowed daily gas usage                                           | `1500000000000`                                                                                 |
 | `max-gas-budget`                        | no                  | Maximum allowed reservable gas budget                                     | `2000000000`                                                                                    |
+| `checkpoint-wait-ms`                    | no                  | Milliseconds the full node should wait for a transaction to reach checkpoint inclusion (local execution) before responding, when a request asks to wait for local execution. Passed through as the gRPC `execute_transaction` call's `checkpoint_inclusion_timeout_ms`. Defaults to `5000` if omitted. | `5000` |
 | `access-controller.access-policy`       | no                  | Access policy mode.                                                       | `disabled`, `allow-all`, `deny-all`. See [this link](./docs/access-controller.md) to learn more |
 
+### Upgrading from JSON-RPC to gRPC
+
+> **Operator-visible breaking change:** the Gas Station now talks to the IOTA full node over **gRPC** instead of JSON-RPC.
+
+**What changes:** `fullnode-url` must now point at the full node's **gRPC** endpoint instead of its JSON-RPC endpoint. The field is still a plain URL string; only the host/port/scheme you put there changes. For the public IOTA networks, that means:
+
+| Network  | Old JSON-RPC URL                    | New gRPC URL                        |
+| -------- | ------------------------------------ | ------------------------------------ |
+| Mainnet  | `https://api.mainnet.iota.cafe`     | `https://grpc.mainnet.iota.cafe:443` |
+| Testnet  | `https://api.testnet.iota.cafe`     | `https://grpc.testnet.iota.cafe:443` |
+| Devnet   | `https://api.devnet.iota.cafe`      | `https://grpc.devnet.iota.cafe:443`  |
+
+If you run your own full node, use its gRPC address instead.
+
+**Why:** JSON-RPC is being retired upstream in favor of gRPC as the full node transport, so the Gas Station has moved to the [iota-rust-sdk](https://github.com/iotaledger/iota-rust-sdk) gRPC client ahead of that deprecation.
+
+**What you need to do when upgrading an existing deployment:**
+
+1. Repoint `fullnode-url` at your full node's gRPC endpoint (see table above, or the equivalent for your own node).
+2. Make sure the full node you're pointing at actually has its gRPC API enabled: `enable-grpc-api: true` in the node's own config (`grpc-api-config` can be left at its defaults unless you need to tune message-size or timeout limits). A node that only serves JSON-RPC will refuse the connection, or requests against it will fail.
+3. `fullnode-basic-auth`, if you use it, is unaffected and passed through the same way.
+
+No Redis flush is required for this change by itself — the gas coin pool doesn't depend on the transport used to talk to the full node. Note also that the new gRPC client connects lazily, so a bad or unreachable `fullnode-url` will now surface as a connection error at startup or on first use, rather than at config-load time.
 
 #### Gas Station reinitialization
 

--- a/docs/access-controller.md
+++ b/docs/access-controller.md
@@ -1,5 +1,7 @@
 # Gas Station Server Access Controller
 
+> **Note:** the Gas Station's fullnode transport moved from JSON-RPC to gRPC (see the [README's upgrade notes](../README.md#upgrading-from-json-rpc-to-grpc)). This required no changes to the Access Controller or to Rego policies: a compatibility layer preserves the exact same JSON shape for `transaction_data` and every other field described below, so existing rules and Rego expressions keep working unchanged. There is nothing to update or re-test in your policies because of that migration.
+
 The **Gas Station Server** includes an **Access Controller** mechanism to manage access to the `/execute_tx` endpoint. This feature allows you to implement filtering logic based on properties derived from transactions. Currently, the Access Controller supports filtering based on the sender's address, enabling you to block or allow specific addresses.
 
 ## Access Controller Rule syntax

--- a/docs/access-controller.md
+++ b/docs/access-controller.md
@@ -1,7 +1,5 @@
 # Gas Station Server Access Controller
 
-> **Note:** the Gas Station's fullnode transport moved from JSON-RPC to gRPC (see the [README's upgrade notes](../README.md#upgrading-from-json-rpc-to-grpc)). This required no changes to the Access Controller or to Rego policies: a compatibility layer preserves the exact same JSON shape for `transaction_data` and every other field described below, so existing rules and Rego expressions keep working unchanged. There is nothing to update or re-test in your policies because of that migration.
-
 The **Gas Station Server** includes an **Access Controller** mechanism to manage access to the `/execute_tx` endpoint. This feature allows you to implement filtering logic based on properties derived from transactions. Currently, the Access Controller supports filtering based on the sender's address, enabling you to block or allow specific addresses.
 
 ## Access Controller Rule syntax

--- a/docs/common-issues.md
+++ b/docs/common-issues.md
@@ -1,6 +1,40 @@
 
 # Common Issues
 
+## Upgrading from JSON-RPC to gRPC
+
+**Problem:**
+
+> **Operator-visible breaking change:** the Gas Station now talks to the IOTA full node over **gRPC** instead of JSON-RPC.
+
+**What changes:** `fullnode-url` must now point at the full node's **gRPC** endpoint instead of its JSON-RPC endpoint. The field is still a plain URL string; only the host/port/scheme you put there changes. For the public IOTA networks, that means:
+
+| Network | Old JSON-RPC URL                | New gRPC URL                     |
+| ------- | ------------------------------- | -------------------------------- |
+| Mainnet | `https://api.mainnet.iota.cafe` | `https://grpc.mainnet.iota.cafe` |
+| Testnet | `https://api.testnet.iota.cafe` | `https://grpc.testnet.iota.cafe` |
+| Devnet  | `https://api.devnet.iota.cafe`  | `https://grpc.devnet.iota.cafe`  |
+
+If you run your own full node, use its gRPC address instead.
+
+If `fullnode-url` still points at one of the three public JSON-RPC endpoints above, the Gas Station **automatically connects to the matching gRPC endpoint instead** and logs a warning at startup, so an existing deployment keeps working unmodified. This redirect only covers the well-known public hosts — a self-hosted JSON-RPC URL cannot be guessed and will simply fail at the first RPC call.
+
+**Explanation:**
+
+JSON-RPC is being retired upstream in favor of gRPC as the full node transport, so the Gas Station has moved to the [iota-rust-sdk](https://github.com/iotaledger/iota-rust-sdk) gRPC client ahead of that deprecation.
+
+**Solution:**
+
+What you need to do when upgrading an existing deployment:
+
+1. Repoint `fullnode-url` at your full node's gRPC endpoint (see table above, or the equivalent for your own node).
+2. Make sure the full node you're pointing at actually has its gRPC API enabled: `enable-grpc-api: true` in the node's own config (`grpc-api-config` can be left at its defaults unless you need to tune message-size or timeout limits). A node that only serves JSON-RPC will refuse the connection, or requests against it will fail.
+3. `fullnode-basic-auth`, if you use it, is unaffected and passed through the same way.
+
+**Changing `fullnode-url` changes the Redis storage namespace.** The Gas Station namespaces all of its Redis state (coin registry, reservations, daily gas usage counter) by the configured full node host, so repointing the URL makes it start from a fresh, empty namespace: the coin pool is re-initialized from the sponsor's on-chain coins, in-flight reservations are dropped, and the daily gas usage counter resets. The old namespace's keys are left behind in Redis and can be cleaned up manually. Because of this, update the URL on **all instances at once during a full stop** — in a rolling deploy, old and new instances would track the same on-chain coins in two independent namespaces and could hand out the same coin twice (equivocation). The automatic redirect described above deliberately does *not* change the namespace, so you can defer the config edit to a convenient maintenance window.
+
+Note also that the new gRPC client connects lazily, so a bad or unreachable `fullnode-url` will now surface as a connection error at startup or on first use, rather than at config-load time.
+
 ## Could not find the referenced object
 
 **Problem:**

--- a/examples/hook/Cargo.lock
+++ b/examples/hook/Cargo.lock
@@ -3,489 +3,33 @@
 version = 4
 
 [[package]]
-name = "addchain"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b2e69442aa5628ea6951fa33e24efe8313f4321a91bd729fc2f75bdfc858570"
-dependencies = [
- "num-bigint 0.3.3",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "addr2line"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
-dependencies = [
- "gimli",
-]
-
-[[package]]
 name = "adler2"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
-
-[[package]]
-name = "adler32"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
-
-[[package]]
-name = "aead"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
-dependencies = [
- "crypto-common",
- "generic-array",
-]
-
-[[package]]
-name = "aes"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
-dependencies = [
- "cfg-if",
- "cipher",
- "cpufeatures",
-]
-
-[[package]]
-name = "aes-gcm"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
-dependencies = [
- "aead",
- "aes",
- "cipher",
- "ctr",
- "ghash",
- "subtle",
-]
-
-[[package]]
-name = "ahash"
-version = "0.8.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
-dependencies = [
- "cfg-if",
- "once_cell",
- "version_check",
- "zerocopy 0.7.35",
-]
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "alloc-no-stdlib"
-version = "2.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
-
-[[package]]
-name = "alloc-stdlib"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
-dependencies = [
- "alloc-no-stdlib",
-]
-
-[[package]]
-name = "allocator-api2"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
-
-[[package]]
-name = "android-tzdata"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
-
-[[package]]
-name = "android_system_properties"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "anemo"
-version = "0.0.0"
-source = "git+https://github.com/mystenlabs/anemo.git?rev=c4e7e4cb4b624d7738c2016d7b7885c6774ff9c2#c4e7e4cb4b624d7738c2016d7b7885c6774ff9c2"
-dependencies = [
- "anyhow",
- "async-trait",
- "bincode",
- "bytes",
- "ed25519",
- "futures",
- "hex",
- "http",
- "matchit 0.5.0",
- "pin-project-lite",
- "pkcs8 0.10.2",
- "quinn",
- "quinn-proto",
- "rand 0.8.5",
- "rcgen",
- "ring",
- "rustls",
- "rustls-webpki",
- "serde",
- "serde_json",
- "socket2 0.5.9",
- "tap",
- "thiserror 1.0.69",
- "tokio",
- "tokio-util",
- "tower 0.4.13",
- "tracing",
- "x509-parser",
-]
-
-[[package]]
-name = "anstream"
-version = "0.6.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
-dependencies = [
- "anstyle",
- "anstyle-parse",
- "anstyle-query",
- "anstyle-wincon",
- "colorchoice",
- "is_terminal_polyfill",
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle"
-version = "1.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
-
-[[package]]
-name = "anstyle-parse"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
-dependencies = [
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle-query"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
-dependencies = [
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "anstyle-wincon"
-version = "3.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
-dependencies = [
- "anstyle",
- "once_cell",
- "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.98"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arbitrary"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 dependencies = [
  "derive_arbitrary",
-]
-
-[[package]]
-name = "ark-bn254"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a22f4561524cd949590d78d7d4c5df8f592430d221f7f3c9497bbafd8972120f"
-dependencies = [
- "ark-ec",
- "ark-ff",
- "ark-std",
-]
-
-[[package]]
-name = "ark-crypto-primitives"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f3a13b34da09176a8baba701233fdffbaa7c1b1192ce031a3da4e55ce1f1a56"
-dependencies = [
- "ark-ec",
- "ark-ff",
- "ark-relations",
- "ark-serialize",
- "ark-snark",
- "ark-std",
- "blake2",
- "derivative",
- "digest 0.10.7",
- "sha2 0.10.9",
-]
-
-[[package]]
-name = "ark-ec"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "defd9a439d56ac24968cca0571f598a61bc8c55f71d50a89cda591cb750670ba"
-dependencies = [
- "ark-ff",
- "ark-poly",
- "ark-serialize",
- "ark-std",
- "derivative",
- "hashbrown 0.13.2",
- "itertools 0.10.5",
- "num-traits",
- "zeroize",
-]
-
-[[package]]
-name = "ark-ff"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec847af850f44ad29048935519032c33da8aa03340876d351dfab5660d2966ba"
-dependencies = [
- "ark-ff-asm",
- "ark-ff-macros",
- "ark-serialize",
- "ark-std",
- "derivative",
- "digest 0.10.7",
- "itertools 0.10.5",
- "num-bigint 0.4.6",
- "num-traits",
- "paste",
- "rustc_version",
- "zeroize",
-]
-
-[[package]]
-name = "ark-ff-asm"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed4aa4fe255d0bc6d79373f7e31d2ea147bcf486cba1be5ba7ea85abdb92348"
-dependencies = [
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "ark-ff-macros"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
-dependencies = [
- "num-bigint 0.4.6",
- "num-traits",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "ark-groth16"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20ceafa83848c3e390f1cbf124bc3193b3e639b3f02009e0e290809a501b95fc"
-dependencies = [
- "ark-crypto-primitives",
- "ark-ec",
- "ark-ff",
- "ark-poly",
- "ark-relations",
- "ark-serialize",
- "ark-std",
-]
-
-[[package]]
-name = "ark-poly"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d320bfc44ee185d899ccbadfa8bc31aab923ce1558716e1997a1e74057fe86bf"
-dependencies = [
- "ark-ff",
- "ark-serialize",
- "ark-std",
- "derivative",
- "hashbrown 0.13.2",
-]
-
-[[package]]
-name = "ark-relations"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00796b6efc05a3f48225e59cb6a2cda78881e7c390872d5786aaf112f31fb4f0"
-dependencies = [
- "ark-ff",
- "ark-std",
- "tracing",
-]
-
-[[package]]
-name = "ark-secp256r1"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3975a01b0a6e3eae0f72ec7ca8598a6620fc72fa5981f6f5cca33b7cd788f633"
-dependencies = [
- "ark-ec",
- "ark-ff",
- "ark-std",
-]
-
-[[package]]
-name = "ark-serialize"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
-dependencies = [
- "ark-serialize-derive",
- "ark-std",
- "digest 0.10.7",
- "num-bigint 0.4.6",
-]
-
-[[package]]
-name = "ark-serialize-derive"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae3281bc6d0fd7e549af32b52511e1302185bd688fd3359fa36423346ff682ea"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "ark-snark"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84d3cc6833a335bb8a600241889ead68ee89a3cf8448081fb7694c0fe503da63"
-dependencies = [
- "ark-ff",
- "ark-relations",
- "ark-serialize",
- "ark-std",
-]
-
-[[package]]
-name = "ark-std"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
-dependencies = [
- "num-traits",
- "rand 0.8.5",
-]
-
-[[package]]
-name = "arrayref"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
-
-[[package]]
-name = "arrayvec"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
-
-[[package]]
-name = "asn1-rs"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56624a96882bb8c26d61312ae18cb45868e5a9992ea73c58e45c3101e56a1e60"
-dependencies = [
- "asn1-rs-derive",
- "asn1-rs-impl",
- "displaydoc",
- "nom",
- "num-traits",
- "rusticata-macros",
- "thiserror 2.0.12",
- "time",
-]
-
-[[package]]
-name = "asn1-rs-derive"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
- "synstructure 0.13.2",
-]
-
-[[package]]
-name = "asn1-rs-impl"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
-]
-
-[[package]]
-name = "async-compression"
-version = "0.4.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b37fc50485c4f3f736a4fb14199f6d5f5ba008d7f28fe710306c92780f004c07"
-dependencies = [
- "brotli",
- "flate2",
- "futures-core",
- "memchr",
- "pin-project-lite",
- "tokio",
- "zstd",
- "zstd-safe",
-]
-
-[[package]]
-name = "async-trait"
-version = "0.1.88"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
 ]
 
 [[package]]
@@ -495,22 +39,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
-name = "auto_ops"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7460f7dd8e100147b82a63afca1a20eb6c231ee36b90ba7272e14951cb58af59"
-
-[[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "axum"
-version = "0.8.3"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de45108900e1f9b9242f7f2e254aa3e2c029c921c258fe9e6b4217eeebd54288"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
  "bytes",
@@ -522,19 +60,18 @@ dependencies = [
  "hyper",
  "hyper-util",
  "itoa",
- "matchit 0.8.4",
+ "matchit",
  "memchr",
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "rustversion",
- "serde",
+ "serde_core",
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tower 0.5.2",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -542,9 +79,9 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.5.2"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68464cd0412f486726fb3373129ef5d2993f90c34bc2bc1c1e9943b2f4fc7ca6"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
  "bytes",
  "futures-core",
@@ -553,51 +90,11 @@ dependencies = [
  "http-body-util",
  "mime",
  "pin-project-lite",
- "rustversion",
  "sync_wrapper",
  "tower-layer",
  "tower-service",
  "tracing",
 ]
-
-[[package]]
-name = "backtrace"
-version = "0.3.74"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
-dependencies = [
- "addr2line",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "base-x"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cbbc9d0964165b47557570cce6c952866c2678457aca742aafc9fb771d30270"
-
-[[package]]
-name = "base16ct"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
-
-[[package]]
-name = "base64"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
-name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64"
@@ -607,9 +104,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
-version = "1.7.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89e25b6adfb930f02d1981565a6e5d9c547ac15a96606256d3b59040e5cd4ca3"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bcs"
@@ -622,123 +119,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "bech32"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
-
-[[package]]
-name = "bellpepper"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae286c2cb403324ab644c7cc68dceb25fe52ca9429908a726d7ed272c1edf7b"
-dependencies = [
- "bellpepper-core",
- "byteorder",
- "ff",
-]
-
-[[package]]
-name = "bellpepper-core"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d8abb418570756396d722841b19edfec21d4e89e1cf8990610663040ecb1aea"
-dependencies = [
- "blake2s_simd",
- "byteorder",
- "ff",
- "serde",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "better_any"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b359aebd937c17c725e19efcb661200883f04c49c53e7132224dac26da39d4a0"
-dependencies = [
- "better_typeid_derive",
-]
-
-[[package]]
-name = "better_typeid_derive"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3deeecb812ca5300b7d3f66f730cc2ebd3511c3d36c691dd79c165d5b19a26e3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "bincode"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "bitcoin-private"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73290177011694f38ec25e165d0387ab7ea749a4b81cd4c80dae5988229f7a57"
-
-[[package]]
-name = "bitcoin_hashes"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d7066118b13d4b20b23645932dfb3a81ce7e29f95726c2036fa33cd7b092501"
-dependencies = [
- "bitcoin-private",
-]
-
-[[package]]
 name = "bitflags"
-version = "1.3.2"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitflags"
-version = "2.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
-
-[[package]]
-name = "bitmaps"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "031043d04099746d8db04daf1fa424b2bc8bd69d92b25962dcde24da39ab64a2"
-dependencies = [
- "typenum",
-]
-
-[[package]]
-name = "bitvec"
-version = "0.20.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7774144344a4faa177370406a7ff5f1da24303817368584c6206c8303eb07848"
-dependencies = [
- "funty 1.1.0",
- "radium 0.6.2",
- "tap",
- "wyz 0.2.0",
-]
-
-[[package]]
-name = "bitvec"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
-dependencies = [
- "funty 2.0.0",
- "radium 0.7.0",
- "tap",
- "wyz 0.5.1",
-]
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "blake2"
@@ -747,37 +131,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
  "digest 0.10.7",
-]
-
-[[package]]
-name = "blake2b_simd"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06e903a20b159e944f91ec8499fe1e55651480c541ea0a584f5d967c49ad9d99"
-dependencies = [
- "arrayref",
- "arrayvec",
- "constant_time_eq 0.3.1",
-]
-
-[[package]]
-name = "blake2s_simd"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e90f7deecfac93095eb874a40febd69427776e24e1bd7f87f33ac62d6f0174df"
-dependencies = [
- "arrayref",
- "arrayvec",
- "constant_time_eq 0.3.1",
-]
-
-[[package]]
-name = "block-buffer"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
-dependencies = [
- "generic-array",
 ]
 
 [[package]]
@@ -790,74 +143,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "block-padding"
-version = "0.3.3"
+name = "block-buffer"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
- "generic-array",
-]
-
-[[package]]
-name = "blst"
-version = "0.3.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47c79a94619fade3c0b887670333513a67ac28a6a7e653eb260bf0d4103db38d"
-dependencies = [
- "cc",
- "glob",
- "threadpool",
- "zeroize",
-]
-
-[[package]]
-name = "blstrs"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a8a8ed6fefbeef4a8c7b460e4110e12c5e22a5b7cf32621aae6ad650c4dcf29"
-dependencies = [
- "blst",
- "byte-slice-cast",
- "ff",
- "group",
- "pairing",
- "rand_core 0.6.4",
- "serde",
- "subtle",
+ "hybrid-array",
 ]
 
 [[package]]
 name = "bnum"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e31ea183f6ee62ac8b8a8cf7feddd766317adfb13ff469de57ce033efd6a790"
-
-[[package]]
-name = "brotli"
-version = "8.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9991eea70ea4f293524138648e41ee89b0b2b12ddef3b255effa43c8056e0e0d"
-dependencies = [
- "alloc-no-stdlib",
- "alloc-stdlib",
- "brotli-decompressor",
-]
-
-[[package]]
-name = "brotli-decompressor"
-version = "5.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
-dependencies = [
- "alloc-no-stdlib",
- "alloc-stdlib",
-]
-
-[[package]]
-name = "bs58"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
+checksum = "f781dba93de3a5ef6dc5b17c9958b208f6f3f021623b360fb605ea51ce443f10"
 
 [[package]]
 name = "bs58"
@@ -870,21 +168,15 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.17.0"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
-
-[[package]]
-name = "byte-slice-cast"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytemuck"
-version = "1.23.0"
+version = "1.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9134a6ef01ce4b366b50689c94f82c14bc72bc5d0386829828a2e2752ef7958c"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
 
 [[package]]
 name = "byteorder"
@@ -894,563 +186,125 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
-dependencies = [
- "serde",
-]
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
-name = "cbc"
-version = "0.1.2"
+name = "bytestring"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+checksum = "86566c496f2f47d9b8147a4c8b02ffdb69c919fe0c2b2e7195d22cbba0e635c9"
 dependencies = [
- "cipher",
-]
-
-[[package]]
-name = "cc"
-version = "1.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8691782945451c1c383942c4874dbe63814f61cb57ef773cda2972682b7bb3c0"
-dependencies = [
- "jobserver",
- "libc",
- "shlex",
+ "bytes",
 ]
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
-name = "cfg_aliases"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
-
-[[package]]
-name = "chacha20"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
-dependencies = [
- "cfg-if",
- "cipher",
- "cpufeatures",
-]
-
-[[package]]
-name = "chacha20poly1305"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
-dependencies = [
- "aead",
- "chacha20",
- "cipher",
- "poly1305",
- "zeroize",
-]
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chrono"
-version = "0.4.39"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
- "android-tzdata",
- "iana-time-zone",
- "js-sys",
  "num-traits",
  "serde",
- "wasm-bindgen",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "ciborium"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
-dependencies = [
- "ciborium-io",
- "ciborium-ll",
- "serde",
-]
-
-[[package]]
-name = "ciborium-io"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
-
-[[package]]
-name = "ciborium-ll"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
-dependencies = [
- "ciborium-io",
- "half",
-]
-
-[[package]]
-name = "cipher"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
-dependencies = [
- "crypto-common",
- "inout",
- "zeroize",
-]
-
-[[package]]
-name = "clap"
-version = "4.5.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eccb054f56cbd38340b380d4a8e69ef1f02f1af43db2f0cc817a4774d80ae071"
-dependencies = [
- "clap_builder",
- "clap_derive",
-]
-
-[[package]]
-name = "clap_builder"
-version = "4.5.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efd9466fac8543255d3b1fcad4762c5e116ffe808c8a3043d4263cd4fd4862a2"
-dependencies = [
- "anstream",
- "anstyle",
- "clap_lex",
- "strsim 0.11.1",
- "terminal_size",
-]
-
-[[package]]
-name = "clap_derive"
-version = "4.5.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
-dependencies = [
- "heck 0.5.0",
- "proc-macro2",
- "quote",
- "syn 2.0.101",
-]
-
-[[package]]
-name = "clap_lex"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
-
-[[package]]
-name = "colorchoice"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
-
-[[package]]
-name = "consensus-config"
-version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#5de884a0608171bb5b4fc153c97830b2796e19e6"
-dependencies = [
- "fastcrypto",
- "iota-network-stack",
- "rand 0.8.5",
- "serde",
- "shared-crypto",
 ]
 
 [[package]]
 name = "const-oid"
-version = "0.9.6"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
-
-[[package]]
-name = "const_format"
-version = "0.2.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "126f97965c8ad46d6d9163268ff28432e8f6a1196a55578867832e3049df63dd"
-dependencies = [
- "const_format_proc_macros",
-]
-
-[[package]]
-name = "const_format_proc_macros"
-version = "0.2.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-xid",
-]
-
-[[package]]
-name = "constant_time_eq"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
-
-[[package]]
-name = "constant_time_eq"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "convert_case"
-version = "0.4.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
-
-[[package]]
-name = "core-foundation-sys"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
-
-[[package]]
-name = "core2"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
 dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "coset"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8cc80f631f8307b887faca24dcc3abc427cd0367f6eb6188f6e8f5b7ad8fb"
-dependencies = [
- "ciborium",
- "ciborium-io",
+ "unicode-segmentation",
 ]
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.17"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "crc32fast"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
-
-[[package]]
-name = "crunchy"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
-
-[[package]]
-name = "crypto-bigint"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
-dependencies = [
- "generic-array",
- "rand_core 0.6.4",
- "subtle",
- "zeroize",
 ]
 
 [[package]]
 name = "crypto-common"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
- "rand_core 0.6.4",
  "typenum",
 ]
 
 [[package]]
-name = "ctr"
-version = "0.9.2"
+name = "crypto-common"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
- "cipher",
-]
-
-[[package]]
-name = "curve25519-dalek"
-version = "4.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "curve25519-dalek-derive",
- "digest 0.10.7",
- "fiat-crypto",
- "rustc_version",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "curve25519-dalek-derive"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
-]
-
-[[package]]
-name = "curve25519-dalek-ng"
-version = "4.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c359b7249347e46fb28804470d071c921156ad62b3eef5d34e2ba867533dec8"
-dependencies = [
- "byteorder",
- "digest 0.9.0",
- "rand_core 0.6.4",
- "subtle-ng",
- "zeroize",
-]
-
-[[package]]
-name = "darling"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
-dependencies = [
- "darling_core 0.14.4",
- "darling_macro 0.14.4",
-]
-
-[[package]]
-name = "darling"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
-dependencies = [
- "darling_core 0.20.11",
- "darling_macro 0.20.11",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim 0.10.0",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim 0.11.1",
- "syn 2.0.101",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
-dependencies = [
- "darling_core 0.14.4",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
-dependencies = [
- "darling_core 0.20.11",
- "quote",
- "syn 2.0.101",
-]
-
-[[package]]
-name = "dary_heap"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04d2cd9c18b9f454ed67da600630b021a8a80bf33f8c95896ab33aaf1c26b728"
-
-[[package]]
-name = "data-encoding"
-version = "2.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
-
-[[package]]
-name = "data-encoding-macro"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47ce6c96ea0102f01122a185683611bd5ac8d99e62bc59dd12e6bda344ee673d"
-dependencies = [
- "data-encoding",
- "data-encoding-macro-internal",
-]
-
-[[package]]
-name = "data-encoding-macro-internal"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
-dependencies = [
- "data-encoding",
- "syn 2.0.101",
-]
-
-[[package]]
-name = "der"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
-dependencies = [
- "const-oid",
- "pem-rfc7468 0.6.0",
- "zeroize",
-]
-
-[[package]]
-name = "der"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
-dependencies = [
- "const-oid",
- "pem-rfc7468 0.7.0",
- "zeroize",
-]
-
-[[package]]
-name = "der-parser"
-version = "10.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
-dependencies = [
- "asn1-rs",
- "displaydoc",
- "nom",
- "num-bigint 0.4.6",
- "num-traits",
- "rusticata-macros",
+ "hybrid-array",
 ]
 
 [[package]]
 name = "deranged"
-version = "0.4.0"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
-dependencies = [
- "powerfmt",
- "serde",
-]
-
-[[package]]
-name = "derivative"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 
 [[package]]
 name = "derive_arbitrary"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "derive_more"
-version = "0.99.20"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
-dependencies = [
- "convert_case",
- "proc-macro2",
- "quote",
- "rustc_version",
- "syn 2.0.101",
-]
-
-[[package]]
-name = "derive_more"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
 dependencies = [
  "derive_more-impl",
 ]
 
 [[package]]
 name = "derive_more-impl"
-version = "1.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
 dependencies = [
+ "convert_case",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "rustc_version",
+ "syn 2.0.119",
  "unicode-xid",
-]
-
-[[package]]
-name = "digest"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
-dependencies = [
- "generic-array",
 ]
 
 [[package]]
@@ -1460,172 +314,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
- "const-oid",
- "crypto-common",
+ "crypto-common 0.1.7",
  "subtle",
 ]
 
 [[package]]
-name = "dirs"
-version = "4.0.0"
+name = "digest"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
- "dirs-sys",
-]
-
-[[package]]
-name = "dirs-next"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
-dependencies = [
- "cfg-if",
- "dirs-sys-next",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
-dependencies = [
- "libc",
- "redox_users",
- "winapi",
-]
-
-[[package]]
-name = "dirs-sys-next"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
-dependencies = [
- "libc",
- "redox_users",
- "winapi",
+ "block-buffer 0.12.1",
+ "const-oid",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
-]
-
-[[package]]
-name = "dyn-clone"
-version = "1.0.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
-
-[[package]]
-name = "ecdsa"
-version = "0.16.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
-dependencies = [
- "der 0.7.10",
- "digest 0.10.7",
- "elliptic-curve",
- "rfc6979",
- "serdect",
- "signature 2.2.0",
- "spki 0.7.3",
-]
-
-[[package]]
-name = "ed25519"
-version = "2.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
-dependencies = [
- "pkcs8 0.10.2",
- "serde",
- "signature 2.2.0",
- "zeroize",
-]
-
-[[package]]
-name = "ed25519-consensus"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c8465edc8ee7436ffea81d21a019b16676ee3db267aa8d5a8d729581ecf998b"
-dependencies = [
- "curve25519-dalek-ng",
- "hex",
- "rand_core 0.6.4",
- "serde",
- "sha2 0.9.9",
- "thiserror 1.0.69",
- "zeroize",
-]
-
-[[package]]
-name = "ed25519-zebra"
-version = "4.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d9ce6874da5d4415896cd45ffbc4d1cfc0c4f9c079427bd870742c30f2f65a9"
-dependencies = [
- "curve25519-dalek",
- "ed25519",
- "hashbrown 0.14.5",
- "hex",
- "rand_core 0.6.4",
- "serde",
- "sha2 0.10.9",
- "zeroize",
-]
-
-[[package]]
-name = "either"
-version = "1.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
-
-[[package]]
-name = "elliptic-curve"
-version = "0.13.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
-dependencies = [
- "base16ct",
- "crypto-bigint",
- "digest 0.10.7",
- "ff",
- "generic-array",
- "group",
- "pem-rfc7468 0.7.0",
- "pkcs8 0.10.2",
- "rand_core 0.6.4",
- "sec1",
- "serdect",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "enum-compat-util"
-version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#5de884a0608171bb5b4fc153c97830b2796e19e6"
-dependencies = [
- "serde_yaml",
-]
-
-[[package]]
-name = "enum_dispatch"
-version = "0.3.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa18ce2bc66555b3218614519ac839ddb759a7d6720732f979ef8d13be147ecd"
-dependencies = [
- "once_cell",
- "proc-macro2",
- "quote",
- "syn 2.0.101",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1636,348 +348,73 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.11"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
-
-[[package]]
-name = "ethnum"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0939f82868b77ef93ce3c3c3daf2b3c526b456741da5a1a4559e590965b6026b"
-
-[[package]]
-name = "eyre"
-version = "0.6.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
-dependencies = [
- "indenter",
- "once_cell",
-]
-
-[[package]]
-name = "fastcrypto"
-version = "0.1.8"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=69d496c71fb37e3d22fe85e5bbfd4256d61422b9#69d496c71fb37e3d22fe85e5bbfd4256d61422b9"
-dependencies = [
- "aes",
- "aes-gcm",
- "ark-ec",
- "ark-ff",
- "ark-secp256r1",
- "ark-serialize",
- "auto_ops",
- "base64ct",
- "bech32",
- "bincode",
- "blake2",
- "blst",
- "bs58 0.4.0",
- "cbc",
- "ctr",
- "curve25519-dalek-ng",
- "derive_more 0.99.20",
- "digest 0.10.7",
- "ecdsa",
- "ed25519-consensus",
- "elliptic-curve",
- "fastcrypto-derive",
- "generic-array",
- "hex",
- "hex-literal",
- "hkdf",
- "lazy_static",
- "num-bigint 0.4.6",
- "once_cell",
- "p256",
- "rand 0.8.5",
- "readonly",
- "rfc6979",
- "rsa",
- "schemars",
- "secp256k1",
- "serde",
- "serde_json",
- "serde_with",
- "sha2 0.10.9",
- "sha3",
- "signature 2.2.0",
- "static_assertions",
- "thiserror 1.0.69",
- "tokio",
- "typenum",
- "zeroize",
-]
-
-[[package]]
-name = "fastcrypto-derive"
-version = "0.1.3"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=69d496c71fb37e3d22fe85e5bbfd4256d61422b9#69d496c71fb37e3d22fe85e5bbfd4256d61422b9"
-dependencies = [
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "fastcrypto-tbls"
-version = "0.1.0"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=69d496c71fb37e3d22fe85e5bbfd4256d61422b9#69d496c71fb37e3d22fe85e5bbfd4256d61422b9"
-dependencies = [
- "bcs",
- "digest 0.10.7",
- "fastcrypto",
- "hex",
- "itertools 0.10.5",
- "rand 0.8.5",
- "serde",
- "sha3",
- "tap",
- "tracing",
- "typenum",
- "zeroize",
-]
-
-[[package]]
-name = "fastcrypto-zkp"
-version = "0.1.3"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=69d496c71fb37e3d22fe85e5bbfd4256d61422b9#69d496c71fb37e3d22fe85e5bbfd4256d61422b9"
-dependencies = [
- "ark-bn254",
- "ark-ec",
- "ark-ff",
- "ark-groth16",
- "ark-relations",
- "ark-serialize",
- "ark-snark",
- "bcs",
- "byte-slice-cast",
- "derive_more 0.99.20",
- "fastcrypto",
- "ff",
- "im",
- "itertools 0.12.1",
- "lazy_static",
- "neptune",
- "num-bigint 0.4.6",
- "once_cell",
- "regex",
- "reqwest",
- "schemars",
- "serde",
- "serde_json",
- "typenum",
-]
-
-[[package]]
-name = "ff"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
-dependencies = [
- "bitvec 1.0.1",
- "byteorder",
- "ff_derive",
- "rand_core 0.6.4",
- "subtle",
-]
-
-[[package]]
-name = "ff_derive"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f10d12652036b0e99197587c6ba87a8fc3031986499973c030d8b44fcc151b60"
-dependencies = [
- "addchain",
- "num-bigint 0.3.3",
- "num-integer",
- "num-traits",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "fiat-crypto"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "filetime"
-version = "0.2.25"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35c0522e981e68cbfa8c3f978441a5f34b30b96e146b33cd3359176b50fe8586"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
 dependencies = [
  "cfg-if",
  "libc",
- "libredox",
- "windows-sys 0.59.0",
 ]
-
-[[package]]
-name = "fixed-hash"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcf0ed7fe52a17a03854ec54a9f76d6d84508d1c0e66bc1793301c73fc8493c"
-dependencies = [
- "byteorder",
- "rand 0.8.5",
- "rustc-hex",
- "static_assertions",
-]
-
-[[package]]
-name = "fixed-hash"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
-dependencies = [
- "byteorder",
- "rand 0.8.5",
- "rustc-hex",
- "static_assertions",
-]
-
-[[package]]
-name = "fixedbitset"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
 
 [[package]]
 name = "flate2"
-version = "1.1.1"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ced92e76e966ca2fd84c8f7aa01a4aea65b0eb6648d72f7c8f3e2764a67fece"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
- "crc32fast",
  "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
 name = "form_urlencoded"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
 
 [[package]]
-name = "funty"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
-
-[[package]]
-name = "funty"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
-
-[[package]]
-name = "futures"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
 dependencies = [
  "futures-core",
- "futures-sink",
 ]
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
-
-[[package]]
-name = "futures-executor"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
-name = "futures-io"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
-
-[[package]]
-name = "futures-macro"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
-]
-
-[[package]]
-name = "futures-sink"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
- "futures-channel",
  "futures-core",
- "futures-io",
- "futures-macro",
- "futures-sink",
  "futures-task",
- "memchr",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
@@ -1987,179 +424,28 @@ version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
- "serde",
  "typenum",
  "version_check",
- "zeroize",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "wasm-bindgen",
 ]
 
 [[package]]
-name = "getrandom"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
-dependencies = [
- "cfg-if",
- "js-sys",
- "libc",
- "r-efi",
- "wasi 0.14.2+wasi-0.2.4",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "getset"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3586f256131df87204eb733da72e3d3eb4f343c639f4b7be279ac7c48baeafe"
-dependencies = [
- "proc-macro-error2",
- "proc-macro2",
- "quote",
- "syn 2.0.101",
-]
-
-[[package]]
-name = "ghash"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
-dependencies = [
- "opaque-debug",
- "polyval",
-]
-
-[[package]]
-name = "gimli"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
-
-[[package]]
-name = "glob"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
-
-[[package]]
-name = "gloo-timers"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
-dependencies = [
- "futures-channel",
- "futures-core",
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "group"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
-dependencies = [
- "ff",
- "rand 0.8.5",
- "rand_core 0.6.4",
- "rand_xorshift",
- "subtle",
-]
-
-[[package]]
-name = "h2"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9421a676d1b147b16b82c9225157dc629087ef8ec4d5e2960f9437a90dac0a5"
-dependencies = [
- "atomic-waker",
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "http",
- "indexmap 2.11.4",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "half"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
-dependencies = [
- "cfg-if",
- "crunchy",
-]
-
-[[package]]
 name = "hashbrown"
-version = "0.12.3"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-
-[[package]]
-name = "hashbrown"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
-dependencies = [
- "ahash",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash",
- "allocator-api2",
- "serde",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.15.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
-dependencies = [
- "allocator-api2",
- "equivalent",
- "foldhash",
-]
-
-[[package]]
-name = "hdrhistogram"
-version = "7.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "765c9198f173dd59ce26ff9f95ef0aafd0a0fe01fb9d72841bc5066a4c06511d"
-dependencies = [
- "byteorder",
- "num-traits",
-]
-
-[[package]]
-name = "heck"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -2168,43 +454,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "hermit-abi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
-
-[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "hex-literal"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
-
-[[package]]
-name = "hkdf"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
-dependencies = [
- "hmac",
-]
-
-[[package]]
-name = "hmac"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
-dependencies = [
- "digest 0.10.7",
-]
 
 [[package]]
 name = "hook"
@@ -2212,12 +465,12 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "axum",
- "base64 0.22.1",
+ "base64",
  "bcs",
- "iota-types",
+ "iota-sdk-types",
  "serde",
  "serde_json",
- "thiserror 2.0.12",
+ "thiserror 2.0.19",
  "tokio",
  "utoipa",
  "utoipa-axum",
@@ -2226,20 +479,19 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.3.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
 dependencies = [
  "bytes",
- "fnv",
  "itoa",
 ]
 
 [[package]]
 name = "http-body"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
 dependencies = [
  "bytes",
  "http",
@@ -2247,9 +499,9 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2257,12 +509,6 @@ dependencies = [
  "http-body",
  "pin-project-lite",
 ]
-
-[[package]]
-name = "http-range-header"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9171a2ea8a68358193d15dd5d70c1c10a2afc3e7e4c5bc92bc9f025cebd7359c"
 
 [[package]]
 name = "httparse"
@@ -2277,15 +523,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
-name = "hyper"
-version = "1.6.0"
+name = "hybrid-array"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
 dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "hyper"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
+dependencies = [
+ "atomic-waker",
  "bytes",
  "futures-channel",
- "futures-util",
- "h2",
+ "futures-core",
  "http",
  "http-body",
  "httparse",
@@ -2294,101 +549,42 @@ dependencies = [
  "pin-project-lite",
  "smallvec",
  "tokio",
- "want",
-]
-
-[[package]]
-name = "hyper-rustls"
-version = "0.27.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2"
-dependencies = [
- "futures-util",
- "http",
- "hyper",
- "hyper-util",
- "rustls",
- "rustls-pki-types",
- "tokio",
- "tokio-rustls",
- "tower-service",
- "webpki-roots",
-]
-
-[[package]]
-name = "hyper-timeout"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
-dependencies = [
- "hyper",
- "hyper-util",
- "pin-project-lite",
- "tokio",
- "tower-service",
 ]
 
 [[package]]
 name = "hyper-util"
-version = "0.1.11"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497bbc33a26fdd4af9ed9c70d63f61cf56a938375fbb32df34db9b1cd6d643f2"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
  "bytes",
- "futures-channel",
- "futures-util",
  "http",
  "http-body",
  "hyper",
- "libc",
  "pin-project-lite",
- "socket2 0.5.9",
  "tokio",
  "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "iana-time-zone"
-version = "0.1.63"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
-dependencies = [
- "android_system_properties",
- "core-foundation-sys",
- "iana-time-zone-haiku",
- "js-sys",
- "log",
- "wasm-bindgen",
- "windows-core",
-]
-
-[[package]]
-name = "iana-time-zone-haiku"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
-dependencies = [
- "cc",
 ]
 
 [[package]]
 name = "icu_collections"
-version = "1.5.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
+ "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
 ]
 
 [[package]]
-name = "icu_locid"
-version = "1.5.0"
+name = "icu_locale_core"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -2398,109 +594,65 @@ dependencies = [
 ]
 
 [[package]]
-name = "icu_locid_transform"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
-dependencies = [
- "displaydoc",
- "icu_locid",
- "icu_locid_transform_data",
- "icu_provider",
- "tinystr",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid_transform_data"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7515e6d781098bf9f7205ab3fc7e9709d34554ae0b21ddbcb5febfa4bc7df11d"
-
-[[package]]
 name = "icu_normalizer"
-version = "1.5.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
- "displaydoc",
  "icu_collections",
  "icu_normalizer_data",
  "icu_properties",
  "icu_provider",
  "smallvec",
- "utf16_iter",
- "utf8_iter",
- "write16",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_normalizer_data"
-version = "1.5.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5e8338228bdc8ab83303f16b797e177953730f601a96c25d10cb3ab0daa0cb7"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "1.5.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
- "displaydoc",
  "icu_collections",
- "icu_locid_transform",
+ "icu_locale_core",
  "icu_properties_data",
  "icu_provider",
- "tinystr",
+ "zerotrie",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_properties_data"
-version = "1.5.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85fb8799753b75aee8d2a21d7c14d9f38921b54b3dbda10f5a3c7a7b82dba5e2"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "1.5.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
- "icu_locid",
- "icu_provider_macros",
- "stable_deref_trait",
- "tinystr",
+ "icu_locale_core",
  "writeable",
  "yoke",
  "zerofrom",
+ "zerotrie",
  "zerovec",
 ]
 
 [[package]]
-name = "icu_provider_macros"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
-]
-
-[[package]]
-name = "ident_case"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
-
-[[package]]
 name = "idna"
-version = "1.0.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
 dependencies = [
  "idna_adapter",
  "smallvec",
@@ -2509,645 +661,96 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.0"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
 ]
 
 [[package]]
-name = "im"
-version = "15.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0acd33ff0285af998aaf9b57342af478078f53492322fafc47450e09397e0e9"
-dependencies = [
- "bitmaps",
- "rand_core 0.6.4",
- "rand_xoshiro",
- "sized-chunks",
- "typenum",
- "version_check",
-]
-
-[[package]]
-name = "impl-codec"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "161ebdfec3c8e3b52bf61c4f3550a1eea4f9579d10dc1b936f3171ebdcd6c443"
-dependencies = [
- "parity-scale-codec 2.3.1",
-]
-
-[[package]]
-name = "impl-codec"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba6a270039626615617f3f36d15fc827041df3b78c439da2cadfa47455a77f2f"
-dependencies = [
- "parity-scale-codec 3.7.4",
-]
-
-[[package]]
-name = "impl-serde"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4551f042f3438e64dbd6226b20527fc84a6e1fe65688b58746a2f53623f25f5c"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "impl-serde"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc88fc67028ae3db0c853baa36269d398d5f45b6982f95549ff5def78c935cd"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "impl-trait-for-tuples"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
-]
-
-[[package]]
-name = "indenter"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
-
-[[package]]
 name = "indexmap"
-version = "1.9.3"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
- "serde",
-]
-
-[[package]]
-name = "indexmap"
-version = "2.11.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.3",
+ "hashbrown",
  "serde",
  "serde_core",
 ]
 
 [[package]]
-name = "inout"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
-dependencies = [
- "block-padding",
- "generic-array",
-]
-
-[[package]]
-name = "io-uring"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "046fa2d4d00aea763528b4950358d0ead425372445dc8ff86312b3c69ff7727b"
-dependencies = [
- "bitflags 2.9.0",
- "cfg-if",
- "libc",
-]
-
-[[package]]
-name = "iota-crypto"
-version = "0.23.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98a38db844c910d78825e173c083f2ef416b69cb091bba8ac1055763c6db065b"
-dependencies = [
- "aead",
- "aes",
- "aes-gcm",
- "autocfg",
- "base64 0.21.7",
- "blake2",
- "chacha20poly1305",
- "cipher",
- "curve25519-dalek",
- "digest 0.10.7",
- "ed25519-zebra",
- "generic-array",
- "getrandom 0.2.16",
- "hkdf",
- "hmac",
- "iterator-sorted 0.1.0",
- "k256",
- "num-traits",
- "pbkdf2",
- "rand 0.8.5",
- "scrypt",
- "serde",
- "sha2 0.10.9",
- "tiny-keccak",
- "unicode-normalization",
- "x25519-dalek",
- "zeroize",
-]
-
-[[package]]
-name = "iota-enum-compat-util"
-version = "1.7.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#5de884a0608171bb5b4fc153c97830b2796e19e6"
-dependencies = [
- "serde_yaml",
-]
-
-[[package]]
-name = "iota-http"
-version = "1.7.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#5de884a0608171bb5b4fc153c97830b2796e19e6"
-dependencies = [
- "bytes",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-util",
- "pin-project-lite",
- "socket2 0.5.9",
- "tokio",
- "tokio-rustls",
- "tokio-util",
- "tower 0.4.13",
- "tracing",
-]
-
-[[package]]
-name = "iota-macros"
-version = "1.7.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#5de884a0608171bb5b4fc153c97830b2796e19e6"
-dependencies = [
- "futures",
- "iota-proc-macros",
- "once_cell",
- "tracing",
-]
-
-[[package]]
-name = "iota-network-stack"
-version = "1.7.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#5de884a0608171bb5b4fc153c97830b2796e19e6"
-dependencies = [
- "anemo",
- "bcs",
- "bytes",
- "eyre",
- "futures",
- "http",
- "http-body",
- "hyper-rustls",
- "hyper-util",
- "iota-http",
- "multiaddr",
- "once_cell",
- "pin-project-lite",
- "serde",
- "snap",
- "tokio",
- "tokio-rustls",
- "tonic",
- "tonic-health",
- "tower 0.4.13",
- "tower-http",
- "tracing",
-]
-
-[[package]]
-name = "iota-proc-macros"
-version = "1.7.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#5de884a0608171bb5b4fc153c97830b2796e19e6"
-dependencies = [
- "msim-macros",
- "proc-macro2",
- "quote",
- "syn 2.0.101",
-]
-
-[[package]]
-name = "iota-protocol-config"
-version = "1.7.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#5de884a0608171bb5b4fc153c97830b2796e19e6"
-dependencies = [
- "clap",
- "iota-protocol-config-macros",
- "move-vm-config",
- "schemars",
- "serde",
- "serde-env",
- "serde_with",
- "tracing",
-]
-
-[[package]]
-name = "iota-protocol-config-macros"
-version = "1.7.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#5de884a0608171bb5b4fc153c97830b2796e19e6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "iota-rust-sdk"
-version = "0.0.0"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=d7084eaf0564f4e2381b2e8408ee1f7d51468450#d7084eaf0564f4e2381b2e8408ee1f7d51468450"
+name = "iota-sdk-types"
+version = "0.0.1-alpha.1"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=b77fcd5ac5fedb3dfbc77ba7d183140e43512339#b77fcd5ac5fedb3dfbc77ba7d183140e43512339"
 dependencies = [
  "base64ct",
  "bcs",
  "blake2",
  "bnum",
- "bs58 0.5.1",
+ "bs58",
+ "bytestring",
+ "derive_more",
+ "filetime",
+ "getrandom",
  "hex",
+ "paste",
+ "rand_core",
  "roaring",
- "schemars",
- "serde",
- "serde_derive",
- "serde_json",
- "serde_with",
- "winnow 0.6.26",
-]
-
-[[package]]
-name = "iota-sdk"
-version = "1.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1dfb0cae5c5bad8186576ca00b8be675257431eda028dcea01cb3b9f276037e"
-dependencies = [
- "bech32",
- "bitflags 2.9.0",
- "bytemuck",
- "derive_more 0.99.20",
- "getset",
- "gloo-timers",
- "hashbrown 0.14.5",
- "hex",
- "iota-crypto",
- "iota_stronghold",
- "iterator-sorted 0.2.0",
- "itertools 0.12.1",
- "lazy_static",
- "once_cell",
- "packable",
- "prefix-hex",
- "primitive-types 0.12.2",
- "rand 0.8.5",
- "regex",
  "serde",
  "serde_json",
  "serde_repr",
- "url",
- "zeroize",
-]
-
-[[package]]
-name = "iota-types"
-version = "1.7.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#5de884a0608171bb5b4fc153c97830b2796e19e6"
-dependencies = [
- "anemo",
- "anyhow",
- "async-trait",
- "bcs",
- "better_any",
- "bincode",
- "byteorder",
- "consensus-config",
- "derive_more 1.0.0",
- "either",
- "enum_dispatch",
- "eyre",
- "fastcrypto",
- "fastcrypto-tbls",
- "fastcrypto-zkp",
- "hex",
- "im",
- "indexmap 2.11.4",
- "iota-enum-compat-util",
- "iota-macros",
- "iota-network-stack",
- "iota-protocol-config",
- "iota-rust-sdk",
- "iota-sdk",
- "itertools 0.13.0",
- "lru",
- "move-binary-format",
- "move-bytecode-utils",
- "move-core-types",
- "move-vm-profiler",
- "move-vm-test-utils",
- "nonempty",
- "num-bigint 0.4.6",
- "num-rational",
- "num-traits",
- "once_cell",
- "packable",
- "parking_lot",
- "passkey-types",
- "prometheus",
- "rand 0.8.5",
- "roaring",
- "schemars",
- "serde",
- "serde-name",
- "serde_json",
  "serde_with",
- "shared-crypto",
- "signature 1.6.4",
- "starfish-config",
- "static_assertions",
- "strum 0.26.3",
- "strum_macros 0.26.4",
- "tap",
- "thiserror 1.0.69",
- "tonic",
- "tracing",
- "typed-store-error",
-]
-
-[[package]]
-name = "iota_stronghold"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c0d301c7edbc31494d183b7d24c1bb51d3fb10fce2f3793df1baf45b6988e10"
-dependencies = [
- "bincode",
- "hkdf",
- "iota-crypto",
- "rust-argon2",
- "serde",
- "stronghold-derive",
- "stronghold-utils",
- "stronghold_engine",
- "thiserror 1.0.69",
- "zeroize",
-]
-
-[[package]]
-name = "ipnet"
-version = "2.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
-
-[[package]]
-name = "iri-string"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbc5ebe9c3a1a7a5127f920a418f7585e9e758e911d0466ed004f393b0e380b2"
-dependencies = [
- "memchr",
- "serde",
-]
-
-[[package]]
-name = "is_terminal_polyfill"
-version = "1.70.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
-
-[[package]]
-name = "iterator-sorted"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d101775d2bc8f99f4ac18bf29b9ed70c0dd138b9a1e88d7b80179470cbbe8bd2"
-
-[[package]]
-name = "iterator-sorted"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed3c1d66191fc266439b989dc1a9a69d9c4156e803ce456221231398b84c35d1"
-
-[[package]]
-name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
-dependencies = [
- "either",
+ "strum",
+ "thiserror 2.0.19",
+ "winnow",
 ]
 
 [[package]]
 name = "itoa"
-version = "1.0.15"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
-
-[[package]]
-name = "jobserver"
-version = "0.1.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a"
-dependencies = [
- "getrandom 0.3.2",
- "libc",
-]
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.77"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
- "once_cell",
+ "cfg-if",
+ "futures-util",
  "wasm-bindgen",
 ]
 
 [[package]]
-name = "k256"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
-dependencies = [
- "cfg-if",
- "ecdsa",
- "elliptic-curve",
- "once_cell",
- "serdect",
- "sha2 0.10.9",
-]
-
-[[package]]
-name = "keccak"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
-dependencies = [
- "cpufeatures",
-]
-
-[[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-dependencies = [
- "spin",
-]
-
-[[package]]
-name = "leb128"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
-
-[[package]]
 name = "libc"
-version = "0.2.172"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
-
-[[package]]
-name = "libflate"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45d9dfdc14ea4ef0900c1cddbc8dcd553fbaacd8a4a282cf4018ae9dd04fb21e"
-dependencies = [
- "adler32",
- "core2",
- "crc32fast",
- "dary_heap",
- "libflate_lz77",
-]
-
-[[package]]
-name = "libflate_lz77"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6e0d73b369f386f1c44abd9c570d5318f55ccde816ff4b562fa452e5182863d"
-dependencies = [
- "core2",
- "hashbrown 0.14.5",
- "rle-decode-fast",
-]
-
-[[package]]
-name = "libm"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a25169bd5913a4b437588a7e3d127cd6e90127b60e0ffbd834a38f1599e016b8"
-
-[[package]]
-name = "libredox"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
-dependencies = [
- "bitflags 2.9.0",
- "libc",
- "redox_syscall",
-]
-
-[[package]]
-name = "libsodium-sys-stable"
-version = "1.22.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b023d38f2afdfe36f81e15a9d7232097701d7b107e3a93ba903083985e235239"
-dependencies = [
- "cc",
- "libc",
- "libflate",
- "minisign-verify",
- "pkg-config",
- "tar",
- "ureq",
- "vcpkg",
- "zip",
-]
-
-[[package]]
-name = "linked-hash-map"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "litemap"
-version = "0.7.5"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lock_api"
-version = "0.4.12"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
 dependencies = [
- "autocfg",
  "scopeguard",
 ]
 
 [[package]]
 name = "log"
-version = "0.4.27"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
-
-[[package]]
-name = "lru"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
-dependencies = [
- "hashbrown 0.15.3",
-]
-
-[[package]]
-name = "matchit"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73cbba799671b762df5a175adf59ce145165747bb891505c43d09aefbbf38beb"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "matchit"
@@ -3157,18 +760,9 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
-
-[[package]]
-name = "memoffset"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
-dependencies = [
- "autocfg",
-]
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "mime"
@@ -3187,355 +781,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
-name = "minisign-verify"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6367d84fb54d4242af283086402907277715b8fe46976963af5ebf173f8efba3"
-
-[[package]]
 name = "miniz_oxide"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
 name = "mio"
-version = "1.0.3"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "move-binary-format"
-version = "0.0.3"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#5de884a0608171bb5b4fc153c97830b2796e19e6"
-dependencies = [
- "anyhow",
- "enum-compat-util",
- "move-core-types",
- "move-proc-macros",
- "ref-cast",
- "serde",
- "variant_count",
-]
-
-[[package]]
-name = "move-bytecode-utils"
-version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#5de884a0608171bb5b4fc153c97830b2796e19e6"
-dependencies = [
- "anyhow",
- "indexmap 2.11.4",
- "move-binary-format",
- "move-core-types",
- "petgraph",
- "serde",
- "serde-reflection",
-]
-
-[[package]]
-name = "move-core-types"
-version = "0.0.4"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#5de884a0608171bb5b4fc153c97830b2796e19e6"
-dependencies = [
- "anyhow",
- "bcs",
- "enum-compat-util",
- "ethnum",
- "hex",
- "leb128",
- "move-proc-macros",
- "num",
- "once_cell",
- "primitive-types 0.10.1",
- "rand 0.8.5",
- "ref-cast",
- "serde",
- "serde_bytes",
- "serde_with",
- "thiserror 1.0.69",
- "uint",
-]
-
-[[package]]
-name = "move-proc-macros"
-version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#5de884a0608171bb5b4fc153c97830b2796e19e6"
-dependencies = [
- "quote",
- "syn 2.0.101",
-]
-
-[[package]]
-name = "move-vm-config"
-version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#5de884a0608171bb5b4fc153c97830b2796e19e6"
-dependencies = [
- "move-binary-format",
- "once_cell",
-]
-
-[[package]]
-name = "move-vm-profiler"
-version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#5de884a0608171bb5b4fc153c97830b2796e19e6"
-dependencies = [
- "move-vm-config",
- "once_cell",
- "serde",
-]
-
-[[package]]
-name = "move-vm-test-utils"
-version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#5de884a0608171bb5b4fc153c97830b2796e19e6"
-dependencies = [
- "anyhow",
- "move-binary-format",
- "move-core-types",
- "move-vm-profiler",
- "move-vm-types",
- "once_cell",
- "serde",
-]
-
-[[package]]
-name = "move-vm-types"
-version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#5de884a0608171bb5b4fc153c97830b2796e19e6"
-dependencies = [
- "bcs",
- "move-binary-format",
- "move-core-types",
- "move-vm-profiler",
- "serde",
- "smallvec",
-]
-
-[[package]]
-name = "msim-macros"
-version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota-sim.git?branch=tokio-1.46.1#20adc0b089bf9072268eea0f059fb8ea2461702f"
-dependencies = [
- "darling 0.14.4",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "multiaddr"
-version = "0.17.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b36f567c7099511fa8612bbbb52dda2419ce0bdbacf31714e3a5ffdb766d3bd"
-dependencies = [
- "arrayref",
- "byteorder",
- "data-encoding",
- "log",
- "multibase",
- "multihash",
- "percent-encoding",
- "serde",
- "static_assertions",
- "unsigned-varint",
- "url",
-]
-
-[[package]]
-name = "multibase"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b3539ec3c1f04ac9748a260728e855f261b4977f5c3406612c884564f329404"
-dependencies = [
- "base-x",
- "data-encoding",
- "data-encoding-macro",
-]
-
-[[package]]
-name = "multihash"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "835d6ff01d610179fbce3de1694d007e500bf33a7f29689838941d6bf783ae40"
-dependencies = [
- "core2",
- "multihash-derive",
- "unsigned-varint",
-]
-
-[[package]]
-name = "multihash-derive"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc076939022111618a5026d3be019fd8b366e76314538ff9a1b59ffbcbf98bcd"
-dependencies = [
- "proc-macro-crate 1.3.1",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "synstructure 0.12.6",
-]
-
-[[package]]
-name = "neptune"
-version = "13.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06626c9ac04c894e9a23d061ba1309f28506cdc5fe64156d28a15fb57fc8e438"
-dependencies = [
- "bellpepper",
- "bellpepper-core",
- "blake2s_simd",
- "blstrs",
- "byteorder",
- "ff",
- "generic-array",
- "log",
- "pasta_curves",
- "serde",
- "trait-set",
-]
-
-[[package]]
-name = "nix"
-version = "0.24.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa52e972a9a719cecb6864fb88568781eb706bac2cd1d4f04a648542dbf78069"
-dependencies = [
- "bitflags 1.3.2",
- "cfg-if",
- "libc",
- "memoffset",
-]
-
-[[package]]
-name = "nom"
-version = "7.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
-dependencies = [
- "memchr",
- "minimal-lexical",
-]
-
-[[package]]
-name = "nonempty"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "995defdca0a589acfdd1bd2e8e3b896b4d4f7675a31fd14c32611440c7f608e6"
-
-[[package]]
-name = "num"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
-dependencies = [
- "num-bigint 0.4.6",
- "num-complex",
- "num-integer",
- "num-iter",
- "num-rational",
- "num-traits",
-]
-
-[[package]]
-name = "num-bigint"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6f7833f2cbf2360a6cfd58cd41a53aa7a90bd4c202f5b1c7dd2ed73c57b2c3"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-bigint"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
-dependencies = [
- "num-integer",
- "num-traits",
- "rand 0.8.5",
-]
-
-[[package]]
-name = "num-bigint-dig"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc84195820f291c7697304f3cbdadd1cb7199c0efc917ff5eafd71225c136151"
-dependencies = [
- "byteorder",
- "lazy_static",
- "libm",
- "num-integer",
- "num-iter",
- "num-traits",
- "rand 0.8.5",
- "smallvec",
- "zeroize",
-]
-
-[[package]]
-name = "num-complex"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
-dependencies = [
- "num-traits",
+ "wasi",
+ "windows-sys",
 ]
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
-
-[[package]]
-name = "num-integer"
-version = "0.1.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-iter"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-rational"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
-dependencies = [
- "num-bigint 0.4.6",
- "num-integer",
- "num-traits",
-]
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-traits"
@@ -3544,154 +814,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
- "libm",
-]
-
-[[package]]
-name = "num_cpus"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
-dependencies = [
- "hermit-abi",
- "libc",
-]
-
-[[package]]
-name = "object"
-version = "0.36.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "oid-registry"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
-dependencies = [
- "asn1-rs",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
-
-[[package]]
-name = "opaque-debug"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
-
-[[package]]
-name = "p256"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
-dependencies = [
- "ecdsa",
- "elliptic-curve",
- "primeorder",
- "sha2 0.10.9",
-]
-
-[[package]]
-name = "packable"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11259b086696fc9256f790485d8f14f11f0fa60a60351af9693e3d49fd24fdb6"
-dependencies = [
- "autocfg",
- "packable-derive",
- "primitive-types 0.12.2",
- "serde",
-]
-
-[[package]]
-name = "packable-derive"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9567693dd2f9a4339cb0a54adfcc0cb431c0ac88b2e46c6ddfb5f5d11a1cc4f"
-dependencies = [
- "proc-macro-crate 1.3.1",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "pairing"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fec4625e73cf41ef4bb6846cafa6d44736525f442ba45e407c4a000a13996f"
-dependencies = [
- "group",
-]
-
-[[package]]
-name = "parity-scale-codec"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "373b1a4c1338d9cd3d1fa53b3a11bdab5ab6bd80a20f7f7becd76953ae2be909"
-dependencies = [
- "arrayvec",
- "bitvec 0.20.4",
- "byte-slice-cast",
- "impl-trait-for-tuples",
- "parity-scale-codec-derive 2.3.1",
- "serde",
-]
-
-[[package]]
-name = "parity-scale-codec"
-version = "3.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9fde3d0718baf5bc92f577d652001da0f8d54cd03a7974e118d04fc888dc23d"
-dependencies = [
- "arrayvec",
- "bitvec 1.0.1",
- "byte-slice-cast",
- "const_format",
- "impl-trait-for-tuples",
- "parity-scale-codec-derive 3.7.4",
- "rustversion",
- "serde",
-]
-
-[[package]]
-name = "parity-scale-codec-derive"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1557010476e0595c9b568d16dcfb81b93cdeb157612726f5170d31aa707bed27"
-dependencies = [
- "proc-macro-crate 1.3.1",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "parity-scale-codec-derive"
-version = "3.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581c837bb6b9541ce7faa9377c20616e4fb7650f6b0f68bc93c827ee504fb7b3"
-dependencies = [
- "proc-macro-crate 3.3.0",
- "proc-macro2",
- "quote",
- "syn 2.0.101",
-]
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "parking_lot"
-version = "0.12.3"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -3699,54 +834,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.10"
+version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "passkey-types"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77144664f6aac5f629d7efa815f5098a054beeeca6ccafee5ec453fd2b0c53f9"
-dependencies = [
- "bitflags 2.9.0",
- "ciborium",
- "coset",
- "data-encoding",
- "getrandom 0.2.16",
- "hmac",
- "indexmap 2.11.4",
- "rand 0.8.5",
- "serde",
- "serde_json",
- "sha2 0.10.9",
- "strum 0.25.0",
- "typeshare",
- "zeroize",
-]
-
-[[package]]
-name = "pasta_curves"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e57598f73cc7e1b2ac63c79c517b31a0877cd7c402cdcaa311b5208de7a095"
-dependencies = [
- "blake2b_simd",
- "ff",
- "group",
- "hex",
- "lazy_static",
- "rand 0.8.5",
- "serde",
- "static_assertions",
- "subtle",
+ "windows-link",
 ]
 
 [[package]]
@@ -3756,150 +852,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
-name = "pbkdf2"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
-dependencies = [
- "digest 0.10.7",
- "hmac",
-]
-
-[[package]]
-name = "pem"
-version = "3.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38af38e8470ac9dee3ce1bae1af9c1671fffc44ddfd8bd1d0a3445bf349a8ef3"
-dependencies = [
- "base64 0.22.1",
- "serde",
-]
-
-[[package]]
-name = "pem-rfc7468"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d159833a9105500e0398934e205e0773f0b27529557134ecfc51c27646adac"
-dependencies = [
- "base64ct",
-]
-
-[[package]]
-name = "pem-rfc7468"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
-dependencies = [
- "base64ct",
-]
-
-[[package]]
 name = "percent-encoding"
-version = "2.3.1"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
-
-[[package]]
-name = "petgraph"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "467d164a6de56270bd7c4d070df81d07beace25012d5103ced4e9ff08d6afdb7"
-dependencies = [
- "fixedbitset",
- "indexmap 1.9.3",
-]
-
-[[package]]
-name = "pin-project"
-version = "1.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
-dependencies = [
- "pin-project-internal",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "1.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
-]
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "pin-utils"
-version = "0.1.0"
+name = "potential_utf"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "pkcs1"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eff33bdbdfc54cc98a2eca766ebdec3e1b8fb7387523d5c9c9a2891da856f719"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
- "der 0.6.1",
- "pkcs8 0.9.0",
- "spki 0.6.0",
- "zeroize",
-]
-
-[[package]]
-name = "pkcs8"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
-dependencies = [
- "der 0.6.1",
- "spki 0.6.0",
-]
-
-[[package]]
-name = "pkcs8"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
-dependencies = [
- "der 0.7.10",
- "spki 0.7.3",
-]
-
-[[package]]
-name = "pkg-config"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
-
-[[package]]
-name = "poly1305"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
-dependencies = [
- "cpufeatures",
- "opaque-debug",
- "universal-hash",
-]
-
-[[package]]
-name = "polyval"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "opaque-debug",
- "universal-hash",
+ "zerovec",
 ]
 
 [[package]]
@@ -3909,311 +879,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
-dependencies = [
- "zerocopy 0.8.25",
-]
-
-[[package]]
-name = "prefix-hex"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f1799f398371ad6957951ec446d3ff322d35c46d9db2e217b67e828b311c249"
-dependencies = [
- "hex",
- "primitive-types 0.12.2",
- "uint",
-]
-
-[[package]]
-name = "primeorder"
-version = "0.13.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
-dependencies = [
- "elliptic-curve",
-]
-
-[[package]]
-name = "primitive-types"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05e4722c697a58a99d5d06a08c30821d7c082a4632198de1eaa5a6c22ef42373"
-dependencies = [
- "fixed-hash 0.7.0",
- "impl-codec 0.5.1",
- "impl-serde 0.3.2",
- "uint",
-]
-
-[[package]]
-name = "primitive-types"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b34d9fd68ae0b74a41b21c03c2f62847aa0ffea044eee893b4c140b37e244e2"
-dependencies = [
- "fixed-hash 0.8.0",
- "impl-codec 0.6.0",
- "impl-serde 0.4.0",
- "uint",
-]
-
-[[package]]
-name = "proc-macro-crate"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
-dependencies = [
- "once_cell",
- "toml_edit 0.19.15",
-]
-
-[[package]]
-name = "proc-macro-crate"
-version = "3.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
-dependencies = [
- "toml_edit 0.22.26",
-]
-
-[[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr2"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "proc-macro-error2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
-dependencies = [
- "proc-macro-error-attr2",
- "proc-macro2",
- "quote",
- "syn 2.0.101",
-]
-
-[[package]]
 name = "proc-macro2"
-version = "1.0.95"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
-name = "prometheus"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ca5326d8d0b950a9acd87e6a3f94745394f62e4dae1b1ee22b2bc0c394af43a"
-dependencies = [
- "cfg-if",
- "fnv",
- "lazy_static",
- "memchr",
- "parking_lot",
- "protobuf",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "prost"
-version = "0.13.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
-dependencies = [
- "bytes",
- "prost-derive",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.13.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
-dependencies = [
- "anyhow",
- "itertools 0.14.0",
- "proc-macro2",
- "quote",
- "syn 2.0.101",
-]
-
-[[package]]
-name = "protobuf"
-version = "3.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d65a1d4ddae7d8b5de68153b48f6aa3bba8cb002b243dbdbc55a5afbc98f99f4"
-dependencies = [
- "once_cell",
- "protobuf-support",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "protobuf-support"
-version = "3.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e36c2f31e0a47f9280fb347ef5e461ffcd2c52dd520d8e216b52f93b0b0d7d6"
-dependencies = [
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "quinn"
-version = "0.11.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3bd15a6f2967aef83887dcb9fec0014580467e33720d073560cf015a5683012"
-dependencies = [
- "bytes",
- "cfg_aliases",
- "futures-io",
- "pin-project-lite",
- "quinn-proto",
- "quinn-udp",
- "rustc-hash",
- "rustls",
- "socket2 0.5.9",
- "thiserror 2.0.12",
- "tokio",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-proto"
-version = "0.11.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcbafbbdbb0f638fe3f35f3c56739f77a8a1d070cb25603226c83339b391472b"
-dependencies = [
- "bytes",
- "getrandom 0.3.2",
- "rand 0.9.1",
- "ring",
- "rustc-hash",
- "rustls",
- "rustls-pki-types",
- "slab",
- "thiserror 2.0.12",
- "tinyvec",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-udp"
-version = "0.5.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee4e529991f949c5e25755532370b8af5d114acae52326361d68d47af64aa842"
-dependencies = [
- "cfg_aliases",
- "libc",
- "once_cell",
- "socket2 0.5.9",
- "tracing",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "r-efi"
-version = "5.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
-
-[[package]]
-name = "radium"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb"
-
-[[package]]
-name = "radium"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
-
-[[package]]
-name = "rand"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
-dependencies = [
- "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
-dependencies = [
- "rand_chacha 0.9.0",
- "rand_core 0.9.3",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -4222,105 +902,23 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.16",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
-dependencies = [
- "getrandom 0.3.2",
-]
-
-[[package]]
-name = "rand_xorshift"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
-dependencies = [
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_xoshiro"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
-dependencies = [
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rcgen"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
-dependencies = [
- "pem",
- "ring",
- "rustls-pki-types",
- "time",
- "yasna",
-]
-
-[[package]]
-name = "readonly"
-version = "0.2.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2a62d85ed81ca5305dc544bd42c8804c5060b78ffa5ad3c64b0fb6a8c13d062"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
+ "getrandom",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.12"
+version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.9.0",
-]
-
-[[package]]
-name = "redox_users"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
-dependencies = [
- "getrandom 0.2.16",
- "libredox",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "ref-cast"
-version = "1.0.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a0ae411dbe946a674d89546582cea4ba2bb8defac896622d6496f14c23ba5cf"
-dependencies = [
- "ref-cast-impl",
-]
-
-[[package]]
-name = "ref-cast-impl"
-version = "1.0.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
+ "bitflags",
 ]
 
 [[package]]
 name = "regex"
-version = "1.11.1"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4330,9 +928,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.9"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4341,132 +939,25 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.5"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
-
-[[package]]
-name = "reqwest"
-version = "0.12.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d19c46a6fdd48bc4dab94b6103fccc55d34c67cc0ad04653aad4ea2a07cd7bbb"
-dependencies = [
- "base64 0.22.1",
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-rustls",
- "hyper-util",
- "ipnet",
- "js-sys",
- "log",
- "mime",
- "once_cell",
- "percent-encoding",
- "pin-project-lite",
- "quinn",
- "rustls",
- "rustls-pemfile",
- "rustls-pki-types",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tokio-rustls",
- "tower 0.5.2",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "webpki-roots",
- "windows-registry",
-]
-
-[[package]]
-name = "rfc6979"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
-dependencies = [
- "hmac",
- "subtle",
-]
-
-[[package]]
-name = "ring"
-version = "0.17.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
-dependencies = [
- "cc",
- "cfg-if",
- "getrandom 0.2.16",
- "libc",
- "untrusted",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "rle-decode-fast"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "roaring"
-version = "0.10.12"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e8d2cfa184d94d0726d650a9f4a1be7f9b76ac9fdb954219878dc00c1c1e7b"
+checksum = "1dedc5658c6ecb3bdb5ef5f3295bb9253f42dcf3fd1402c03f6b1f7659c3c4a9"
 dependencies = [
  "bytemuck",
  "byteorder",
 ]
 
 [[package]]
-name = "rsa"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55a77d189da1fee555ad95b7e50e7457d91c0e089ec68ca69ad2989413bbdab4"
-dependencies = [
- "byteorder",
- "digest 0.10.7",
- "num-bigint-dig",
- "num-integer",
- "num-iter",
- "num-traits",
- "pkcs1",
- "pkcs8 0.9.0",
- "rand_core 0.6.4",
- "sha2 0.10.9",
- "signature 2.2.0",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "rust-argon2"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b50162d19404029c1ceca6f6980fe40d45c8b369f6f44446fa14bb39573b5bb9"
-dependencies = [
- "base64 0.13.1",
- "blake2b_simd",
- "constant_time_eq 0.1.5",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "rust-embed"
-version = "8.7.1"
+version = "8.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60e425e204264b144d4c929d126d0de524b40a961686414bab5040f7465c71be"
+checksum = "e9e7760e252aaba7b09f4be00e36476cf585bdb68a53552ac954cdf504ab4bc9"
 dependencies = [
  "rust-embed-impl",
  "rust-embed-utils",
@@ -4475,44 +966,27 @@ dependencies = [
 
 [[package]]
 name = "rust-embed-impl"
-version = "8.7.0"
+version = "8.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bf418c9a2e3f6663ca38b8a7134cc2c2167c9d69688860e8961e3faa731702e"
+checksum = "3bcfc4d6f53af43755f7a723e4b6b8794fcce052a178dd8c6c1dadc5f5343097"
 dependencies = [
+ "mime_guess",
  "proc-macro2",
  "quote",
  "rust-embed-utils",
- "syn 2.0.101",
+ "syn 2.0.119",
  "walkdir",
 ]
 
 [[package]]
 name = "rust-embed-utils"
-version = "8.7.0"
+version = "8.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d55b95147fe01265d06b3955db798bdaed52e60e2211c41137701b3aba8e21"
+checksum = "42ffa149f6aa81b58a5b3011d01a857c4ed12c7a732d2c51947a4c7c692185f0"
 dependencies = [
- "sha2 0.10.9",
+ "sha2",
  "walkdir",
 ]
-
-[[package]]
-name = "rustc-demangle"
-version = "0.1.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
-
-[[package]]
-name = "rustc-hash"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
-
-[[package]]
-name = "rustc-hex"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
 
 [[package]]
 name = "rustc_version"
@@ -4524,90 +998,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "rusticata-macros"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
-dependencies = [
- "nom",
-]
-
-[[package]]
-name = "rustix"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
-dependencies = [
- "bitflags 2.9.0",
- "errno",
- "libc",
- "linux-raw-sys",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rustls"
-version = "0.23.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "730944ca083c1c233a75c09f199e973ca499344a2b7ba9e755c457e86fb4a321"
-dependencies = [
- "once_cell",
- "ring",
- "rustls-pki-types",
- "rustls-webpki",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
-name = "rustls-pki-types"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
-dependencies = [
- "web-time",
-]
-
-[[package]]
-name = "rustls-webpki"
-version = "0.103.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7149975849f1abb3832b246010ef62ccc80d3a76169517ada7188252b9cfb437"
-dependencies = [
- "ring",
- "rustls-pki-types",
- "untrusted",
-]
-
-[[package]]
 name = "rustversion"
-version = "1.0.20"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "ryu"
-version = "1.0.20"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
-
-[[package]]
-name = "salsa20"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
-dependencies = [
- "cipher",
-]
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -4619,201 +1019,80 @@ dependencies = [
 ]
 
 [[package]]
-name = "schemars"
-version = "0.8.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
-dependencies = [
- "dyn-clone",
- "either",
- "schemars_derive",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "schemars_derive"
-version = "0.8.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
-dependencies = [
- "proc-macro2",
- "quote",
- "serde_derive_internals",
- "syn 2.0.101",
-]
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "scrypt"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
-dependencies = [
- "pbkdf2",
- "salsa20",
- "sha2 0.10.9",
-]
-
-[[package]]
-name = "sec1"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
-dependencies = [
- "base16ct",
- "der 0.7.10",
- "generic-array",
- "pkcs8 0.10.2",
- "serdect",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "secp256k1"
-version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25996b82292a7a57ed3508f052cfff8640d38d32018784acd714758b43da9c8f"
-dependencies = [
- "bitcoin_hashes",
- "rand 0.8.5",
- "secp256k1-sys",
-]
-
-[[package]]
-name = "secp256k1-sys"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a129b9e9efbfb223753b9163c4ab3b13cff7fd9c7f010fbac25ab4099fa07e"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "semver"
-version = "1.0.26"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
-version = "1.0.226"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dca6411025b24b60bfa7ec1fe1f8e710ac09782dca409ee8237ba74b51295fd"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
 ]
 
 [[package]]
-name = "serde-env"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d13536c0c431652192b75c7d5afa83dedae98f91d7e687ff30a009e9d15284fb"
-dependencies = [
- "anyhow",
- "serde",
-]
-
-[[package]]
-name = "serde-name"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b5b14ebbcc4e4f2b3642fa99c388649da58d1dc3308c7d109f39f565d1710f0"
-dependencies = [
- "serde",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "serde-reflection"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b6798a64289ff550d8d79847467789a5fd30b42c9c406a4d6dc0bc9b567e55c"
-dependencies = [
- "once_cell",
- "serde",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "serde_bytes"
-version = "0.11.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8437fd221bde2d4ca316d61b90e337e9e702b3820b87d63caa9ba6c02bd06d96"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "serde_core"
-version = "1.0.226"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba2ba63999edb9dac981fb34b3e5c0d111a69b0924e253ed29d83f7c99e966a4"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.226"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8db53ae22f34573731bafa1db20f04027b2d25e02d8205921b569171699cdb33"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
-]
-
-[[package]]
-name = "serde_derive_internals"
-version = "0.29.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
- "indexmap 2.11.4",
  "itoa",
  "memchr",
- "ryu",
  "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
 name = "serde_path_to_error"
-version = "0.1.17"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59fab13f937fa393d08645bf3a84bdfe86e296747b506ada67bb15f10f218b2a"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
 dependencies = [
  "itoa",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "serde_repr"
-version = "0.1.20"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -4830,352 +1109,93 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.12.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6b6f7f2fcb69f747921f79f3926bd1e203fce4fef62c268dd3abfb6d86029aa"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
 dependencies = [
- "base64 0.22.1",
+ "base64",
+ "bs58",
  "chrono",
  "hex",
- "indexmap 1.9.3",
- "indexmap 2.11.4",
- "serde",
- "serde_derive",
+ "serde_core",
  "serde_json",
- "serde_with_macros",
  "time",
 ]
 
 [[package]]
-name = "serde_with_macros"
-version = "3.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d00caa5193a3c8362ac2b73be6b9e768aa5a4b2f721d8f4b339600c3cb51f8e"
-dependencies = [
- "darling 0.20.11",
- "proc-macro2",
- "quote",
- "syn 2.0.101",
-]
-
-[[package]]
-name = "serde_yaml"
-version = "0.8.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578a7433b776b56a35785ed5ce9a7e777ac0598aac5a6dd1b4b18a307c7fc71b"
-dependencies = [
- "indexmap 1.9.3",
- "ryu",
- "serde",
- "yaml-rust",
-]
-
-[[package]]
-name = "serdect"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
-dependencies = [
- "base16ct",
- "serde",
-]
-
-[[package]]
 name = "sha2"
-version = "0.9.9"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
-dependencies = [
- "block-buffer 0.9.0",
- "cfg-if",
- "cpufeatures",
- "digest 0.9.0",
- "opaque-debug",
-]
-
-[[package]]
-name = "sha2"
-version = "0.10.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.7",
+ "digest 0.11.3",
 ]
-
-[[package]]
-name = "sha3"
-version = "0.10.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
-dependencies = [
- "digest 0.10.7",
- "keccak",
-]
-
-[[package]]
-name = "shared-crypto"
-version = "1.7.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#5de884a0608171bb5b4fc153c97830b2796e19e6"
-dependencies = [
- "bcs",
- "eyre",
- "fastcrypto",
- "serde",
- "serde_repr",
-]
-
-[[package]]
-name = "shlex"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.5"
+version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
+ "errno",
  "libc",
-]
-
-[[package]]
-name = "signature"
-version = "1.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
-
-[[package]]
-name = "signature"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
-dependencies = [
- "digest 0.10.7",
- "rand_core 0.6.4",
 ]
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.7"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
-
-[[package]]
-name = "sized-chunks"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16d69225bde7a69b235da73377861095455d298f2b970996eec25ddbb42b3d1e"
-dependencies = [
- "bitmaps",
- "typenum",
-]
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "slab"
-version = "0.4.9"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
-dependencies = [
- "autocfg",
-]
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.0"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
-
-[[package]]
-name = "snap"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "socket2"
-version = "0.5.9"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f5fd57c80058a56cf5c777ab8a126398ece8e442983605d280a44ce79d0edef"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "socket2"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
-dependencies = [
- "libc",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-
-[[package]]
-name = "spki"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
-dependencies = [
- "base64ct",
- "der 0.6.1",
-]
-
-[[package]]
-name = "spki"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
-dependencies = [
- "base64ct",
- "der 0.7.10",
+ "windows-sys",
 ]
 
 [[package]]
 name = "stable_deref_trait"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
-
-[[package]]
-name = "starfish-config"
-version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#5de884a0608171bb5b4fc153c97830b2796e19e6"
-dependencies = [
- "fastcrypto",
- "iota-network-stack",
- "rand 0.8.5",
- "serde",
- "shared-crypto",
-]
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
-name = "stronghold-derive"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2835db23c4724c05a2f85b81c4681f4aa8ea158edc8a7f4ad791c916fb766c2e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "stronghold-runtime"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18db7cc51450cefdab5f4990e128dd02c98da6d2992b93ffef8992ac0d2f3ddf"
-dependencies = [
- "dirs",
- "iota-crypto",
- "libc",
- "libsodium-sys-stable",
- "log",
- "nix",
- "rand 0.8.5",
- "serde",
- "thiserror 1.0.69",
- "windows",
- "zeroize",
-]
-
-[[package]]
-name = "stronghold-utils"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8300214898af5e153e7f66e49dbd1c6a21585f2d592d9f24f58b969792475ed6"
-dependencies = [
- "rand 0.8.5",
- "stronghold-derive",
-]
-
-[[package]]
-name = "stronghold_engine"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fd7371c42e557dd71a7f860bb2ec6b6fdb32f97a97987ccc2435fdd1f3a8615"
-dependencies = [
- "anyhow",
- "dirs-next",
- "hex",
- "iota-crypto",
- "once_cell",
- "paste",
- "serde",
- "stronghold-runtime",
- "thiserror 1.0.69",
- "zeroize",
-]
-
-[[package]]
-name = "strsim"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
-name = "strsim"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "strum"
-version = "0.25.0"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 dependencies = [
- "strum_macros 0.25.3",
-]
-
-[[package]]
-name = "strum"
-version = "0.26.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
-dependencies = [
- "strum_macros 0.26.4",
+ "strum_macros",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.25.3"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
 dependencies = [
- "heck 0.4.1",
+ "heck",
  "proc-macro2",
  "quote",
- "rustversion",
- "syn 2.0.101",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
-dependencies = [
- "heck 0.5.0",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn 2.0.101",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5185,16 +1205,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
-name = "subtle-ng"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
-
-[[package]]
 name = "syn"
-version = "1.0.109"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5203,9 +1217,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.101"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5217,21 +1231,6 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
-dependencies = [
- "futures-core",
-]
-
-[[package]]
-name = "synstructure"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "unicode-xid",
-]
 
 [[package]]
 name = "synstructure"
@@ -5241,34 +1240,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
-]
-
-[[package]]
-name = "tap"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
-
-[[package]]
-name = "tar"
-version = "0.4.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
-dependencies = [
- "filetime",
- "libc",
- "xattr",
-]
-
-[[package]]
-name = "terminal_size"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45c6481c4829e4cc63825e62c49186a34538b7b2750b73b266581ffb612fb5ed"
-dependencies = [
- "rustix",
- "windows-sys 0.59.0",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5282,11 +1254,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.12"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
- "thiserror-impl 2.0.12",
+ "thiserror-impl 2.0.19",
 ]
 
 [[package]]
@@ -5297,74 +1269,44 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.12"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
-]
-
-[[package]]
-name = "threadpool"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
-dependencies = [
- "num_cpus",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.41"
+version = "0.3.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
+checksum = "3e1d5e639ff6bab73cb6885cc7e7b1de96c3f32c68ec55f3952614bec1092244"
 dependencies = [
  "deranged",
- "itoa",
  "num-conv",
  "powerfmt",
- "serde",
+ "serde_core",
  "time-core",
- "time-macros",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.4"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
-
-[[package]]
-name = "time-macros"
-version = "0.2.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
-dependencies = [
- "num-conv",
- "time-core",
-]
-
-[[package]]
-name = "tiny-keccak"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
-dependencies = [
- "crunchy",
-]
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "tinystr"
-version = "0.7.6"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -5372,9 +1314,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.9.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09b3661f17e86524eccd4371ab0429194e0d7c008abb45f7a7495b1719463c71"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -5387,209 +1329,46 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.47.1"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
- "backtrace",
  "bytes",
- "io-uring",
  "libc",
  "mio",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "slab",
- "socket2 0.6.0",
+ "socket2",
  "tokio-macros",
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.5.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
+checksum = "6328af13490e73a9b4694030fafd93f8c8c6a9dede33e821c3fc63eddf8042ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
-]
-
-[[package]]
-name = "tokio-rustls"
-version = "0.26.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
-dependencies = [
- "rustls",
- "tokio",
-]
-
-[[package]]
-name = "tokio-stream"
-version = "0.1.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
-dependencies = [
- "futures-core",
- "pin-project-lite",
- "tokio",
- "tokio-util",
-]
-
-[[package]]
-name = "tokio-util"
-version = "0.7.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-sink",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3da5db5a963e24bc68be8b17b6fa82814bb22ee8660f192bb182771d498f09a3"
-
-[[package]]
-name = "toml_edit"
-version = "0.19.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
-dependencies = [
- "indexmap 2.11.4",
- "toml_datetime",
- "winnow 0.5.40",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.22.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e"
-dependencies = [
- "indexmap 2.11.4",
- "toml_datetime",
- "winnow 0.7.9",
-]
-
-[[package]]
-name = "tonic"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e581ba15a835f4d9ea06c55ab1bd4dce26fc53752c69a04aac00703bfb49ba9"
-dependencies = [
- "async-trait",
- "axum",
- "base64 0.22.1",
- "bytes",
- "h2",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-timeout",
- "hyper-util",
- "percent-encoding",
- "pin-project",
- "prost",
- "socket2 0.5.9",
- "tokio",
- "tokio-stream",
- "tower 0.5.2",
- "tower-layer",
- "tower-service",
- "tracing",
- "zstd",
-]
-
-[[package]]
-name = "tonic-health"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb87334d340313fefa513b6e60794d44a86d5f039b523229c99c323e4e19ca4b"
-dependencies = [
- "prost",
- "tokio",
- "tokio-stream",
- "tonic",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "tower"
-version = "0.4.13"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
- "hdrhistogram",
- "indexmap 1.9.3",
- "pin-project",
  "pin-project-lite",
- "rand 0.8.5",
- "slab",
- "tokio",
- "tokio-util",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tower"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
-dependencies = [
- "futures-core",
- "futures-util",
- "indexmap 2.11.4",
- "pin-project-lite",
- "slab",
  "sync_wrapper",
  "tokio",
- "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "tower-http"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
-dependencies = [
- "async-compression",
- "base64 0.21.7",
- "bitflags 2.9.0",
- "bytes",
- "futures-core",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "http-range-header",
- "httpdate",
- "iri-string",
- "mime",
- "mime_guess",
- "percent-encoding",
- "pin-project-lite",
- "tokio",
- "tokio-util",
- "tower 0.4.13",
- "tower-layer",
- "tower-service",
- "tracing",
- "uuid",
 ]
 
 [[package]]
@@ -5606,122 +1385,47 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.41"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "log",
  "pin-project-lite",
- "tracing-attributes",
  "tracing-core",
 ]
 
 [[package]]
-name = "tracing-attributes"
-version = "0.1.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
-]
-
-[[package]]
 name = "tracing-core"
-version = "0.1.33"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
 ]
 
 [[package]]
-name = "trait-set"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b79e2e9c9ab44c6d7c20d5976961b47e8f49ac199154daa514b77cd1ab536625"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "try-lock"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
-
-[[package]]
-name = "typed-store-error"
-version = "1.7.0"
-source = "git+https://github.com/iotaledger/iota?tag=v1.9.2#5de884a0608171bb5b4fc153c97830b2796e19e6"
-dependencies = [
- "serde",
- "thiserror 1.0.69",
-]
-
-[[package]]
 name = "typenum"
-version = "1.18.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
-
-[[package]]
-name = "typeshare"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19be0f411120091e76e13e5a0186d8e2bcc3e7e244afdb70152197f1a8486ceb"
-dependencies = [
- "chrono",
- "serde",
- "serde_json",
- "typeshare-annotation",
-]
-
-[[package]]
-name = "typeshare-annotation"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a615d6c2764852a2e88a4f16e9ce1ea49bb776b5872956309e170d63a042a34f"
-dependencies = [
- "quote",
- "syn 2.0.101",
-]
-
-[[package]]
-name = "uint"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76f64bba2c53b04fcab63c01a7d7427eadc821e3bc48c34dc9ba29c501164b52"
-dependencies = [
- "byteorder",
- "crunchy",
- "hex",
- "static_assertions",
-]
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicase"
-version = "2.8.1"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.18"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
-name = "unicode-normalization"
-version = "0.1.24"
+name = "unicode-segmentation"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
-dependencies = [
- "tinyvec",
-]
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-xid"
@@ -5730,44 +1434,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
-name = "universal-hash"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
-dependencies = [
- "crypto-common",
- "subtle",
-]
-
-[[package]]
-name = "unsigned-varint"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6889a77d49f1f013504cec6bf97a2c730394adedaeb1deb5ea08949a50541105"
-
-[[package]]
-name = "untrusted"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
-
-[[package]]
-name = "ureq"
-version = "2.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
-dependencies = [
- "base64 0.22.1",
- "log",
- "once_cell",
- "url",
-]
-
-[[package]]
 name = "url"
-version = "2.5.4"
+version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -5776,30 +1446,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "utf16_iter"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
-
-[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
-name = "utf8parse"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
-
-[[package]]
 name = "utoipa"
-version = "5.3.1"
+version = "5.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "435c6f69ef38c9017b4b4eea965dfb91e71e53d869e896db40d1cf2441dd75c0"
+checksum = "8bde15df68e80b16c7d16b9616e80770ad158988daa56a27dccd1e55558b0160"
 dependencies = [
- "indexmap 2.11.4",
+ "indexmap",
  "serde",
  "serde_json",
  "utoipa-gen",
@@ -5820,24 +1478,24 @@ dependencies = [
 
 [[package]]
 name = "utoipa-gen"
-version = "5.3.1"
+version = "5.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a77d306bc75294fd52f3e99b13ece67c02c1a2789190a6f31d32f736624326f7"
+checksum = "6ba0b99ee52df3028635d93840c797102da61f8a7bb3cf751032455895b52ef8"
 dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.101",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "utoipa-swagger-ui"
-version = "9.0.1"
+version = "9.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29519b3c485df6b13f4478ac909a491387e9ef70204487c3b64b53749aec0be"
+checksum = "d047458f1b5b65237c2f6dc6db136945667f40a7668627b3490b9513a3d43a55"
 dependencies = [
  "axum",
- "base64 0.22.1",
+ "base64",
  "mime_guess",
  "regex",
  "rust-embed",
@@ -5847,31 +1505,6 @@ dependencies = [
  "utoipa",
  "zip",
 ]
-
-[[package]]
-name = "uuid"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
-dependencies = [
- "getrandom 0.3.2",
-]
-
-[[package]]
-name = "variant_count"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aae2faf80ac463422992abf4de234731279c058aaf33171ca70277c98406b124"
-dependencies = [
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -5890,73 +1523,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "want"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
-dependencies = [
- "try-lock",
-]
-
-[[package]]
 name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
+version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
-
-[[package]]
-name = "wasi"
-version = "0.14.2+wasi-0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
-dependencies = [
- "wit-bindgen-rt",
-]
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.100"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
-dependencies = [
- "bumpalo",
- "log",
- "proc-macro2",
- "quote",
- "syn 2.0.101",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
-name = "wasm-bindgen-futures"
-version = "0.4.50"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
-dependencies = [
- "cfg-if",
- "js-sys",
- "once_cell",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.100"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5964,480 +1553,71 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.100"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
+ "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
- "wasm-bindgen-backend",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.100"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
-name = "web-sys"
-version = "0.3.77"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "web-time"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.26.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37493cadf42a2a939ed404698ded7fb378bf301b5011f973361779a3a74f8c93"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
 name = "winapi-util"
-version = "0.1.9"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "windows"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e53b97a83176b369b0eb2fd8158d4ae215357d02df9d40c1e1bf1879c5482c80"
-dependencies = [
- "windows_aarch64_msvc 0.36.1",
- "windows_i686_gnu 0.36.1",
- "windows_i686_msvc 0.36.1",
- "windows_x86_64_gnu 0.36.1",
- "windows_x86_64_msvc 0.36.1",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.61.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4763c1de310c86d75a878046489e2e5ba02c649d185f21c67d4cf8a56d098980"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link",
- "windows-result",
- "windows-strings 0.4.0",
-]
-
-[[package]]
-name = "windows-implement"
-version = "0.60.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.59.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
+ "windows-sys",
 ]
 
 [[package]]
 name = "windows-link"
-version = "0.1.1"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
-
-[[package]]
-name = "windows-registry"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
-dependencies = [
- "windows-result",
- "windows-strings 0.3.1",
- "windows-targets 0.53.0",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ba9642430ee452d5a7aa78d72907ebe8cfda358e8cb7918a2050581322f97"
-dependencies = [
- "windows-link",
-]
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
-version = "0.52.0"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
-dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1e4c7e8ceaaf9cb7d7507c974735728ab453b67ef8f18febdd7c11fe59dca8b"
-dependencies = [
- "windows_aarch64_gnullvm 0.53.0",
- "windows_aarch64_msvc 0.53.0",
- "windows_i686_gnu 0.53.0",
- "windows_i686_gnullvm 0.53.0",
- "windows_i686_msvc 0.53.0",
- "windows_x86_64_gnu 0.53.0",
- "windows_x86_64_gnullvm 0.53.0",
- "windows_x86_64_msvc 0.53.0",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
-
-[[package]]
-name = "winnow"
-version = "0.5.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
-dependencies = [
- "memchr",
+ "windows-link",
 ]
 
 [[package]]
 name = "winnow"
-version = "0.6.26"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e90edd2ac1aa278a5c4599b1d89cf03074b610800f866d4026dc199d7929a28"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
 ]
-
-[[package]]
-name = "winnow"
-version = "0.7.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9fb597c990f03753e08d3c29efbfcf2019a003b4bf4ba19225c158e1549f0f3"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "wit-bindgen-rt"
-version = "0.39.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
-dependencies = [
- "bitflags 2.9.0",
-]
-
-[[package]]
-name = "write16"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
 
 [[package]]
 name = "writeable"
-version = "0.5.5"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
-
-[[package]]
-name = "wyz"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
-
-[[package]]
-name = "wyz"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
-dependencies = [
- "tap",
-]
-
-[[package]]
-name = "x25519-dalek"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
-dependencies = [
- "curve25519-dalek",
- "rand_core 0.6.4",
- "zeroize",
-]
-
-[[package]]
-name = "x509-parser"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4569f339c0c402346d4a75a9e39cf8dad310e287eef1ff56d4c68e5067f53460"
-dependencies = [
- "asn1-rs",
- "data-encoding",
- "der-parser",
- "lazy_static",
- "nom",
- "oid-registry",
- "rusticata-macros",
- "thiserror 2.0.12",
- "time",
-]
-
-[[package]]
-name = "xattr"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d65cbf2f12c15564212d48f4e3dfb87923d25d611f2aed18f4cb23f0413d89e"
-dependencies = [
- "libc",
- "rustix",
-]
-
-[[package]]
-name = "yaml-rust"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
-dependencies = [
- "linked-hash-map",
-]
-
-[[package]]
-name = "yasna"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
-dependencies = [
- "time",
-]
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "yoke"
-version = "0.7.5"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
- "serde",
  "stable_deref_trait",
  "yoke-derive",
  "zerofrom",
@@ -6445,103 +1625,53 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.7.5"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
- "synstructure 0.13.2",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
-dependencies = [
- "zerocopy-derive 0.7.35",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.8.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
-dependencies = [
- "zerocopy-derive 0.8.25",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
+ "syn 2.0.119",
+ "synstructure",
 ]
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
- "synstructure 0.13.2",
+ "syn 2.0.119",
+ "synstructure",
 ]
 
 [[package]]
-name = "zeroize"
-version = "1.8.1"
+name = "zerotrie"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
- "serde",
- "zeroize_derive",
-]
-
-[[package]]
-name = "zeroize_derive"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
+ "displaydoc",
+ "yoke",
+ "zerofrom",
 ]
 
 [[package]]
 name = "zerovec"
-version = "0.10.4"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -6550,66 +1680,49 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.10.3"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "zip"
-version = "2.6.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dcb24d0152526ae49b9b96c1dcf71850ca1e0b882e4e28ed898a93c41334744"
+checksum = "12598812502ed0105f607f941c386f43d441e00148fce9dec3ca5ffb0bde9308"
 dependencies = [
  "arbitrary",
  "crc32fast",
- "crossbeam-utils",
  "flate2",
- "indexmap 2.11.4",
+ "indexmap",
  "memchr",
  "zopfli",
 ]
 
 [[package]]
-name = "zopfli"
-version = "0.8.2"
+name = "zlib-rs"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edfc5ee405f504cd4984ecc6f14d02d55cfda60fa4b689434ef4102aae150cd7"
+checksum = "b142a20ec14a91d5bc708c1dc21b080c550113d8aa77afa29635673a65dd02c5"
+
+[[package]]
+name = "zmij"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
 dependencies = [
  "bumpalo",
  "crc32fast",
  "log",
  "simd-adler32",
-]
-
-[[package]]
-name = "zstd"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
-dependencies = [
- "zstd-safe",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "7.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
-dependencies = [
- "zstd-sys",
-]
-
-[[package]]
-name = "zstd-sys"
-version = "2.0.15+zstd.1.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb81183ddd97d0c74cedf1d50d85c8d08c1b8b68ee863bdee9e706eedba1a237"
-dependencies = [
- "cc",
- "pkg-config",
 ]

--- a/examples/hook/Cargo.toml
+++ b/examples/hook/Cargo.toml
@@ -10,7 +10,11 @@ anyhow = "1.0.98"
 axum = "0.8.0"
 base64 = "0.22.1"
 bcs = "0.1.4"
-iota-types = { git = "https://github.com/iotaledger/iota", tag = "v1.15.0", package = "iota-types" }
+iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "b77fcd5ac5fedb3dfbc77ba7d183140e43512339", features = [
+    "hash",
+    "serde",
+    "rand",
+] }
 serde = "1"
 serde_json = "1.0.140"
 thiserror = "2.0.12"

--- a/examples/hook/src/endpoint_types.rs
+++ b/examples/hook/src/endpoint_types.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 use anyhow::Context as _;
 use axum::http::StatusCode;
 use base64::prelude::*;
-use iota_types::transaction::TransactionData;
+use iota_sdk_types::Transaction;
 use serde::Deserialize;
 use serde::Serialize;
 use utoipa::ToSchema;
@@ -37,7 +37,7 @@ pub struct ExecuteTxRequestPayload {
     /// ID used to reference a gas reservation.
     #[schema(format = "uint64")]
     pub reservation_id: u64,
-    /// Transaction as base64 encoded BCS serialized `TransactionData`.
+    /// Transaction as base64 encoded BCS serialized `Transaction`.
     #[schema(content_encoding = "base64")]
     pub tx_bytes: String,
     /// Base64 encoded user signature.
@@ -56,12 +56,12 @@ pub enum ExecuteTransactionRequestType {
 
 impl ExecuteTxHookRequest {
     /// Helper function to allow accessing transaction data easily.
-    pub fn parse_transaction_data(&self) -> Result<TransactionData, RequestError> {
+    pub fn parse_transaction_data(&self) -> Result<Transaction, RequestError> {
         BASE64_STANDARD
             .decode(&self.execute_tx_request.payload.tx_bytes)
             .context("failed to decode base64 string with transaction data")
             .and_then(|bytes| {
-                bcs::from_bytes(&bytes).context("failed to parse BCS bytes to `TransactionData`")
+                bcs::from_bytes(&bytes).context("failed to parse BCS bytes to `Transaction`")
             })
             .map_err(|err| RequestError::new(err).with_status(StatusCode::BAD_REQUEST))
     }

--- a/examples/rust/README.md
+++ b/examples/rust/README.md
@@ -4,11 +4,16 @@
 
 1. Ensure the IOTA Gas Station is up and running. To learn how to set up the Gas Station, please follow this [link](../../README.md#how-to-run-with-docker).
 2. The expected address of the Gas Station is `http://localhost:9527`. Modify this if necessary.
+3. Set `USER_PRIVATE_KEY` to a bech32-encoded (`iotaprivkey1...`) ed25519 private key for
+   the account that will act as the transaction sender -- e.g. one printed by
+   `iota keytool generate ed25519`. These examples have no keystore/wallet-config support
+   (the new `iota-rust-sdk` doesn't provide one), so a private key must be supplied this
+   way. The sender address needs to own at least one IOTA coin on testnet.
 
 ## How to run
 
 ```bash
-GAS_STATION_AUTH='your-bearer-token' cargo run --example sponsored_transaction
+USER_PRIVATE_KEY='iotaprivkey1...' GAS_STATION_AUTH='your-bearer-token' cargo run --example sponsored_transaction
 ```
 
 ## Common Issues

--- a/examples/rust/hook_with_config_headers.rs
+++ b/examples/rust/hook_with_config_headers.rs
@@ -87,19 +87,16 @@ async fn main() -> anyhow::Result<()> {
         .unwrap_or_else(|| panic!("{user} owns no IOTA coins on testnet"))
         .object_reference()?;
 
-    let reference_gas_price = client.get_reference_gas_price().await?.into_inner();
-
-    // Build the transaction offline: the gas payment is exactly the coins/sponsor the gas
-    // station already reserved above, so there's no need for client-based gas
-    // auto-selection here.
-    let mut builder = TransactionBuilder::new(user);
+    // With a client attached, the builder resolves the current reference gas price from
+    // the network itself; the gas payment is still exactly the coins/sponsor the gas
+    // station reserved above.
+    let mut builder = TransactionBuilder::new(user).with_client(&client);
     builder
         .transfer_objects(user, [object_ref])
         .sponsor(sponsor_account)
-        .gas(gas_coins)
-        .gas_price(reference_gas_price)
+        .gas(gas_coins.into_iter().map(|coin| coin.object_id))
         .gas_budget(3_000_000);
-    let tx = builder.finish()?;
+    let tx = builder.finish().await?;
 
     // Sign the transaction with the user's own key.
     let signature = keypair.sign_transaction(&tx)?;

--- a/examples/rust/hook_with_config_headers.rs
+++ b/examples/rust/hook_with_config_headers.rs
@@ -115,13 +115,10 @@ async fn main() -> anyhow::Result<()> {
 
     println!("Transaction effects: {effects:#?}");
 
-    // `effects` is the JSON-RPC-shaped wire DTO this service returns; check the nested
-    // `status.status` field the same way an external HTTP client of this API would.
-    let effects_json = serde_json::to_value(&effects)?;
-    assert_eq!(
-        effects_json["status"]["status"].as_str(),
-        Some("success"),
-        "transaction did not succeed: {effects_json}"
+    assert!(
+        effects.status.is_success(),
+        "transaction did not succeed: {:?}",
+        effects.status
     );
 
     Ok(())

--- a/examples/rust/hook_with_config_headers.rs
+++ b/examples/rust/hook_with_config_headers.rs
@@ -1,110 +1,128 @@
-use std::path::Path;
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
 
-use iota_config::IOTA_CLIENT_CONFIG;
+//! This example demonstrates using the gas station to create a transaction:
+//!  - Reserve gas from the gas station
+//!  - Create a transaction with the gas object reserved from the gas station
+//!  - Sign the transaction with the user's own key
+//!  - Let an external hook decide if the transaction should be executed
+//!  - Execute the transaction with the gas station, if allowed
+//!
+//! As this is a hook example, make sure that the example hook server from this project is
+//! running (`cargo run` in the `examples/hook` folder) and that your IOTA gas station is
+//! using an access controller that relies on a hook.
+//!
+//! This example uses headers **configured in the gas station** as part of the **request
+//! headers** sent to the hook, so you have to configure additional headers in the config.
+//! We use test headers here to control how the hook responds to the request made by the
+//! gas station:
+//!
+//! ```yaml
+//! access-controller:
+//!   access-policy: deny-all
+//!   rules:
+//!   - action:
+//!     - url: 'http://127.0.0.1:8080'
+//!       headers:
+//!       - authorization: ['Bearer this-could-be-your-auth-token']
+//!       - test-response: ['{"decision": "allow"}']
+//! ```
+//! You can set the `decision` value to other values ("allow"/"deny"/"noDecision") if you
+//! want to test different responses, or use the header `test-error` with a string value to
+//! test errors returned from the hook.
+//!
+//! Before you run this example, make sure:
+//!  - `USER_PRIVATE_KEY` is set to a bech32-encoded (`iotaprivkey1...`) ed25519 private
+//!    key for the account that will act as the transaction sender -- e.g. one printed by
+//!    `iota keytool generate ed25519`.
+//!  - `GAS_STATION_AUTH` is set to the gas station's bearer token, if it requires one.
+//!  - the IOTA gas station is running and configured for TESTNET.
+//!  - the sender address owns at least one IOTA coin on testnet (it's transferred to
+//!    itself below, purely to have something for the sponsored transaction to do).
+
+use iota_gas_station::gas_station::gas_station_core::NANOS_PER_IOTA;
 use iota_gas_station::rpc::client::GasStationRpcClient;
-use iota_json_rpc_types::{IotaExecutionStatus, IotaTransactionBlockEffectsAPI};
-use iota_sdk::{wallet_context::WalletContext, IotaClientBuilder};
-use iota_types::{
-    gas_coin::NANOS_PER_IOTA,
-    transaction::{TransactionData, TransactionDataAPI},
-};
+use iota_sdk_crypto::{IotaSigner, ToFromBech32, ed25519::Ed25519PrivateKey};
+use iota_sdk_grpc_client::Client;
+use iota_sdk_transaction_builder::TransactionBuilder;
+use iota_sdk_types::StructTag;
 
-// This example demonstrates using the gas station to create a transaction
-//  - Reserve gas from the gas station
-//  - Create a transaction with the gas object reserved from the gas station
-//  - Sign the transaction with the wallet
-//  - Let an external hook decide if the transaction should be executed
-//  - Execute the transaction with the gas station, if allowed
+const USER_PRIVATE_KEY_ENV: &str = "USER_PRIVATE_KEY";
 
-// As this is a hook example, make sure, that the example hook server from this project is running
-// (`cargo run` in `examples/hook` folder) and that your IOTA gas station is using an access controller,
-// that relies on a hook.
-//
-// This example uses headers **configured in the gas station** as part **request headers** to the hook,
-// so have to configure additional headers in the config.
-// We are going to use test headers to control how the hook responds to the request by the gas station.
-//
-// ```yaml
-// access-controller:
-//   access-policy: deny-all
-//   rules:
-//   - action:
-//     - url: 'http://127.0.0.1:8080'
-//       headers:
-//       - authorization: ['Bearer this-could-be-your-auth-token']
-//       - test-response: ['{"decision": "allow"}']
-// ```
-// You can set the `decision` value to other values ("allow"/"deny"/"noDecision") if you want to test
-// different responses or use the header `test-error` with a string value to test errors returned from the hook.
-
-// Before you run this example make sure:
-//  - GAS_STATION_AUTH env is set to the correct value
-//  - the IOTA gas station is running, an its configured for the TESTNET
 #[tokio::main]
-async fn main() {
-    // Create a new gas station client
-    let gas_station_url = "http://localhost:9527".to_string();
-    let gas_station_client = GasStationRpcClient::new(gas_station_url);
+async fn main() -> anyhow::Result<()> {
+    // Create a new gas station client.
+    let gas_station_client = GasStationRpcClient::new("http://localhost:9527".to_string());
 
-    // Reserve the 1 IOTA for 10 seconds
+    // Reserve 1 IOTA for 10 seconds.
     let (sponsor_account, reservation_id, gas_coins) = gas_station_client
         .reserve_gas(NANOS_PER_IOTA, 10)
         .await
         .expect("Failed to reserve gas");
-    assert!(gas_coins.len() >= 1);
+    assert!(!gas_coins.is_empty());
 
-    // Create a new IOTA Client
-    let iota_client = IotaClientBuilder::default().build_testnet().await.unwrap();
+    let private_key = std::env::var(USER_PRIVATE_KEY_ENV).unwrap_or_else(|_| {
+        panic!(
+            "{USER_PRIVATE_KEY_ENV} must be set to a bech32-encoded (`iotaprivkey1...`) ed25519 private key"
+        )
+    });
+    let keypair = Ed25519PrivateKey::from_bech32(&private_key)
+        .unwrap_or_else(|err| panic!("{USER_PRIVATE_KEY_ENV} is not a valid bech32 private key: {err}"));
+    let user = keypair.public_key().derive_address();
 
-    // Load the config from default location (~./iota/iota_config/client.yaml)
-    let config_path = format!(
-        "{}/{}",
-        iota_config::iota_config_dir().unwrap().to_str().unwrap(),
-        IOTA_CLIENT_CONFIG
-    );
-    let wallet_context = WalletContext::new(&Path::new(&config_path)).unwrap();
+    // Connect to a testnet fullnode over gRPC to resolve an object owned by `user` and the
+    // current reference gas price -- the gas station's HTTP API only covers gas
+    // sponsorship/execution, not general chain reads.
+    let client = Client::new_testnet()?;
 
-    // Get the first gas object owned by the address
-    let user = wallet_context.active_address().unwrap();
-    let object = wallet_context
-        .get_one_gas_object_owned_by_address(user)
-        .await
-        .unwrap()
-        .unwrap();
+    // Get an object owned by the user to transfer -- to itself, purely as a demo payload.
+    let page = client
+        .list_owned_objects(user, Some(StructTag::new_gas_coin()), Some(1), None, None)
+        .await?
+        .into_inner();
+    let object_ref = page
+        .items
+        .first()
+        .unwrap_or_else(|| panic!("{user} owns no IOTA coins on testnet"))
+        .object_reference()?;
 
-    let ref_gas_price = iota_client
-        .governance_api()
-        .get_reference_gas_price()
-        .await
-        .unwrap();
+    let reference_gas_price = client.get_reference_gas_price().await?.into_inner();
 
-    // Create the TransactionKind.
-    // TransactionKind is an type that doesn't have information about gas and sender.
-    let tx_kind = iota_client
-        .transaction_builder()
-        .transfer_object_tx_kind(object.0, user)
-        .await
-        .unwrap();
+    // Build the transaction offline: the gas payment is exactly the coins/sponsor the gas
+    // station already reserved above, so there's no need for client-based gas
+    // auto-selection here.
+    let mut builder = TransactionBuilder::new(user);
+    builder
+        .transfer_objects(user, [object_ref])
+        .sponsor(sponsor_account)
+        .gas(gas_coins)
+        .gas_price(reference_gas_price)
+        .gas_budget(3_000_000);
+    let tx = builder.finish()?;
 
-    // Build the TransactionData.
-    // TransactionData is unsigned version of Transaction. The maximum gas budget is 0.01 IOTA.
-    let mut tx_data = TransactionData::new(tx_kind, user, gas_coins[0], 3000000, ref_gas_price);
-    // Set the gas object and gas-station sponsor account fetched from the gas station
-    tx_data.gas_data_mut().payment = gas_coins;
-    tx_data.gas_data_mut().owner = sponsor_account;
+    // Sign the transaction with the user's own key.
+    let signature = keypair.sign_transaction(&tx)?;
 
-    // Sign the TransactionData with the wallet.
-    let transaction = wallet_context.sign_transaction(&tx_data);
-    let signature = transaction.tx_signatures()[0].to_owned();
-
-    // Send the TransactionData together with the signature to the Gas Station.
-    // The Gas Station will execute the Transaction and returns the effects.
+    // Send the transaction together with the signature to the Gas Station.
+    // The Gas Station will execute the transaction and return the effects. The hook
+    // receives the test headers configured in the gas station's own config (see above),
+    // not anything passed here.
     let effects = gas_station_client
-        .execute_tx(reservation_id, &tx_data, &signature, None, None)
+        .execute_tx(reservation_id, &tx, &signature, None, None)
         .await
         .expect("transaction should be sent");
 
-    println!("Transaction effects: {:?}", effects);
+    println!("Transaction effects: {effects:#?}");
 
-    assert_eq!(effects.into_status(), IotaExecutionStatus::Success);
+    // `effects` is the JSON-RPC-shaped wire DTO this service returns; check the nested
+    // `status.status` field the same way an external HTTP client of this API would.
+    let effects_json = serde_json::to_value(&effects)?;
+    assert_eq!(
+        effects_json["status"]["status"].as_str(),
+        Some("success"),
+        "transaction did not succeed: {effects_json}"
+    );
+
+    Ok(())
 }

--- a/examples/rust/hook_with_request_headers.rs
+++ b/examples/rust/hook_with_request_headers.rs
@@ -118,13 +118,10 @@ async fn main() -> anyhow::Result<()> {
 
     println!("Transaction effects: {effects:#?}");
 
-    // `effects` is the JSON-RPC-shaped wire DTO this service returns; check the nested
-    // `status.status` field the same way an external HTTP client of this API would.
-    let effects_json = serde_json::to_value(&effects)?;
-    assert_eq!(
-        effects_json["status"]["status"].as_str(),
-        Some("success"),
-        "transaction did not succeed: {effects_json}"
+    assert!(
+        effects.status.is_success(),
+        "transaction did not succeed: {:?}",
+        effects.status
     );
 
     Ok(())

--- a/examples/rust/hook_with_request_headers.rs
+++ b/examples/rust/hook_with_request_headers.rs
@@ -80,19 +80,16 @@ async fn main() -> anyhow::Result<()> {
         .unwrap_or_else(|| panic!("{user} owns no IOTA coins on testnet"))
         .object_reference()?;
 
-    let reference_gas_price = client.get_reference_gas_price().await?.into_inner();
-
-    // Build the transaction offline: the gas payment is exactly the coins/sponsor the gas
-    // station already reserved above, so there's no need for client-based gas
-    // auto-selection here.
-    let mut builder = TransactionBuilder::new(user);
+    // With a client attached, the builder resolves the current reference gas price from
+    // the network itself; the gas payment is still exactly the coins/sponsor the gas
+    // station reserved above.
+    let mut builder = TransactionBuilder::new(user).with_client(&client);
     builder
         .transfer_objects(user, [object_ref])
         .sponsor(sponsor_account)
-        .gas(gas_coins)
-        .gas_price(reference_gas_price)
+        .gas(gas_coins.into_iter().map(|coin| coin.object_id))
         .gas_budget(3_000_000);
-    let tx = builder.finish()?;
+    let tx = builder.finish().await?;
 
     // Sign the transaction with the user's own key.
     let signature = keypair.sign_transaction(&tx)?;

--- a/examples/rust/hook_with_request_headers.rs
+++ b/examples/rust/hook_with_request_headers.rs
@@ -1,114 +1,131 @@
-use std::{path::Path, str::FromStr};
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
 
-use axum::http::{HeaderMap, HeaderName, HeaderValue};
-use iota_config::IOTA_CLIENT_CONFIG;
+//! This example demonstrates using the gas station to create a transaction:
+//!  - Reserve gas from the gas station
+//!  - Create a transaction with the gas object reserved from the gas station
+//!  - Sign the transaction with the user's own key
+//!  - Let an external hook decide if the transaction should be executed
+//!  - Execute the transaction with the gas station, if allowed
+//!
+//! As this is a hook example, make sure that the example hook server from this project is
+//! running (`cargo run` in the `examples/hook` folder) and that your IOTA gas station is
+//! using an access controller that relies on a hook.
+//!
+//! This example passes headers **sent to the gas station** as **part of the payload**
+//! to the hook, so no need to configure additional headers in the config, and we can
+//! just use the hook's url as the action value:
+//!
+//! ```yaml
+//! access-controller:
+//!   access-policy: deny-all
+//!   rules:
+//!   - action: "http://127.0.0.1:8080"
+//! ```
+//!
+//! Before you run this example, make sure:
+//!  - `USER_PRIVATE_KEY` is set to a bech32-encoded (`iotaprivkey1...`) ed25519 private
+//!    key for the account that will act as the transaction sender -- e.g. one printed by
+//!    `iota keytool generate ed25519`.
+//!  - `GAS_STATION_AUTH` is set to the gas station's bearer token, if it requires one.
+//!  - the IOTA gas station is running and configured for TESTNET.
+//!  - the sender address owns at least one IOTA coin on testnet (it's transferred to
+//!    itself below, purely to have something for the sponsored transaction to do).
+
+use iota_gas_station::gas_station::gas_station_core::NANOS_PER_IOTA;
 use iota_gas_station::rpc::client::GasStationRpcClient;
-use iota_json_rpc_types::{IotaExecutionStatus, IotaTransactionBlockEffectsAPI};
-use iota_sdk::{wallet_context::WalletContext, IotaClientBuilder};
-use iota_types::{
-    gas_coin::NANOS_PER_IOTA,
-    transaction::{TransactionData, TransactionDataAPI},
-};
+use iota_sdk_crypto::{IotaSigner, ToFromBech32, ed25519::Ed25519PrivateKey};
+use iota_sdk_grpc_client::Client;
+use iota_sdk_transaction_builder::TransactionBuilder;
+use iota_sdk_types::StructTag;
+use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
 
-// This example demonstrates using the gas station to create a transaction
-//  - Reserve gas from the gas station
-//  - Create a transaction with the gas object reserved from the gas station
-//  - Sign the transaction with the wallet
-//  - Let an external hook decide if the transaction should be executed
-//  - Execute the transaction with the gas station, if allowed
+const USER_PRIVATE_KEY_ENV: &str = "USER_PRIVATE_KEY";
 
-// As this is a hook example, make sure, that the example hook server from this project is running
-// (`cargo run` in `examples/hook` folder) and that your IOTA gas station is using an access controller,
-// that relies on a hook.
-//
-// This example passes headers **sent to the gas station** as **part of the payload** to the hook,
-// so no need to configure additional headers in the config, and we can just use the hook's url as the action value:
-//
-// ```yaml
-// access-controller:
-//   access-policy: deny-all
-//   rules:
-//   - action: "http://127.0.0.1:8080"
-// ```
-
-// Before you run this example make sure:
-//  - GAS_STATION_AUTH env is set to the correct value
-//  - the IOTA gas station is running, an its configured for the TESTNET
 #[tokio::main]
-async fn main() {
-    // Create a new gas station client
-    let gas_station_url = "http://localhost:9527".to_string();
-    let gas_station_client = GasStationRpcClient::new(gas_station_url);
+async fn main() -> anyhow::Result<()> {
+    // Create a new gas station client.
+    let gas_station_client = GasStationRpcClient::new("http://localhost:9527".to_string());
 
-    // Reserve the 1 IOTA for 10 seconds
+    // Reserve 1 IOTA for 10 seconds.
     let (sponsor_account, reservation_id, gas_coins) = gas_station_client
         .reserve_gas(NANOS_PER_IOTA, 10)
         .await
         .expect("Failed to reserve gas");
-    assert!(gas_coins.len() >= 1);
+    assert!(!gas_coins.is_empty());
 
-    // Create a new IOTA Client
-    let iota_client = IotaClientBuilder::default().build_testnet().await.unwrap();
+    let private_key = std::env::var(USER_PRIVATE_KEY_ENV).unwrap_or_else(|_| {
+        panic!(
+            "{USER_PRIVATE_KEY_ENV} must be set to a bech32-encoded (`iotaprivkey1...`) ed25519 private key"
+        )
+    });
+    let keypair = Ed25519PrivateKey::from_bech32(&private_key)
+        .unwrap_or_else(|err| panic!("{USER_PRIVATE_KEY_ENV} is not a valid bech32 private key: {err}"));
+    let user = keypair.public_key().derive_address();
 
-    // Load the config from default location (~./iota/iota_config/client.yaml)
-    let config_path = format!(
-        "{}/{}",
-        iota_config::iota_config_dir().unwrap().to_str().unwrap(),
-        IOTA_CLIENT_CONFIG
-    );
-    let wallet_context = WalletContext::new(&Path::new(&config_path)).unwrap();
+    // Connect to a testnet fullnode over gRPC to resolve an object owned by `user` and the
+    // current reference gas price -- the gas station's HTTP API only covers gas
+    // sponsorship/execution, not general chain reads.
+    let client = Client::new_testnet()?;
 
-    // Get the first gas object owned by the address
-    let user = wallet_context.active_address().unwrap();
-    let object = wallet_context
-        .get_one_gas_object_owned_by_address(user)
-        .await
-        .unwrap()
-        .unwrap();
+    // Get an object owned by the user to transfer -- to itself, purely as a demo payload.
+    let page = client
+        .list_owned_objects(user, Some(StructTag::new_gas_coin()), Some(1), None, None)
+        .await?
+        .into_inner();
+    let object_ref = page
+        .items
+        .first()
+        .unwrap_or_else(|| panic!("{user} owns no IOTA coins on testnet"))
+        .object_reference()?;
 
-    let ref_gas_price = iota_client
-        .governance_api()
-        .get_reference_gas_price()
-        .await
-        .unwrap();
+    let reference_gas_price = client.get_reference_gas_price().await?.into_inner();
 
-    // Create the TransactionKind.
-    // TransactionKind is an type that doesn't have information about gas and sender.
-    let tx_kind = iota_client
-        .transaction_builder()
-        .transfer_object_tx_kind(object.0, user)
-        .await
-        .unwrap();
+    // Build the transaction offline: the gas payment is exactly the coins/sponsor the gas
+    // station already reserved above, so there's no need for client-based gas
+    // auto-selection here.
+    let mut builder = TransactionBuilder::new(user);
+    builder
+        .transfer_objects(user, [object_ref])
+        .sponsor(sponsor_account)
+        .gas(gas_coins)
+        .gas_price(reference_gas_price)
+        .gas_budget(3_000_000);
+    let tx = builder.finish()?;
 
-    // Build the TransactionData.
-    // TransactionData is unsigned version of Transaction. The maximum gas budget is 0.01 IOTA.
-    let mut tx_data = TransactionData::new(tx_kind, user, gas_coins[0], 3000000, ref_gas_price);
-    // Set the gas object and gas-station sponsor account fetched from the gas station
-    tx_data.gas_data_mut().payment = gas_coins;
-    tx_data.gas_data_mut().owner = sponsor_account;
+    // Sign the transaction with the user's own key.
+    let signature = keypair.sign_transaction(&tx)?;
 
-    // Sign the TransactionData with the wallet.
-    let transaction = wallet_context.sign_transaction(&tx_data);
-    let signature = transaction.tx_signatures()[0].to_owned();
-
-    // Build the response, we want to get from the hook as part of the request headers used for the call to the hook.
-    // These headers will be part of the payload sent to the hook.
+    // Build the headers we want the hook to see as part of the payload sent to it (these
+    // headers travel *inside* the `/v1/execute_tx` request body, not as HTTP headers of
+    // that request itself).
     let mut headers = HeaderMap::new();
     headers.append(
-        HeaderName::from_str("test-response").unwrap(),
-        HeaderValue::from_str(r#"{"decision": "allow"}"#).unwrap(),
+        HeaderName::from_static("test-response"),
+        HeaderValue::from_static(r#"{"decision": "allow"}"#),
     );
-    // You can set the `decision` value to other values ("allow"/"deny"/"noDecision") if you want to test
-    // different responses or use the header `test-error` with a string value to test errors returned from the hook.
+    // You can set the `decision` value to other values ("allow"/"deny"/"noDecision") if you
+    // want to test different responses, or use the header `test-error` with a string value
+    // to test errors returned from the hook.
 
-    // Send the TransactionData together with the signature to the Gas Station.
-    // The Gas Station will execute the Transaction and returns the effects.
+    // Send the transaction together with the signature to the Gas Station.
+    // The Gas Station will execute the transaction and return the effects.
     let effects = gas_station_client
-        .execute_tx(reservation_id, &tx_data, &signature, None, Some(headers))
+        .execute_tx(reservation_id, &tx, &signature, None, Some(headers))
         .await
         .expect("transaction should be sent");
 
-    println!("Transaction effects: {:?}", effects);
+    println!("Transaction effects: {effects:#?}");
 
-    assert_eq!(effects.into_status(), IotaExecutionStatus::Success);
+    // `effects` is the JSON-RPC-shaped wire DTO this service returns; check the nested
+    // `status.status` field the same way an external HTTP client of this API would.
+    let effects_json = serde_json::to_value(&effects)?;
+    assert_eq!(
+        effects_json["status"]["status"].as_str(),
+        Some("success"),
+        "transaction did not succeed: {effects_json}"
+    );
+
+    Ok(())
 }

--- a/examples/rust/sponsored_transaction.rs
+++ b/examples/rust/sponsored_transaction.rs
@@ -1,88 +1,106 @@
-use std::path::Path;
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
 
-use iota_config::IOTA_CLIENT_CONFIG;
-use iota_gas_station::rpc::client::GasStationRpcClient;
-use iota_json_rpc_types::{IotaExecutionStatus, IotaTransactionBlockEffectsAPI};
-use iota_sdk::{wallet_context::WalletContext, IotaClientBuilder};
-use iota_types::{
-    gas_coin::NANOS_PER_IOTA,
-    transaction::{TransactionData, TransactionDataAPI},
-};
+//! This example demonstrates using the gas station to create a transaction:
+//!  - Reserve gas from the gas station
+//!  - Create a transaction with the gas object reserved from the gas station
+//!  - Sign the transaction with the user's own key
+//!  - Execute the transaction with the gas station
+//!
+//! Unlike `hook_with_request_headers`/`hook_with_config_headers` (which talk to this
+//! service's `/v1/reserve_gas`/`/v1/execute_tx` endpoints directly through
+//! [`GasStationRpcClient`]), this example instead uses
+//! `iota-sdk-transaction-builder`'s own **native** gas-station support --
+//! [`TransactionBuilder::gas_station_sponsor`] and
+//! [`TransactionBuilder::add_gas_station_header`] -- which speaks the exact same wire
+//! protocol (`/version`, `/v1/reserve_gas`, `/v1/execute_tx`) internally. This is both a
+//! shorter way to write the example *and* a from-the-client-side check that this
+//! service's wire contract is compatible with the upstream SDK's own gas-station client
+//! (verified against `iota-sdk-transaction-builder`'s `builder/gas_station.rs` at the
+//! pinned SDK revision this crate migrated to).
+//!
+//! Before you run this example, make sure:
+//!  - `USER_PRIVATE_KEY` is set to a bech32-encoded (`iotaprivkey1...`) ed25519 private
+//!    key for the account that will act as the transaction *sender* -- e.g. one printed
+//!    by `iota keytool generate ed25519`. This is **not** the gas station's sponsor
+//!    account: the gas station supplies its own sponsor address and gas coins via
+//!    `/v1/reserve_gas`, this key only needs to own (and sign for) the object being
+//!    transferred below.
+//!  - `GAS_STATION_AUTH` is set to the gas station's bearer token, if it requires one.
+//!  - the IOTA gas station is running and configured for TESTNET.
+//!  - the sender address owns at least one IOTA coin on testnet (it's transferred to
+//!    itself below, purely to have something for the sponsored transaction to do).
 
-// This example demonstrates using the gas station to create a transaction
-//  - Reserve gas from the gas station
-//  - Create a transaction with the gas object reserved from the gas station
-//  - Sign the transaction with the wallet
-//  - Execute the transaction with the gas station
+use iota_sdk_crypto::ToFromBech32;
+use iota_sdk_crypto::ed25519::Ed25519PrivateKey;
+use iota_sdk_grpc_client::Client;
+use iota_sdk_transaction_builder::TransactionBuilder;
+use iota_sdk_types::StructTag;
 
-// Before you run this example make sure:
-//  - GAS_STATION_AUTH env is set to the correct value
-//  - the IOTA gas station is running, an its configured for the TESTNET
+const USER_PRIVATE_KEY_ENV: &str = "USER_PRIVATE_KEY";
+const GAS_STATION_AUTH_ENV: &str = "GAS_STATION_AUTH";
+
 #[tokio::main]
-async fn main() {
-    // Create a new gas station client
-    let gas_station_url = "http://localhost:9527".to_string();
-    let gas_station_client = GasStationRpcClient::new(gas_station_url);
+async fn main() -> anyhow::Result<()> {
+    let private_key = std::env::var(USER_PRIVATE_KEY_ENV).unwrap_or_else(|_| {
+        panic!(
+            "{USER_PRIVATE_KEY_ENV} must be set to a bech32-encoded (`iotaprivkey1...`) ed25519 private key"
+        )
+    });
+    let keypair = Ed25519PrivateKey::from_bech32(&private_key)
+        .unwrap_or_else(|err| panic!("{USER_PRIVATE_KEY_ENV} is not a valid bech32 private key: {err}"));
+    let sender = keypair.public_key().derive_address();
+    println!("Sender address: {sender}");
 
-    // Reserve the 1 IOTA for 10 seconds
-    let (sponsor_account, reservation_id, gas_coins) = gas_station_client
-        .reserve_gas(NANOS_PER_IOTA, 10)
-        .await
-        .expect("Failed to reserve gas");
-    assert!(gas_coins.len() >= 1);
+    let gas_station_url = url::Url::parse("http://localhost:9527")?;
 
-    // Create a new IOTA Client
-    let iota_client = IotaClientBuilder::default().build_testnet().await.unwrap();
+    // Connect to a testnet fullnode over gRPC. The gas station's own HTTP API only
+    // covers gas sponsorship and execution -- resolving the sender's own objects, the
+    // reference gas price, and (via `execute`, below) confirming the executed effects
+    // still all go through a fullnode.
+    let client = Client::new_testnet()?;
 
-    // Load the config from default location (~./iota/iota_config/client.yaml)
-    let config_path = format!(
-        "{}/{}",
-        iota_config::iota_config_dir().unwrap().to_str().unwrap(),
-        IOTA_CLIENT_CONFIG
+    // Find a coin owned by the sender to use as this demo's payload: transfer one of the
+    // sender's own IOTA coins back to themselves. (Mirrors the old wallet-context-based
+    // version of this example, which grabbed "the first gas object owned by the
+    // address" -- any object the sender owns would do here, a coin is just the simplest
+    // one to look up.)
+    let page = client
+        .list_owned_objects(sender, Some(StructTag::new_gas_coin()), Some(1), None, None)
+        .await?
+        .into_inner();
+    let coin_id = page
+        .items
+        .first()
+        .unwrap_or_else(|| panic!("{sender} owns no IOTA coins on testnet"))
+        .object_reference()?
+        .object_id;
+
+    let mut builder = TransactionBuilder::new(sender).with_client(&client);
+    let gas_station_builder = builder
+        .transfer_objects(sender, [coin_id])
+        .gas_station_sponsor(gas_station_url);
+    if let Ok(auth) = std::env::var(GAS_STATION_AUTH_ENV) {
+        if !auth.is_empty() {
+            gas_station_builder.add_gas_station_header(
+                http::header::AUTHORIZATION,
+                http::HeaderValue::from_str(&format!("Bearer {auth}"))?,
+            );
+        }
+    }
+
+    // `execute` builds the transaction (auto-selecting gas price/budget via the
+    // fullnode), sends it to the gas station for sponsorship and execution, then polls
+    // the fullnode until finalized and returns its effects -- all in one call.
+    let effects = builder.execute(&keypair, None).await?;
+    println!("Transaction effects: {effects:#?}");
+
+    assert!(
+        effects.as_v1().status.is_success(),
+        "transaction did not succeed: {:?}",
+        effects.as_v1().status
     );
-    let wallet_context = WalletContext::new(&Path::new(&config_path)).unwrap();
 
-    // Get the first gas object owned by the address
-    let user = wallet_context.active_address().unwrap();
-    let object = wallet_context
-        .get_one_gas_object_owned_by_address(user)
-        .await
-        .unwrap()
-        .unwrap();
-
-    let ref_gas_price = iota_client
-        .governance_api()
-        .get_reference_gas_price()
-        .await
-        .unwrap();
-
-    // Create the TransactionKind.
-    // TransactionKind is an type that doesn't have information about gas and sender.
-    let tx_kind = iota_client
-        .transaction_builder()
-        .transfer_object_tx_kind(object.0, user)
-        .await
-        .unwrap();
-
-    // Build the TransactionData.
-    // TransactionData is unsigned version of Transaction. The maximum gas budget is 0.01 IOTA.
-    let mut tx_data = TransactionData::new(tx_kind, user, gas_coins[0], 3000000, ref_gas_price);
-    // Set the gas object and gas-station sponsor account fetched from the gas station
-    tx_data.gas_data_mut().payment = gas_coins;
-    tx_data.gas_data_mut().owner = sponsor_account;
-
-    // Sign the TransactionData with the wallet.
-    let transaction = wallet_context.sign_transaction(&tx_data);
-    let signature = transaction.tx_signatures()[0].to_owned();
-
-    // Send the TransactionData together with the signature to the Gas Station.
-    // The Gas Station will execute the Transaction and returns the effects.
-    let effects = gas_station_client
-        .execute_tx(reservation_id, &tx_data, &signature, None, None)
-        .await
-        .expect("transaction should be sent");
-
-    println!("Transaction effects: {:?}", effects);
-
-    assert_eq!(effects.into_status(), IotaExecutionStatus::Success);
+    Ok(())
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.88"
+channel = "1.95"

--- a/scripts/sync-sdk-rev.sh
+++ b/scripts/sync-sdk-rev.sh
@@ -100,6 +100,24 @@ if [ "$WITH_MONOREPO" -eq 1 ]; then
   ' "$MANIFEST" > "$TMP"
   cp "$TMP" "$MANIFEST"
   echo "updated monorepo rev      -> $MONO_SHA  (ref: $MONO_REF)"
+
+  # Keep the fastcrypto [patch] pinned to the same version as the monorepo's
+  # own [patch."https://github.com/MystenLabs/fastcrypto"] table.
+  MONO_FC_VER="$(printf '%s\n' "$MONO_TOML" \
+    | awk '/^\[patch\."https:\/\/github\.com\/MystenLabs\/fastcrypto"\]/{s=1; next} s && /^\[/{s=0} s && /^fastcrypto[ =]/{print; exit}' \
+    | grep -oE '"=?[0-9][^"]*"' | head -n1 | tr -d '"')"
+  if [ -n "$MONO_FC_VER" ] && grep -q '^\[patch\."https://github\.com/MystenLabs/fastcrypto"\]' "$MANIFEST"; then
+    awk -v want="$MONO_FC_VER" '
+      /^\[patch\."https:\/\/github\.com\/MystenLabs\/fastcrypto"\]/{s=1; print; next}
+      s && /^\[/{s=0}
+      s && /^fastcrypto *=/{ sub(/"[^"]*"/, "\"" want "\"") }
+      { print }
+    ' "$MANIFEST" > "$TMP"
+    cp "$TMP" "$MANIFEST"
+    echo "updated fastcrypto patch  -> $MONO_FC_VER"
+  else
+    echo "warning: could not sync the fastcrypto patch version (patch table missing on one side)" >&2
+  fi
 fi
 
 echo

--- a/scripts/sync-sdk-rev.sh
+++ b/scripts/sync-sdk-rev.sh
@@ -103,4 +103,8 @@ if [ "$WITH_MONOREPO" -eq 1 ]; then
 fi
 
 echo
-echo "next: cargo update --workspace && cargo check --all-targets"
+echo "running: cargo update --workspace"
+(cd "$ROOT" && cargo update --workspace)
+
+echo
+echo "next: cargo check --all-targets"

--- a/scripts/sync-sdk-rev.sh
+++ b/scripts/sync-sdk-rev.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+#
+# Sync this repo's iota-rust-sdk pin with the rev used by the iota monorepo.
+#
+# All iota-rust-sdk crates must share one rev, and it must match the rev the
+# monorepo pins -- otherwise Cargo builds two incompatible copies of
+# iota_sdk_types and monorepo types (test-cluster) stop unifying with ours.
+#
+#   ./scripts/sync-sdk-rev.sh                  # update to develop's rev
+#   ./scripts/sync-sdk-rev.sh --check          # exit 1 if out of sync (CI)
+#   ./scripts/sync-sdk-rev.sh --ref v1.29.0    # follow a tag/branch instead
+#   ./scripts/sync-sdk-rev.sh --with-monorepo  # also bump the dev-dep rev
+set -euo pipefail
+
+MONO_REF="develop"
+CHECK_ONLY=0
+WITH_MONOREPO=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --check)         CHECK_ONLY=1 ;;
+    --with-monorepo) WITH_MONOREPO=1 ;;
+    --ref)           MONO_REF="${2:?--ref needs a value}"; shift ;;
+    -h|--help)       sed -n '2,12p' "$0"; exit 0 ;;
+    *)               echo "unknown argument: $1" >&2; exit 2 ;;
+  esac
+  shift
+done
+
+die() { echo "error: $*" >&2; exit 1; }
+
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+[ -n "$ROOT" ] || die "not inside a git repository"
+MANIFEST="$ROOT/Cargo.toml"
+[ -f "$MANIFEST" ] || die "no Cargo.toml at $MANIFEST"
+
+RAW="https://raw.githubusercontent.com/iotaledger/iota/${MONO_REF}/Cargo.toml"
+MONO_TOML="$(curl -sfL "$RAW")" || die "cannot fetch $RAW"
+
+extract_revs() {
+  grep -E 'iotaledger/iota-rust-sdk' \
+    | grep -oE 'rev *= *"[0-9a-f]{40}"' \
+    | grep -oE '[0-9a-f]{40}' \
+    | sort -u
+}
+
+WANT_ALL="$(printf '%s\n' "$MONO_TOML" | extract_revs || true)"
+WANT_N="$(printf '%s\n' "$WANT_ALL" | grep -c . || true)"
+[ "$WANT_N" -gt 0 ] || die "no iota-rust-sdk rev found in $MONO_REF Cargo.toml"
+[ "$WANT_N" -eq 1 ] || die "$MONO_REF pins $WANT_N different SDK revs: $(echo $WANT_ALL)"
+WANT="$(printf '%s\n' "$WANT_ALL" | head -n1)"
+
+OURS_ALL="$(extract_revs < "$MANIFEST" || true)"
+OURS_N="$(printf '%s\n' "$OURS_ALL" | grep -c . || true)"
+[ "$OURS_N" -gt 0 ] || die "no iota-rust-sdk rev found in $MANIFEST"
+if [ "$OURS_N" -gt 1 ]; then
+  echo "warning: this repo pins $OURS_N different SDK revs: $(echo $OURS_ALL)" >&2
+  echo "         all of them will be set to $WANT" >&2
+fi
+
+URL_LINES=$(grep -cE 'iotaledger/iota-rust-sdk' "$MANIFEST" || true)
+REV_LINES=$(grep -E 'iotaledger/iota-rust-sdk' "$MANIFEST" | grep -cE 'rev *= *"' || true)
+[ "$URL_LINES" -eq "$REV_LINES" ] \
+  || die "$((URL_LINES - REV_LINES)) iota-rust-sdk line(s) have no rev on the same line; fix by hand"
+
+echo "monorepo ${MONO_REF} pins : $WANT"
+echo "this repo pins           : $(echo $OURS_ALL)"
+
+if [ "$OURS_N" -eq 1 ] && [ "$OURS_ALL" = "$WANT" ] && [ "$WITH_MONOREPO" -eq 0 ]; then
+  echo "already in sync."
+  exit 0
+fi
+
+if [ "$CHECK_ONLY" -eq 1 ]; then
+  die "out of sync with $MONO_REF -- run ./scripts/sync-sdk-rev.sh"
+fi
+
+TMP="$(mktemp)"; trap 'rm -f "$TMP"' EXIT
+awk -v want="$WANT" '
+  /iotaledger\/iota-rust-sdk/ { gsub(/rev *= *"[0-9a-f]+"/, "rev = \"" want "\"") }
+  { print }
+' "$MANIFEST" > "$TMP"
+cp "$TMP" "$MANIFEST"
+echo "updated iota-rust-sdk rev -> $WANT"
+
+if [ "$WITH_MONOREPO" -eq 1 ]; then
+  MONO_SHA="$(git ls-remote https://github.com/iotaledger/iota "refs/heads/${MONO_REF}" | awk '{print $1}')"
+  if [ -z "$MONO_SHA" ]; then
+    MONO_SHA="$(git ls-remote https://github.com/iotaledger/iota "refs/tags/${MONO_REF}" | awk '{print $1}')"
+  fi
+  [ -n "$MONO_SHA" ] || die "cannot resolve iotaledger/iota ref '${MONO_REF}'"
+
+  if grep -E 'iotaledger/iota(\.git)?"' "$MANIFEST" | grep -q 'tag *= *"'; then
+    die "monorepo deps use tag = \"...\"; convert them to rev = \"...\" by hand first"
+  fi
+
+  awk -v want="$MONO_SHA" '
+    /iotaledger\/iota(\.git)?"/ { gsub(/rev *= *"[0-9a-f]+"/, "rev = \"" want "\"") }
+    { print }
+  ' "$MANIFEST" > "$TMP"
+  cp "$TMP" "$MANIFEST"
+  echo "updated monorepo rev      -> $MONO_SHA  (ref: $MONO_REF)"
+fi
+
+echo
+echo "next: cargo update --workspace && cargo check --all-targets"

--- a/scripts/sync-sdk-rev.sh
+++ b/scripts/sync-sdk-rev.sh
@@ -6,13 +6,18 @@
 # monorepo pins -- otherwise Cargo builds two incompatible copies of
 # iota_sdk_types and monorepo types (test-cluster) stop unifying with ours.
 #
-#   ./scripts/sync-sdk-rev.sh                  # update to develop's rev
+#   ./scripts/sync-sdk-rev.sh                  # sync to the monorepo rev pinned here
 #   ./scripts/sync-sdk-rev.sh --check          # exit 1 if out of sync (CI)
-#   ./scripts/sync-sdk-rev.sh --ref v1.29.0    # follow a tag/branch instead
-#   ./scripts/sync-sdk-rev.sh --with-monorepo  # also bump the dev-dep rev
+#   ./scripts/sync-sdk-rev.sh --ref v1.29.0    # follow a tag/branch/sha instead
+#   ./scripts/sync-sdk-rev.sh --with-monorepo  # bump the dev-dep rev to develop + sync
+#
+# Without --ref, the reference point is the monorepo rev this repo already
+# pins for its dev-deps (test-cluster), so --check verifies internal
+# consistency instead of chasing the develop tip. --with-monorepo defaults
+# to develop because it deliberately moves that pin forward.
 set -euo pipefail
 
-MONO_REF="develop"
+MONO_REF=""
 CHECK_ONLY=0
 WITH_MONOREPO=0
 
@@ -21,7 +26,7 @@ while [ $# -gt 0 ]; do
     --check)         CHECK_ONLY=1 ;;
     --with-monorepo) WITH_MONOREPO=1 ;;
     --ref)           MONO_REF="${2:?--ref needs a value}"; shift ;;
-    -h|--help)       sed -n '2,12p' "$0"; exit 0 ;;
+    -h|--help)       sed -n '2,17p' "$0"; exit 0 ;;
     *)               echo "unknown argument: $1" >&2; exit 2 ;;
   esac
   shift
@@ -33,6 +38,23 @@ ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
 [ -n "$ROOT" ] || die "not inside a git repository"
 MANIFEST="$ROOT/Cargo.toml"
 [ -f "$MANIFEST" ] || die "no Cargo.toml at $MANIFEST"
+
+if [ -z "$MONO_REF" ]; then
+  if [ "$WITH_MONOREPO" -eq 1 ]; then
+    MONO_REF="develop"
+  else
+    PINNED_ALL="$(grep -E 'iotaledger/iota(\.git)?"' "$MANIFEST" \
+      | grep -oE 'rev *= *"[0-9a-f]{40}"' | grep -oE '[0-9a-f]{40}' | sort -u)"
+    PINNED_N="$(printf '%s\n' "$PINNED_ALL" | grep -c . || true)"
+    [ "$PINNED_N" -le 1 ] || die "this repo pins $PINNED_N different monorepo revs; pass --ref"
+    if [ "$PINNED_N" -eq 1 ]; then
+      MONO_REF="$PINNED_ALL"
+    else
+      echo "warning: no monorepo rev pinned in $MANIFEST; falling back to develop" >&2
+      MONO_REF="develop"
+    fi
+  fi
+fi
 
 RAW="https://raw.githubusercontent.com/iotaledger/iota/${MONO_REF}/Cargo.toml"
 MONO_TOML="$(curl -sfL "$RAW")" || die "cannot fetch $RAW"
@@ -63,8 +85,10 @@ REV_LINES=$(grep -E 'iotaledger/iota-rust-sdk' "$MANIFEST" | grep -cE 'rev *= *"
 [ "$URL_LINES" -eq "$REV_LINES" ] \
   || die "$((URL_LINES - REV_LINES)) iota-rust-sdk line(s) have no rev on the same line; fix by hand"
 
-echo "monorepo ${MONO_REF} pins : $WANT"
-echo "this repo pins           : $(echo $OURS_ALL)"
+REF_LABEL="$MONO_REF"
+printf '%s' "$MONO_REF" | grep -qE '^[0-9a-f]{40}$' && REF_LABEL="${MONO_REF:0:12} (pinned here)"
+printf '%-40s : %s\n' "monorepo ${REF_LABEL} pins" "$WANT"
+printf '%-40s : %s\n' "this repo pins" "$(echo $OURS_ALL)"
 
 if [ "$OURS_N" -eq 1 ] && [ "$OURS_ALL" = "$WANT" ] && [ "$WITH_MONOREPO" -eq 0 ]; then
   echo "already in sync."
@@ -84,11 +108,15 @@ cp "$TMP" "$MANIFEST"
 echo "updated iota-rust-sdk rev -> $WANT"
 
 if [ "$WITH_MONOREPO" -eq 1 ]; then
-  MONO_SHA="$(git ls-remote https://github.com/iotaledger/iota "refs/heads/${MONO_REF}" | awk '{print $1}')"
-  if [ -z "$MONO_SHA" ]; then
-    MONO_SHA="$(git ls-remote https://github.com/iotaledger/iota "refs/tags/${MONO_REF}" | awk '{print $1}')"
+  if printf '%s' "$MONO_REF" | grep -qE '^[0-9a-f]{40}$'; then
+    MONO_SHA="$MONO_REF"
+  else
+    MONO_SHA="$(git ls-remote https://github.com/iotaledger/iota "refs/heads/${MONO_REF}" | awk '{print $1}')"
+    if [ -z "$MONO_SHA" ]; then
+      MONO_SHA="$(git ls-remote https://github.com/iotaledger/iota "refs/tags/${MONO_REF}" | awk '{print $1}')"
+    fi
+    [ -n "$MONO_SHA" ] || die "cannot resolve iotaledger/iota ref '${MONO_REF}'"
   fi
-  [ -n "$MONO_SHA" ] || die "cannot resolve iotaledger/iota ref '${MONO_REF}'"
 
   if grep -E 'iotaledger/iota(\.git)?"' "$MANIFEST" | grep -q 'tag *= *"'; then
     die "monorepo deps use tag = \"...\"; convert them to rev = \"...\" by hand first"

--- a/src/access_controller/mod.rs
+++ b/src/access_controller/mod.rs
@@ -8,6 +8,7 @@ pub mod decision;
 pub mod hook;
 pub mod policy;
 pub mod predicates;
+pub(crate) mod rego_input;
 pub mod reports;
 pub mod rule;
 pub mod utils;
@@ -17,7 +18,7 @@ use std::{collections::HashMap, fmt::Formatter, sync::Arc};
 use anyhow::{Context, Result};
 use decision::Decision;
 use hook::SkippableDecision;
-use iota_types::digests::TransactionDigest;
+use iota_sdk_types::TransactionDigest;
 use policy::AccessPolicy;
 use predicates::Action;
 use rule::{AccessRule, GasUsageConfirmationRequest, TransactionContext};
@@ -211,7 +212,7 @@ mod test {
     use std::collections::BTreeMap;
 
     use indoc::indoc;
-    use iota_types::base_types::IotaAddress;
+    use iota_sdk_types::Address;
     use url::Url;
 
     use crate::access_controller::{
@@ -229,8 +230,8 @@ mod test {
 
     #[tokio::test]
     async fn test_deny_policy_rules_should_allow() {
-        let sender_address = IotaAddress::from_bytes([1; 32]).unwrap();
-        let blocked_address = IotaAddress::from_bytes([2; 32]).unwrap();
+        let sender_address = Address::from_bytes([1; 32]).unwrap();
+        let blocked_address = Address::from_bytes([2; 32]).unwrap();
         let allow_rule = AccessRuleBuilder::new()
             .sender_address(sender_address)
             .allow()
@@ -269,8 +270,8 @@ mod test {
 
     #[tokio::test]
     async fn test_allow_policy_rules_should_block() {
-        let blocked_address = IotaAddress::from_bytes([1; 32]).unwrap();
-        let sender_address = IotaAddress::from_bytes([2; 32]).unwrap();
+        let blocked_address = Address::from_bytes([1; 32]).unwrap();
+        let sender_address = Address::from_bytes([2; 32]).unwrap();
 
         let deny_rule = AccessRuleBuilder::new()
             .sender_address(blocked_address)
@@ -310,7 +311,7 @@ mod test {
 
     #[tokio::test]
     async fn test_deny_policy_rules_gas_budget() {
-        let sender_address = IotaAddress::from_bytes([1; 32]).unwrap();
+        let sender_address = Address::from_bytes([1; 32]).unwrap();
         let gas_budget = 100;
         let allow_rule = AccessRuleBuilder::new()
             .sender_address(sender_address)
@@ -338,7 +339,7 @@ mod test {
 
     #[tokio::test]
     async fn test_allow_policy_rules_gas_budget() {
-        let sender_address = IotaAddress::from_bytes([1; 32]).unwrap();
+        let sender_address = Address::from_bytes([1; 32]).unwrap();
         let gas_budget = 100;
         let deny_rule = AccessRuleBuilder::new()
             .sender_address(sender_address)
@@ -365,8 +366,8 @@ mod test {
 
     #[tokio::test]
     async fn test_allow_policy_rules_move_call_package_address() {
-        let sender_address = IotaAddress::from_bytes([1; 32]).unwrap();
-        let package_address = IotaAddress::from_bytes([2; 32]).unwrap();
+        let sender_address = Address::from_bytes([1; 32]).unwrap();
+        let package_address = Address::from_bytes([2; 32]).unwrap();
         let deny_rule = AccessRuleBuilder::new()
             .sender_address(sender_address)
             .move_call_package_address(package_address)
@@ -377,7 +378,7 @@ mod test {
             .with_move_call_package_addresses(vec![package_address]);
         let allowed_tx = TransactionContext::default()
             .with_sender_address(sender_address)
-            .with_move_call_package_addresses(vec![IotaAddress::from_bytes([3; 32]).unwrap()]);
+            .with_move_call_package_addresses(vec![Address::from_bytes([3; 32]).unwrap()]);
 
         let ac = AccessController::new(AccessPolicy::AllowAll, [deny_rule]);
         assert!(matches!(
@@ -392,8 +393,8 @@ mod test {
 
     #[tokio::test]
     async fn test_deny_policy_rules_move_call_package_address() {
-        let sender_address = IotaAddress::from_bytes([1; 32]).unwrap();
-        let package_address = IotaAddress::from_bytes([2; 32]).unwrap();
+        let sender_address = Address::from_bytes([1; 32]).unwrap();
+        let package_address = Address::from_bytes([2; 32]).unwrap();
         let allow_rule = AccessRuleBuilder::new()
             .sender_address(sender_address)
             .move_call_package_address(package_address)
@@ -404,7 +405,7 @@ mod test {
             .with_move_call_package_addresses(vec![package_address]);
         let denied_tx = TransactionContext::default()
             .with_sender_address(sender_address)
-            .with_move_call_package_addresses(vec![IotaAddress::from_bytes([3; 32]).unwrap()]);
+            .with_move_call_package_addresses(vec![Address::from_bytes([3; 32]).unwrap()]);
 
         let ac = AccessController::new(AccessPolicy::DenyAll, [allow_rule]);
         assert!(matches!(
@@ -419,7 +420,7 @@ mod test {
 
     #[tokio::test]
     async fn test_allow_policy_rules_ptb_command_count() {
-        let sender_address = IotaAddress::from_bytes([1; 32]).unwrap();
+        let sender_address = Address::from_bytes([1; 32]).unwrap();
         let deny_rule = AccessRuleBuilder::new()
             .sender_address(sender_address)
             .ptb_command_count(ValueNumber::GreaterThan(1))
@@ -445,7 +446,7 @@ mod test {
 
     #[tokio::test]
     async fn test_deny_policy_rules_ptb_command_count() {
-        let sender_address = IotaAddress::from_bytes([1; 32]).unwrap();
+        let sender_address = Address::from_bytes([1; 32]).unwrap();
         let allow_rule = AccessRuleBuilder::new()
             .sender_address(sender_address)
             .ptb_command_count(ValueNumber::LessThanOrEqual(1))
@@ -484,7 +485,7 @@ mod test {
         assert_eq!(ac.rules.len(), 1);
         assert_eq!(
             ac.rules[0].sender_address,
-            ValueIotaAddress::List(vec![IotaAddress::from_bytes([1; 32]).unwrap()])
+            ValueIotaAddress::List(vec![Address::from_bytes([1; 32]).unwrap()])
         );
         assert_eq!(
             ac.rules[0].transaction_gas_budget,
@@ -502,7 +503,7 @@ mod test {
         let ac = AccessController::new(
             AccessPolicy::DenyAll,
             [AccessRuleBuilder::new()
-                .sender_address(IotaAddress::from_bytes([1; 32]).unwrap())
+                .sender_address(Address::from_bytes([1; 32]).unwrap())
                 .gas_budget(ValueNumber::LessThanOrEqual(10000))
                 .ptb_command_count(ValueNumber::LessThanOrEqual(5))
                 .allow()
@@ -530,8 +531,8 @@ mod test {
         let ac = AccessController::new(
             AccessPolicy::DenyAll,
             [AccessRuleBuilder::new()
-                .sender_address(IotaAddress::from_bytes([1; 32]).unwrap())
-                .move_call_package_address(IotaAddress::from_bytes([2; 32]).unwrap())
+                .sender_address(Address::from_bytes([1; 32]).unwrap())
+                .move_call_package_address(Address::from_bytes([2; 32]).unwrap())
                 .allow()
                 .build()],
         );
@@ -565,11 +566,11 @@ mod test {
         assert_eq!(ac.rules.len(), 1);
         assert_eq!(
             ac.rules[0].sender_address,
-            ValueIotaAddress::List(vec![IotaAddress::from_bytes([1; 32]).unwrap()])
+            ValueIotaAddress::List(vec![Address::from_bytes([1; 32]).unwrap()])
         );
         assert_eq!(
             ac.rules[0].move_call_package_address,
-            Some(ValueIotaAddress::List(vec![IotaAddress::from_bytes(
+            Some(ValueIotaAddress::List(vec![Address::from_bytes(
                 [2; 32]
             )
             .unwrap()]))
@@ -645,7 +646,7 @@ mod test {
 
     #[tokio::test]
     async fn test_evaluation_order_multiple_rules_policy_deny() {
-        let sender_address = IotaAddress::from_bytes([1; 32]).unwrap();
+        let sender_address = Address::from_bytes([1; 32]).unwrap();
         let deny_rule = AccessRuleBuilder::new()
             .sender_address(sender_address)
             .deny()
@@ -666,7 +667,7 @@ mod test {
 
     #[tokio::test]
     async fn test_evaluation_order_multiple_rules_policy_allow() {
-        let sender_address = IotaAddress::from_bytes([1; 32]).unwrap();
+        let sender_address = Address::from_bytes([1; 32]).unwrap();
 
         let deny_rule = AccessRuleBuilder::new()
             .sender_address(sender_address)
@@ -686,9 +687,9 @@ mod test {
 
     #[tokio::test]
     async fn test_evaluation_logic_matching() {
-        let sender_1 = IotaAddress::from_bytes([1; 32]).unwrap();
-        let sender_2 = IotaAddress::from_bytes([2; 32]).unwrap();
-        let package_id = IotaAddress::from_bytes([10; 32]).unwrap();
+        let sender_1 = Address::from_bytes([1; 32]).unwrap();
+        let sender_2 = Address::from_bytes([2; 32]).unwrap();
+        let package_id = Address::from_bytes([10; 32]).unwrap();
 
         let allow_sender_1_and_package = AccessRuleBuilder::new()
             .sender_address(sender_1)
@@ -884,7 +885,7 @@ mod test {
         #[tokio::test]
         async fn test_hook_is_called_if_another_rule_term_applies() {
             let (mock_server, url, error) = get_mock_server_bad_request().await;
-            let sender_address = IotaAddress::from_bytes([1; 32]).unwrap();
+            let sender_address = Address::from_bytes([1; 32]).unwrap();
             let hook_rule = AccessRuleBuilder::new()
                 .sender_address(sender_address)
                 .hook(url, None)
@@ -907,8 +908,8 @@ mod test {
         #[tokio::test]
         async fn test_hook_is_not_called_if_another_rule_term_does_not_apply() {
             let (mock_server, url, _) = get_mock_server_bad_request().await;
-            let sender_address = IotaAddress::from_bytes([1; 32]).unwrap();
-            let blocked_address = IotaAddress::from_bytes([2; 32]).unwrap();
+            let sender_address = Address::from_bytes([1; 32]).unwrap();
+            let blocked_address = Address::from_bytes([2; 32]).unwrap();
             let hook_rule = AccessRuleBuilder::new()
                 .sender_address(sender_address)
                 .hook(url, None)

--- a/src/access_controller/predicates/iota_address.rs
+++ b/src/access_controller/predicates/iota_address.rs
@@ -2,16 +2,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::fmt;
+use std::str::FromStr;
 
-use fastcrypto::encoding::decode_bytes_hex;
-use iota_types::base_types::IotaAddress;
+use iota_sdk_types::Address;
 use serde::{
     de::{self, Visitor},
     Deserialize, Serialize,
 };
 
 impl ValueIotaAddress {
-    pub fn new(addresses: impl IntoIterator<Item = IotaAddress>) -> Self {
+    pub fn new(addresses: impl IntoIterator<Item = Address>) -> Self {
         let addresses: Vec<_> = addresses.into_iter().collect();
         if addresses.is_empty() {
             ValueIotaAddress::All
@@ -22,7 +22,7 @@ impl ValueIotaAddress {
         }
     }
 
-    pub fn includes(&self, address: &IotaAddress) -> bool {
+    pub fn includes(&self, address: &Address) -> bool {
         match self {
             ValueIotaAddress::All => true,
             ValueIotaAddress::Single(single) => single == address,
@@ -30,18 +30,18 @@ impl ValueIotaAddress {
         }
     }
 
-    pub fn includes_any<'a>(&self, addresses: impl IntoIterator<Item = &'a IotaAddress>) -> bool {
+    pub fn includes_any<'a>(&self, addresses: impl IntoIterator<Item = &'a Address>) -> bool {
         addresses.into_iter().any(|address| self.includes(&address))
     }
 }
 
-/// The ValueIotaAddress enum represents a single IotaAddress, a list of IotaAddress or all IotaAddresses.
+/// The ValueIotaAddress enum represents a single Address, a list of Address or all Addresses.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub enum ValueIotaAddress {
     #[default]
     All,
-    Single(IotaAddress),
-    List(Vec<IotaAddress>),
+    Single(Address),
+    List(Vec<Address>),
 }
 
 impl Serialize for ValueIotaAddress {
@@ -68,7 +68,7 @@ impl<'de> Deserialize<'de> for ValueIotaAddress {
             type Value = ValueIotaAddress;
 
             fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-                formatter.write_str("a string, a single IotaAddress, or a list of IotaAddresses")
+                formatter.write_str("a string, a single Address, or a list of Addresses")
             }
 
             fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
@@ -78,8 +78,8 @@ impl<'de> Deserialize<'de> for ValueIotaAddress {
                 if value == "*" {
                     Ok(ValueIotaAddress::All)
                 } else {
-                    let from_hex: IotaAddress = decode_bytes_hex(value).map_err(E::custom)?;
-                    Ok(ValueIotaAddress::Single(from_hex))
+                    let address = Address::from_str(value).map_err(E::custom)?;
+                    Ok(ValueIotaAddress::Single(address))
                 }
             }
 
@@ -98,7 +98,7 @@ impl<'de> Deserialize<'de> for ValueIotaAddress {
 
 impl<K> From<K> for ValueIotaAddress
 where
-    K: IntoIterator<Item = IotaAddress>,
+    K: IntoIterator<Item = Address>,
 {
     fn from(k: K) -> Self {
         ValueIotaAddress::new(k)
@@ -108,14 +108,14 @@ where
 #[cfg(test)]
 mod test {
     use indoc::indoc;
-    use iota_types::base_types::IotaAddress;
+    use iota_sdk_types::Address;
 
     use super::ValueIotaAddress;
 
     #[test]
     fn test_include_from_one() {
-        let iota_address = IotaAddress::from_bytes([1; 32]).unwrap();
-        let iota_address_not_included = IotaAddress::from_bytes([2; 32]).unwrap();
+        let iota_address = Address::from_bytes([1; 32]).unwrap();
+        let iota_address_not_included = Address::from_bytes([2; 32]).unwrap();
 
         let value_iota_address = ValueIotaAddress::from([iota_address]);
 
@@ -125,9 +125,9 @@ mod test {
 
     #[test]
     fn test_include_from_many() {
-        let iota_address1 = IotaAddress::from_bytes([1; 32]).unwrap();
-        let iota_address2 = IotaAddress::from_bytes([2; 32]).unwrap();
-        let iota_address_not_included = IotaAddress::from_bytes([3; 32]).unwrap();
+        let iota_address1 = Address::from_bytes([1; 32]).unwrap();
+        let iota_address2 = Address::from_bytes([2; 32]).unwrap();
+        let iota_address_not_included = Address::from_bytes([3; 32]).unwrap();
 
         let value_iota_address = ValueIotaAddress::from([iota_address1, iota_address2]);
 
@@ -138,7 +138,7 @@ mod test {
 
     #[test]
     fn test_serde_one_address() {
-        let iota_address = IotaAddress::from_bytes([1; 32]).unwrap();
+        let iota_address = Address::from_bytes([1; 32]).unwrap();
         let value_iota_address = ValueIotaAddress::Single(iota_address);
         let data = serde_yaml::to_string(&value_iota_address).unwrap();
 
@@ -157,7 +157,7 @@ mod test {
 
     #[test]
     fn test_serde_multiple_addresses() {
-        let iota_address = IotaAddress::from_bytes([1; 32]).unwrap();
+        let iota_address = Address::from_bytes([1; 32]).unwrap();
         let value_iota_address = ValueIotaAddress::List(vec![iota_address, iota_address]);
         let data = serde_yaml::to_string(&value_iota_address).unwrap();
         assert_eq!(

--- a/src/access_controller/predicates/rego_expression/bcs_decoder.rs
+++ b/src/access_controller/predicates/rego_expression/bcs_decoder.rs
@@ -4,7 +4,7 @@
 use std::fmt::Display;
 
 use anyhow::{bail, Context};
-use iota_sdk::json::{IotaJsonValue, MoveTypeLayout};
+use iota_sdk_types::Address;
 use regorus::Value;
 use serde::{Deserialize, Serialize};
 
@@ -121,31 +121,31 @@ fn bcs_decode_bytes(data_bytes: &[u8], data_type: BcsDataType) -> Result<Value, 
         }
 
         BcsDataType::Bool => {
-            let decoded =
-                IotaJsonValue::from_bcs_bytes(Some(&MoveTypeLayout::Bool.into()), data_bytes)?;
-            Ok(Value::from(decoded.to_json_value()))
+            let decoded: bool = bcs::from_bytes(data_bytes)
+                .map_err(|e| anyhow::anyhow!("Failed to decode bool: {}", e))?;
+            Ok(Value::Bool(decoded))
         }
         BcsDataType::Address => {
-            let decoded =
-                IotaJsonValue::from_bcs_bytes(Some(&MoveTypeLayout::Address.into()), data_bytes)?;
-            let address_str = decoded
-                .to_iota_address()
-                .map_err(|e| anyhow::anyhow!("Failed to convert to Iota address: {}", e))?;
-            Ok(Value::from(address_str.to_string()))
+            let decoded: Address = bcs::from_bytes(data_bytes)
+                .map_err(|e| anyhow::anyhow!("Failed to decode address: {}", e))?;
+            Ok(Value::from(decoded.to_string()))
         }
         BcsDataType::VectorAddress => {
-            let decoded = IotaJsonValue::from_bcs_bytes(
-                Some(&MoveTypeLayout::Vector(MoveTypeLayout::Address.into())),
-                data_bytes,
-            )?;
-            Ok(Value::from(decoded.to_json_value()))
+            let decoded: Vec<Address> = bcs::from_bytes(data_bytes)
+                .map_err(|e| anyhow::anyhow!("Failed to decode vector of addresses: {}", e))?;
+            Ok(Value::from(
+                decoded
+                    .into_iter()
+                    .map(|address| Value::from(address.to_string()))
+                    .collect::<Vec<_>>(),
+            ))
         }
         BcsDataType::VectorBool => {
-            let decoded = IotaJsonValue::from_bcs_bytes(
-                Some(&MoveTypeLayout::Vector(MoveTypeLayout::Bool.into())),
-                data_bytes,
-            )?;
-            Ok(Value::from(decoded.to_json_value()))
+            let decoded: Vec<bool> = bcs::from_bytes(data_bytes)
+                .map_err(|e| anyhow::anyhow!("Failed to decode vector of bools: {}", e))?;
+            Ok(Value::from(
+                decoded.into_iter().map(Value::Bool).collect::<Vec<_>>(),
+            ))
         }
         // We don't use the IotaJsonValue here, we use the BCS directly
         // It seems the SDK is inconsistent with nested MoveType declarations.
@@ -209,26 +209,34 @@ mod tests {
     // Its important to use original encoding to ensure that the BCS decoder works correctly.
     const TRANSACTION_KIND_JSON: &str = include_str!("./../test_files/transaction_kind.json");
 
-    use iota_types::transaction::{CallArg, TransactionKind};
-
     use super::*;
     use std::collections::HashMap;
-    fn get_test_data() -> HashMap<Vec<u8>, BcsDataType> {
-        let tx_kind = serde_json::from_str::<TransactionKind>(TRANSACTION_KIND_JSON)
-            .expect("Failed to parse transaction kind JSON");
 
-        let TransactionKind::ProgrammableTransaction(ptb) = tx_kind else {
-            panic!("Expected a ProgrammableTransaction kind");
-        };
-        let inputs_bytes: Vec<Vec<u8>> = ptb
-            .inputs
+    /// Parses the fixture's `Pure` inputs directly out of its raw JSON,
+    /// rather than deserializing into a full transaction-kind type: this
+    /// fixture is in the *pre-migration* `iota_types::transaction::TransactionKind`
+    /// JSON shape (see `access_controller/rego_input.rs`'s module docs for the
+    /// documented list of shape divergences from the new SDK type), and this
+    /// crate no longer depends on that old type at all. Mirrors the same
+    /// raw-JSON-parsing approach already used by `rego_input.rs`'s own test
+    /// against this identical fixture file.
+    fn get_test_data() -> HashMap<Vec<u8>, BcsDataType> {
+        let fixture: serde_json::Value = serde_json::from_str(TRANSACTION_KIND_JSON)
+            .expect("Failed to parse transaction kind JSON");
+        let pt_json = fixture
+            .get("ProgrammableTransaction")
+            .expect("fixture is a ProgrammableTransaction kind");
+        let inputs_bytes: Vec<Vec<u8>> = pt_json["inputs"]
+            .as_array()
+            .expect("fixture inputs is an array")
             .iter()
-            .filter_map(|input| {
-                if let CallArg::Pure(pure_input) = input {
-                    Some(pure_input.clone())
-                } else {
-                    None
-                }
+            .map(|input| {
+                input["Pure"]
+                    .as_array()
+                    .expect("fixture inputs are all Pure byte arrays")
+                    .iter()
+                    .map(|b| b.as_u64().unwrap() as u8)
+                    .collect()
             })
             .collect();
 

--- a/src/access_controller/rego_input.rs
+++ b/src/access_controller/rego_input.rs
@@ -1,0 +1,653 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! Compatibility shim reproducing the *pre-SDK-migration* JSON shape of
+//! `iota_types::transaction::TransactionData` for `input.transaction_data` in
+//! Rego policies (see `docs/access-controller.md`).
+//!
+//! Rego policies are configuration deployed by customers, not code reviewed
+//! in this repository, so the JSON shape of `input.transaction_data` is a
+//! wire contract this migration must not silently change. This module
+//! defines Serialize-only "shadow" types mirroring the old
+//! `#[derive(Serialize)]`-based `iota_types::transaction` JSON shape, and
+//! converts a `&iota_sdk_types::Transaction` into them, instead of directly
+//! serializing the new SDK type (whose native JSON shape has diverged from
+//! the old one in multiple ways -- see below).
+//!
+//! ## Known JSON-shape divergences bridged here
+//!
+//! Found by diffing `iota-sdk-types`' native serde output (see
+//! `crates/iota-sdk-types/src/transaction/{mod,serialization}.rs` in the
+//! pinned SDK checkout) against `docs/access-controller.md` and
+//! `predicates/test_files/transaction_kind.json`:
+//!
+//! 1. `Input::Pure` serializes as a base64 **string** (`{"Pure": "AQIDBA=="}`)
+//!    natively; old `CallArg::Pure` serialized as a **byte array**
+//!    (`{"Pure": [1,2,3,4]}`). `bcs_decoder.rs`'s `bcs.decode_typed` extension
+//!    calls `.as_array()` on this value, so this one is load-bearing, not
+//!    cosmetic.
+//! 2. `TransactionV1` has a `gas_payment: GasPayment` field; old
+//!    `TransactionDataV1` had `gas_data: GasData`. Field also renamed
+//!    (`objects` -> `payment` in the shadow, mirroring `GasPayment.objects`
+//!    vs `GasData.payment`).
+//! 3. `GasPayment.objects: Vec<ObjectReference>` serializes each entry as a
+//!    **struct** (`{"object_id":..,"version":"1","digest":..}`, `version` as
+//!    a **string** via `ReadableDisplay`); old `GasData.payment:
+//!    Vec<(ObjectID, SequenceNumber, ObjectDigest)>` serialized each entry as
+//!    a plain 3-element **array** with `version` as a JSON **number**.
+//! 4. `GasPayment.price`/`.budget` serialize as **strings** (`ReadableDisplay`);
+//!    old `GasData.price`/`.budget` were plain `u64` (JSON **numbers** --
+//!    confirmed against the literal numbers in the documented example
+//!    payload).
+//! 5. `TransactionExpiration::Epoch(EpochId)`'s inner value serializes as a
+//!    **string** (`ReadableDisplay`); old `TransactionExpiration::Epoch`'s
+//!    inner value was a plain `u64` (JSON **number**).
+//! 6. `TransactionKind::Programmable` is the new variant name; old was
+//!    `TransactionKind::ProgrammableTransaction`. Both `docs/access-controller.md`
+//!    and the fixture key on the old name.
+//! 7. `Input`'s object-carrying variants (`ImmutableOrOwned`, `Shared`,
+//!    `Receiving`) are top-level `Input` variants; old nested them one level
+//!    deeper under `CallArg::Object(ObjectArg::..)`, e.g.
+//!    `{"Object": {"ImmOrOwnedObject": [..]}}` rather than
+//!    `{"ImmutableOrOwned": {..}}`. `SharedObjectReference`'s object-id field
+//!    is also renamed: `object_id` (new) vs `id` (old
+//!    `ObjectArg::SharedObject`), and `initial_shared_version` is a
+//!    `Version` (`ReadableDisplay` string) vs old plain `u64`.
+//! 8. Every `Command` variant other than `MoveCall` changed from an
+//!    old-style multi-field **tuple** variant (serializing as a JSON array,
+//!    e.g. `{"TransferObjects": [[...objects...], address]}`) to a new-style
+//!    newtype-around-a-named-struct variant (serializing as a JSON object,
+//!    e.g. `{"TransferObjects": {"objects": [...], "address": ...}}`).
+//! 9. `Command::MakeMoveVec` (old name) is `Command::MakeMoveVector` (new
+//!    name).
+//! 10. `Argument::GasCoin` (old name) is `Argument::Gas` (new name).
+//! 11. `Publish`/`Upgrade`'s `modules: Vec<Vec<u8>>` serialize each module as
+//!     a base64 **string** natively; old serialized each module as a plain
+//!     byte **array**.
+//!
+//! ## Residual, deliberately-not-fully-bridged divergences
+//!
+//! - `MoveCall.type_arguments` (`Vec<TypeTag>`) and `MakeMoveVector.type_`
+//!   (`Option<TypeTag>`): the new `TypeTag` serializes as a `Display`-based
+//!   string (e.g. `"u64"`, `"0x2::coin::Coin<0x2::iota::IOTA>"`). The old
+//!   `type_arguments`/`type_` fields used `move_core_types::type_input::TypeInput`,
+//!   whose exact JSON shape wasn't verified here (that crate isn't one of
+//!   the ground-truth locations given for this migration, and every fixture
+//!   and documented policy example uses an empty `type_arguments` list, so
+//!   this is untested in practice). The shadow renders these as
+//!   `Display`-based strings too, which is a reasonable compatibility bet
+//!   but is *not* independently confirmed against the old shape. Flagged for
+//!   follow-up if a customer policy is found inspecting non-empty
+//!   `type_arguments`.
+//! - System-transaction `TransactionKind` variants (`Genesis`,
+//!   `ConsensusCommitPrologueV1`, `AuthenticatorStateUpdateV1(Deprecated)`,
+//!   `EndOfEpochTransaction`, `RandomnessStateUpdate`): these are never
+//!   submitted by a user through the gas station's public `/execute_tx`
+//!   endpoint (they are validator/consensus-internal transaction kinds), so
+//!   full old-shape fidelity for their *contents* was not pursued. The old
+//!   variant *names* (tags) are preserved so a policy branching only on
+//!   `kind`'s discriminant still behaves the same, but the nested payload is
+//!   serialized using the new SDK type's own (new-shape) `Serialize` impl.
+//!   `AuthenticatorStateUpdateV1` additionally lost its payload entirely
+//!   between SDK revisions (new variant is a unit variant, deprecated), so
+//!   the shadow can only emit an empty payload for it regardless.
+
+use iota_sdk_types::{
+    Address, Argument, Command, ConsensusCommitPrologueV1, GasPayment, GenesisTransaction, Input,
+    MakeMoveVector, MergeCoins, MoveCall, ObjectDigest, ObjectId, ObjectReference, Publish,
+    RandomnessStateUpdate, SplitCoins, Transaction, TransactionExpiration, TransactionKind,
+    TransactionV1, TransferObjects, TypeTag, Upgrade,
+};
+use serde::Serialize;
+use serde_json::Value;
+
+/// Converts `transaction` into the pre-migration
+/// `iota_types::transaction::TransactionData` JSON shape, for use as
+/// `input.transaction_data` in Rego policies.
+pub(crate) fn to_legacy_json(transaction: &Transaction) -> Value {
+    serde_json::to_value(ShadowTransactionData::from(transaction))
+        .expect("shadow transaction-data shapes are always representable as JSON")
+}
+
+/// Old-shape equivalent of `iota_types::transaction::TransactionDataAPI::move_calls`:
+/// `(package, module, function)` for every `Command::MoveCall` in a
+/// programmable transaction (empty for any other transaction kind). Ported
+/// from `ProgrammableTransaction::move_calls` /
+/// `TransactionKind::move_calls` at the `v1.20.1` tag.
+pub(crate) fn move_calls(transaction: &Transaction) -> Vec<(ObjectId, &str, &str)> {
+    let Transaction::V1(v1) = transaction else {
+        return vec![];
+    };
+    let TransactionKind::Programmable(pt) = &v1.kind else {
+        return vec![];
+    };
+    pt.commands
+        .iter()
+        .filter_map(|command| match command {
+            Command::MoveCall(mc) => Some((mc.package, mc.module.as_str(), mc.function.as_str())),
+            _ => None,
+        })
+        .collect()
+}
+
+/// Mirrors `iota_types::transaction::TransactionData`.
+#[derive(Serialize)]
+enum ShadowTransactionData {
+    V1(ShadowTransactionDataV1),
+    /// `Transaction` is `#[non_exhaustive]` in `iota_sdk_types`, but the
+    /// pinned rev this crate builds against (`b77fcd5`) defines only `V1`.
+    /// A successfully-deserialized `Transaction` value can therefore never
+    /// take this arm today -- it exists solely so this keeps compiling (and
+    /// degrades instead of panicking on attacker-controlled transaction
+    /// bytes) if a future SDK bump adds a real variant here before this
+    /// file is updated to handle it explicitly.
+    Unrecognized(String),
+}
+
+impl From<&Transaction> for ShadowTransactionData {
+    fn from(transaction: &Transaction) -> Self {
+        match transaction {
+            Transaction::V1(v1) => ShadowTransactionData::V1(v1.into()),
+            other => ShadowTransactionData::Unrecognized(format!("{other:?}")),
+        }
+    }
+}
+
+/// Mirrors `iota_types::transaction::TransactionDataV1`.
+#[derive(Serialize)]
+struct ShadowTransactionDataV1 {
+    kind: ShadowTransactionKind,
+    sender: Address,
+    gas_data: ShadowGasData,
+    expiration: ShadowTransactionExpiration,
+}
+
+impl From<&TransactionV1> for ShadowTransactionDataV1 {
+    fn from(v1: &TransactionV1) -> Self {
+        Self {
+            kind: (&v1.kind).into(),
+            sender: v1.sender,
+            gas_data: (&v1.gas_payment).into(),
+            expiration: (&v1.expiration).into(),
+        }
+    }
+}
+
+/// Mirrors `iota_types::transaction::TransactionKind`.
+#[derive(Serialize)]
+enum ShadowTransactionKind {
+    ProgrammableTransaction(ShadowProgrammableTransaction),
+    // System-transaction kinds: never submitted by a user through the gas
+    // station's public API. Tag preserved for old-name compatibility; nested
+    // payload uses the new SDK type's own `Serialize` impl (see module docs).
+    Genesis(GenesisTransaction),
+    ConsensusCommitPrologueV1(ConsensusCommitPrologueV1),
+    AuthenticatorStateUpdateV1(()),
+    EndOfEpochTransaction(Vec<iota_sdk_types::EndOfEpochTransactionKind>),
+    RandomnessStateUpdate(RandomnessStateUpdate),
+    /// See `ShadowTransactionData::Unrecognized`: unreachable with the
+    /// currently pinned SDK rev (all 6 variants above are matched
+    /// exhaustively), kept only for forward-compat with a future SDK bump.
+    Unrecognized(String),
+}
+
+impl From<&TransactionKind> for ShadowTransactionKind {
+    fn from(kind: &TransactionKind) -> Self {
+        match kind {
+            TransactionKind::Programmable(pt) => {
+                ShadowTransactionKind::ProgrammableTransaction(pt.into())
+            }
+            TransactionKind::Genesis(genesis) => ShadowTransactionKind::Genesis(genesis.clone()),
+            TransactionKind::ConsensusCommitPrologueV1(prologue) => {
+                ShadowTransactionKind::ConsensusCommitPrologueV1(prologue.clone())
+            }
+            TransactionKind::AuthenticatorStateUpdateV1Deprecated => {
+                ShadowTransactionKind::AuthenticatorStateUpdateV1(())
+            }
+            TransactionKind::EndOfEpoch(kinds) => {
+                ShadowTransactionKind::EndOfEpochTransaction(kinds.clone())
+            }
+            TransactionKind::RandomnessStateUpdate(update) => {
+                ShadowTransactionKind::RandomnessStateUpdate(update.clone())
+            }
+            other => ShadowTransactionKind::Unrecognized(format!("{other:?}")),
+        }
+    }
+}
+
+/// Mirrors `iota_types::transaction::ProgrammableTransaction`.
+#[derive(Serialize)]
+struct ShadowProgrammableTransaction {
+    inputs: Vec<ShadowCallArg>,
+    commands: Vec<ShadowCommand>,
+}
+
+impl From<&iota_sdk_types::ProgrammableTransaction> for ShadowProgrammableTransaction {
+    fn from(pt: &iota_sdk_types::ProgrammableTransaction) -> Self {
+        Self {
+            inputs: pt.inputs.iter().map(Into::into).collect(),
+            commands: pt.commands.iter().map(Into::into).collect(),
+        }
+    }
+}
+
+/// Mirrors `iota_types::transaction::CallArg`.
+#[derive(Serialize)]
+enum ShadowCallArg {
+    Pure(Vec<u8>),
+    Object(ShadowObjectArg),
+    /// See `ShadowTransactionData::Unrecognized`. `Input` is
+    /// `#[non_exhaustive]` but the pinned rev defines only the 4 variants
+    /// matched below, so this is unreachable today for the same reason.
+    Unrecognized(String),
+}
+
+impl From<&Input> for ShadowCallArg {
+    fn from(input: &Input) -> Self {
+        match input {
+            Input::Pure(bytes) => ShadowCallArg::Pure(bytes.clone()),
+            Input::ImmutableOrOwned(object_ref) => {
+                ShadowCallArg::Object(ShadowObjectArg::ImmOrOwnedObject(object_ref.into()))
+            }
+            Input::Shared(shared) => ShadowCallArg::Object(ShadowObjectArg::SharedObject {
+                id: shared.object_id,
+                initial_shared_version: shared.initial_shared_version.as_u64(),
+                mutable: shared.mutable,
+            }),
+            Input::Receiving(object_ref) => {
+                ShadowCallArg::Object(ShadowObjectArg::Receiving(object_ref.into()))
+            }
+            other => ShadowCallArg::Unrecognized(format!("{other:?}")),
+        }
+    }
+}
+
+/// Mirrors `iota_types::transaction::ObjectArg`.
+#[derive(Serialize)]
+enum ShadowObjectArg {
+    ImmOrOwnedObject(ShadowObjectRef),
+    SharedObject {
+        id: ObjectId,
+        initial_shared_version: u64,
+        mutable: bool,
+    },
+    Receiving(ShadowObjectRef),
+}
+
+/// Mirrors old `type ObjectRef = (ObjectID, SequenceNumber, ObjectDigest)`:
+/// a 3-element tuple (a 3-field tuple struct serializes identically to a
+/// plain 3-tuple), with the version as a plain number rather than the new
+/// SDK's `ReadableDisplay`-string `Version`.
+#[derive(Serialize)]
+struct ShadowObjectRef(ObjectId, u64, ObjectDigest);
+
+impl From<&ObjectReference> for ShadowObjectRef {
+    fn from(object_ref: &ObjectReference) -> Self {
+        Self(
+            object_ref.object_id,
+            object_ref.version.as_u64(),
+            object_ref.digest,
+        )
+    }
+}
+
+/// Mirrors `iota_types::transaction::Command`.
+#[derive(Serialize)]
+enum ShadowCommand {
+    MoveCall(ShadowMoveCall),
+    TransferObjects(Vec<ShadowArgument>, ShadowArgument),
+    SplitCoins(ShadowArgument, Vec<ShadowArgument>),
+    MergeCoins(ShadowArgument, Vec<ShadowArgument>),
+    Publish(Vec<Vec<u8>>, Vec<ObjectId>),
+    MakeMoveVec(Option<String>, Vec<ShadowArgument>),
+    Upgrade(Vec<Vec<u8>>, Vec<ObjectId>, ObjectId, ShadowArgument),
+    /// See `ShadowTransactionData::Unrecognized`. `Command` is
+    /// `#[non_exhaustive]` but the pinned rev defines only the 7 variants
+    /// matched below, so this is unreachable today for the same reason. Note
+    /// this arm is *not* used by [`super::move_calls`] (which only ever
+    /// looks for `Command::MoveCall` and otherwise ignores/skips a command,
+    /// exactly like this arm's semantics for that security-relevant path).
+    Unrecognized(String),
+}
+
+impl From<&Command> for ShadowCommand {
+    fn from(command: &Command) -> Self {
+        match command {
+            Command::MoveCall(move_call) => ShadowCommand::MoveCall(move_call.into()),
+            Command::TransferObjects(TransferObjects { objects, address }) => {
+                ShadowCommand::TransferObjects(
+                    objects.iter().map(Into::into).collect(),
+                    address.into(),
+                )
+            }
+            Command::SplitCoins(SplitCoins { coin, amounts }) => ShadowCommand::SplitCoins(
+                coin.into(),
+                amounts.iter().map(Into::into).collect(),
+            ),
+            Command::MergeCoins(MergeCoins {
+                coin,
+                coins_to_merge,
+            }) => ShadowCommand::MergeCoins(
+                coin.into(),
+                coins_to_merge.iter().map(Into::into).collect(),
+            ),
+            Command::Publish(Publish {
+                modules,
+                dependencies,
+            }) => ShadowCommand::Publish(modules.clone(), dependencies.clone()),
+            Command::MakeMoveVector(MakeMoveVector { type_, elements }) => {
+                ShadowCommand::MakeMoveVec(
+                    type_.as_ref().map(TypeTag::to_string),
+                    elements.iter().map(Into::into).collect(),
+                )
+            }
+            Command::Upgrade(Upgrade {
+                modules,
+                dependencies,
+                package,
+                ticket,
+            }) => ShadowCommand::Upgrade(
+                modules.clone(),
+                dependencies.clone(),
+                *package,
+                ticket.into(),
+            ),
+            other => ShadowCommand::Unrecognized(format!("{other:?}")),
+        }
+    }
+}
+
+/// Mirrors `iota_types::transaction::ProgrammableMoveCall`.
+#[derive(Serialize)]
+struct ShadowMoveCall {
+    package: ObjectId,
+    module: String,
+    function: String,
+    type_arguments: Vec<String>,
+    arguments: Vec<ShadowArgument>,
+}
+
+impl From<&MoveCall> for ShadowMoveCall {
+    fn from(move_call: &MoveCall) -> Self {
+        Self {
+            package: move_call.package,
+            module: move_call.module.as_str().to_string(),
+            function: move_call.function.as_str().to_string(),
+            type_arguments: move_call
+                .type_arguments
+                .iter()
+                .map(TypeTag::to_string)
+                .collect(),
+            arguments: move_call.arguments.iter().map(Into::into).collect(),
+        }
+    }
+}
+
+/// Mirrors `iota_types::transaction::Argument`.
+#[derive(Serialize)]
+enum ShadowArgument {
+    GasCoin,
+    Input(u16),
+    Result(u16),
+    NestedResult(u16, u16),
+    /// See `ShadowTransactionData::Unrecognized`. `Argument` is
+    /// `#[non_exhaustive]` but the pinned rev defines only the 4 variants
+    /// matched below, so this is unreachable today for the same reason.
+    Unrecognized(String),
+}
+
+impl From<&Argument> for ShadowArgument {
+    fn from(argument: &Argument) -> Self {
+        match argument {
+            Argument::Gas => ShadowArgument::GasCoin,
+            Argument::Input(i) => ShadowArgument::Input(*i),
+            Argument::Result(i) => ShadowArgument::Result(*i),
+            Argument::NestedResult(i, j) => ShadowArgument::NestedResult(*i, *j),
+            other => ShadowArgument::Unrecognized(format!("{other:?}")),
+        }
+    }
+}
+
+/// Mirrors `iota_types::transaction::GasData`.
+#[derive(Serialize)]
+struct ShadowGasData {
+    payment: Vec<ShadowObjectRef>,
+    owner: Address,
+    price: u64,
+    budget: u64,
+}
+
+impl From<&GasPayment> for ShadowGasData {
+    fn from(gas_payment: &GasPayment) -> Self {
+        Self {
+            payment: gas_payment.objects.iter().map(Into::into).collect(),
+            owner: gas_payment.owner,
+            price: gas_payment.price,
+            budget: gas_payment.budget,
+        }
+    }
+}
+
+/// Mirrors `iota_types::transaction::TransactionExpiration`.
+#[derive(Serialize)]
+enum ShadowTransactionExpiration {
+    None,
+    Epoch(u64),
+    /// See `ShadowTransactionData::Unrecognized`. `TransactionExpiration` is
+    /// `#[non_exhaustive]` but the pinned rev defines only the 2 variants
+    /// matched below, so this is unreachable today for the same reason.
+    Unrecognized(String),
+}
+
+impl From<&TransactionExpiration> for ShadowTransactionExpiration {
+    fn from(expiration: &TransactionExpiration) -> Self {
+        match expiration {
+            TransactionExpiration::None => ShadowTransactionExpiration::None,
+            TransactionExpiration::Epoch(epoch) => ShadowTransactionExpiration::Epoch(*epoch),
+            other => ShadowTransactionExpiration::Unrecognized(format!("{other:?}")),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use iota_sdk_types::{Identifier, ProgrammableTransaction, TransactionV1};
+    use std::str::FromStr;
+
+    const TRANSACTION_KIND_JSON: &str = include_str!("predicates/test_files/transaction_kind.json");
+
+    fn wrap_in_transaction(kind: TransactionKind) -> Transaction {
+        Transaction::V1(TransactionV1 {
+            kind,
+            sender: Address::ZERO,
+            gas_payment: GasPayment {
+                objects: vec![],
+                owner: Address::ZERO,
+                price: 0,
+                budget: 0,
+            },
+            expiration: TransactionExpiration::None,
+        })
+    }
+
+    /// Rebuilds the exact `ProgrammableTransaction` described by the
+    /// pre-migration fixture (14 `Pure` inputs, 1 `MoveCall` command
+    /// referencing all 14 as `Input(i)` arguments) straight from the
+    /// fixture's own JSON, then asserts the shadow serializer's output for
+    /// it is semantically identical to the fixture -- i.e. a genuine
+    /// round-trip check, not just a hand-copied expectation.
+    #[test]
+    fn matches_pre_migration_json_shape_for_fixture_transaction() {
+        let fixture: Value = serde_json::from_str(TRANSACTION_KIND_JSON).unwrap();
+        let pt_json = fixture
+            .get("ProgrammableTransaction")
+            .expect("fixture is a ProgrammableTransaction kind");
+
+        let inputs: Vec<Input> = pt_json["inputs"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|input| {
+                let bytes: Vec<u8> = input["Pure"]
+                    .as_array()
+                    .expect("fixture inputs are all Pure byte arrays")
+                    .iter()
+                    .map(|b| b.as_u64().unwrap() as u8)
+                    .collect();
+                Input::Pure(bytes)
+            })
+            .collect();
+
+        let move_call_json = &pt_json["commands"][0]["MoveCall"];
+        let package =
+            Address::from_str(move_call_json["package"].as_str().unwrap()).unwrap();
+        let arguments: Vec<Argument> = (0..move_call_json["arguments"].as_array().unwrap().len()
+            as u16)
+            .map(Argument::Input)
+            .collect();
+
+        let tx = wrap_in_transaction(TransactionKind::Programmable(ProgrammableTransaction {
+            inputs,
+            commands: vec![Command::MoveCall(MoveCall {
+                package: ObjectId::from(package),
+                module: Identifier::new_unchecked(move_call_json["module"].as_str().unwrap()),
+                function: Identifier::new_unchecked(
+                    move_call_json["function"].as_str().unwrap(),
+                ),
+                type_arguments: vec![],
+                arguments,
+            })],
+        }));
+
+        let actual = to_legacy_json(&tx);
+        let actual_kind = actual
+            .get("V1")
+            .and_then(|v1| v1.get("kind"))
+            .expect("shadow output always has a V1.kind");
+
+        assert_eq!(actual_kind, &fixture);
+    }
+
+    #[test]
+    fn pure_input_serializes_as_byte_array_not_base64_string() {
+        let tx = wrap_in_transaction(TransactionKind::Programmable(ProgrammableTransaction {
+            inputs: vec![Input::Pure(vec![5, 104, 101, 108, 108, 111])],
+            commands: vec![],
+        }));
+        let json = to_legacy_json(&tx);
+        assert_eq!(
+            json["V1"]["kind"]["ProgrammableTransaction"]["inputs"][0],
+            serde_json::json!({ "Pure": [5, 104, 101, 108, 108, 111] })
+        );
+    }
+
+    #[test]
+    fn gas_data_uses_old_field_name_and_plain_numbers() {
+        let tx = Transaction::V1(TransactionV1 {
+            kind: TransactionKind::Programmable(ProgrammableTransaction {
+                inputs: vec![],
+                commands: vec![],
+            }),
+            sender: Address::ZERO,
+            gas_payment: GasPayment {
+                objects: vec![ObjectReference::new(
+                    ObjectId::ZERO,
+                    iota_sdk_types::Version::from_u64(7),
+                    ObjectDigest::ZERO,
+                )],
+                owner: Address::ZERO,
+                price: 1000,
+                budget: 3_000_000,
+            },
+            expiration: TransactionExpiration::None,
+        });
+
+        let json = to_legacy_json(&tx);
+        let v1 = &json["V1"];
+        assert!(v1.get("gas_data").is_some(), "expected old `gas_data` key, got: {v1}");
+        assert!(v1.get("gas_payment").is_none());
+        assert_eq!(v1["gas_data"]["price"], serde_json::json!(1000));
+        assert_eq!(v1["gas_data"]["budget"], serde_json::json!(3_000_000));
+        // old shape: plain 3-element array, version as a number.
+        assert_eq!(
+            v1["gas_data"]["payment"][0][1],
+            serde_json::json!(7),
+            "expected numeric version in a 3-tuple, got: {}",
+            v1["gas_data"]["payment"][0]
+        );
+    }
+
+    #[test]
+    fn gas_argument_serializes_as_gas_coin() {
+        let tx = wrap_in_transaction(TransactionKind::Programmable(ProgrammableTransaction {
+            inputs: vec![],
+            commands: vec![Command::MergeCoins(MergeCoins {
+                coin: Argument::Gas,
+                coins_to_merge: vec![],
+            })],
+        }));
+        let json = to_legacy_json(&tx);
+        let commands = &json["V1"]["kind"]["ProgrammableTransaction"]["commands"];
+        // Old-shape `MergeCoins` is a 2-tuple `[coin, coins_to_merge]`.
+        assert_eq!(commands[0]["MergeCoins"][0], serde_json::json!("GasCoin"));
+    }
+
+    #[test]
+    fn non_move_call_commands_use_old_tuple_array_shape() {
+        let tx = wrap_in_transaction(TransactionKind::Programmable(ProgrammableTransaction {
+            inputs: vec![],
+            commands: vec![Command::TransferObjects(TransferObjects {
+                objects: vec![Argument::Input(0)],
+                address: Argument::Input(1),
+            })],
+        }));
+        let json = to_legacy_json(&tx);
+        let transfer = &json["V1"]["kind"]["ProgrammableTransaction"]["commands"][0]
+            ["TransferObjects"];
+        assert!(transfer.is_array(), "expected old-style array, got: {transfer}");
+        assert_eq!(transfer[0], serde_json::json!([{ "Input": 0 }]));
+        assert_eq!(transfer[1], serde_json::json!({ "Input": 1 }));
+    }
+
+    #[test]
+    fn move_calls_extracts_package_module_function_for_ptb_only() {
+        let package = Address::from_str(
+            "0xb674e2ed79db3c25fa4c00d5c7d62a9c18089e1fc4c2de5b5ee8b2836a85ae26",
+        )
+        .unwrap();
+        let tx = wrap_in_transaction(TransactionKind::Programmable(ProgrammableTransaction {
+            inputs: vec![],
+            commands: vec![
+                Command::MoveCall(MoveCall {
+                    package: ObjectId::from(package),
+                    module: Identifier::new_unchecked("allowed_module_name"),
+                    function: Identifier::new_unchecked("allowed_function_name"),
+                    type_arguments: vec![],
+                    arguments: vec![],
+                }),
+                Command::MergeCoins(MergeCoins {
+                    coin: Argument::Gas,
+                    coins_to_merge: vec![],
+                }),
+            ],
+        }));
+
+        let calls = move_calls(&tx);
+        assert_eq!(calls.len(), 1, "the MergeCoins command must not be counted");
+        assert_eq!(calls[0].0, ObjectId::from(package));
+        assert_eq!(calls[0].1, "allowed_module_name");
+        assert_eq!(calls[0].2, "allowed_function_name");
+
+        // Non-programmable transaction kinds have no move calls at all.
+        let system_tx = wrap_in_transaction(TransactionKind::RandomnessStateUpdate(
+            RandomnessStateUpdate {
+                epoch: 0,
+                randomness_round: iota_sdk_types::RandomnessRound::new(0),
+                random_bytes: vec![],
+                randomness_obj_initial_shared_version: iota_sdk_types::Version::from_u64(1),
+            },
+        ));
+        assert!(move_calls(&system_tx).is_empty());
+    }
+}

--- a/src/access_controller/rego_input.rs
+++ b/src/access_controller/rego_input.rs
@@ -232,10 +232,9 @@ impl From<&Command> for ShadowCommand {
                     address.into(),
                 )
             }
-            Command::SplitCoins(SplitCoins { coin, amounts }) => ShadowCommand::SplitCoins(
-                coin.into(),
-                amounts.iter().map(Into::into).collect(),
-            ),
+            Command::SplitCoins(SplitCoins { coin, amounts }) => {
+                ShadowCommand::SplitCoins(coin.into(), amounts.iter().map(Into::into).collect())
+            }
             Command::MergeCoins(MergeCoins {
                 coin,
                 coins_to_merge,
@@ -408,8 +407,7 @@ mod tests {
             .collect();
 
         let move_call_json = &pt_json["commands"][0]["MoveCall"];
-        let package =
-            Address::from_str(move_call_json["package"].as_str().unwrap()).unwrap();
+        let package = Address::from_str(move_call_json["package"].as_str().unwrap()).unwrap();
         let arguments: Vec<Argument> = (0..move_call_json["arguments"].as_array().unwrap().len()
             as u16)
             .map(Argument::Input)
@@ -420,9 +418,7 @@ mod tests {
             commands: vec![Command::MoveCall(MoveCall {
                 package: ObjectId::from(package),
                 module: Identifier::new_unchecked(move_call_json["module"].as_str().unwrap()),
-                function: Identifier::new_unchecked(
-                    move_call_json["function"].as_str().unwrap(),
-                ),
+                function: Identifier::new_unchecked(move_call_json["function"].as_str().unwrap()),
                 type_arguments: vec![],
                 arguments,
             })],
@@ -473,7 +469,10 @@ mod tests {
 
         let json = to_legacy_json(&tx);
         let v1 = &json["V1"];
-        assert!(v1.get("gas_data").is_some(), "expected old `gas_data` key, got: {v1}");
+        assert!(
+            v1.get("gas_data").is_some(),
+            "expected old `gas_data` key, got: {v1}"
+        );
         assert!(v1.get("gas_payment").is_none());
         assert_eq!(v1["gas_data"]["price"], serde_json::json!(1000));
         assert_eq!(v1["gas_data"]["budget"], serde_json::json!(3_000_000));
@@ -511,19 +510,21 @@ mod tests {
             })],
         }));
         let json = to_legacy_json(&tx);
-        let transfer = &json["V1"]["kind"]["ProgrammableTransaction"]["commands"][0]
-            ["TransferObjects"];
-        assert!(transfer.is_array(), "expected old-style array, got: {transfer}");
+        let transfer =
+            &json["V1"]["kind"]["ProgrammableTransaction"]["commands"][0]["TransferObjects"];
+        assert!(
+            transfer.is_array(),
+            "expected old-style array, got: {transfer}"
+        );
         assert_eq!(transfer[0], serde_json::json!([{ "Input": 0 }]));
         assert_eq!(transfer[1], serde_json::json!({ "Input": 1 }));
     }
 
     #[test]
     fn move_calls_extracts_package_module_function_for_ptb_only() {
-        let package = Address::from_str(
-            "0xb674e2ed79db3c25fa4c00d5c7d62a9c18089e1fc4c2de5b5ee8b2836a85ae26",
-        )
-        .unwrap();
+        let package =
+            Address::from_str("0xb674e2ed79db3c25fa4c00d5c7d62a9c18089e1fc4c2de5b5ee8b2836a85ae26")
+                .unwrap();
         let tx = wrap_in_transaction(TransactionKind::Programmable(ProgrammableTransaction {
             inputs: vec![],
             commands: vec![

--- a/src/access_controller/rego_input.rs
+++ b/src/access_controller/rego_input.rs
@@ -1,96 +1,25 @@
 // Copyright (c) 2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-//! Compatibility shim reproducing the *pre-SDK-migration* JSON shape of
+//! Compatibility shim reproducing the legacy JSON shape of
 //! `iota_types::transaction::TransactionData` for `input.transaction_data` in
 //! Rego policies (see `docs/access-controller.md`).
 //!
 //! Rego policies are configuration deployed by customers, not code reviewed
 //! in this repository, so the JSON shape of `input.transaction_data` is a
-//! wire contract this migration must not silently change. This module
-//! defines Serialize-only "shadow" types mirroring the old
-//! `#[derive(Serialize)]`-based `iota_types::transaction` JSON shape, and
-//! converts a `&iota_sdk_types::Transaction` into them, instead of directly
-//! serializing the new SDK type (whose native JSON shape has diverged from
-//! the old one in multiple ways -- see below).
+//! wire contract that must not silently change. This module defines
+//! Serialize-only "shadow" types mirroring the legacy JSON shape and converts
+//! a `&iota_sdk_types::Transaction` into them, instead of directly serializing
+//! the SDK type (whose native JSON shape diverges from the legacy one in
+//! several ways -- e.g. `Pure` inputs as base64 strings instead of byte
+//! arrays, renamed variants, and tuple-vs-struct command encodings; the
+//! golden tests below pin the required shape against
+//! `predicates/test_files/transaction_kind.json`).
 //!
-//! ## Known JSON-shape divergences bridged here
-//!
-//! Found by diffing `iota-sdk-types`' native serde output (see
-//! `crates/iota-sdk-types/src/transaction/{mod,serialization}.rs` in the
-//! pinned SDK checkout) against `docs/access-controller.md` and
-//! `predicates/test_files/transaction_kind.json`:
-//!
-//! 1. `Input::Pure` serializes as a base64 **string** (`{"Pure": "AQIDBA=="}`)
-//!    natively; old `CallArg::Pure` serialized as a **byte array**
-//!    (`{"Pure": [1,2,3,4]}`). `bcs_decoder.rs`'s `bcs.decode_typed` extension
-//!    calls `.as_array()` on this value, so this one is load-bearing, not
-//!    cosmetic.
-//! 2. `TransactionV1` has a `gas_payment: GasPayment` field; old
-//!    `TransactionDataV1` had `gas_data: GasData`. Field also renamed
-//!    (`objects` -> `payment` in the shadow, mirroring `GasPayment.objects`
-//!    vs `GasData.payment`).
-//! 3. `GasPayment.objects: Vec<ObjectReference>` serializes each entry as a
-//!    **struct** (`{"object_id":..,"version":"1","digest":..}`, `version` as
-//!    a **string** via `ReadableDisplay`); old `GasData.payment:
-//!    Vec<(ObjectID, SequenceNumber, ObjectDigest)>` serialized each entry as
-//!    a plain 3-element **array** with `version` as a JSON **number**.
-//! 4. `GasPayment.price`/`.budget` serialize as **strings** (`ReadableDisplay`);
-//!    old `GasData.price`/`.budget` were plain `u64` (JSON **numbers** --
-//!    confirmed against the literal numbers in the documented example
-//!    payload).
-//! 5. `TransactionExpiration::Epoch(EpochId)`'s inner value serializes as a
-//!    **string** (`ReadableDisplay`); old `TransactionExpiration::Epoch`'s
-//!    inner value was a plain `u64` (JSON **number**).
-//! 6. `TransactionKind::Programmable` is the new variant name; old was
-//!    `TransactionKind::ProgrammableTransaction`. Both `docs/access-controller.md`
-//!    and the fixture key on the old name.
-//! 7. `Input`'s object-carrying variants (`ImmutableOrOwned`, `Shared`,
-//!    `Receiving`) are top-level `Input` variants; old nested them one level
-//!    deeper under `CallArg::Object(ObjectArg::..)`, e.g.
-//!    `{"Object": {"ImmOrOwnedObject": [..]}}` rather than
-//!    `{"ImmutableOrOwned": {..}}`. `SharedObjectReference`'s object-id field
-//!    is also renamed: `object_id` (new) vs `id` (old
-//!    `ObjectArg::SharedObject`), and `initial_shared_version` is a
-//!    `Version` (`ReadableDisplay` string) vs old plain `u64`.
-//! 8. Every `Command` variant other than `MoveCall` changed from an
-//!    old-style multi-field **tuple** variant (serializing as a JSON array,
-//!    e.g. `{"TransferObjects": [[...objects...], address]}`) to a new-style
-//!    newtype-around-a-named-struct variant (serializing as a JSON object,
-//!    e.g. `{"TransferObjects": {"objects": [...], "address": ...}}`).
-//! 9. `Command::MakeMoveVec` (old name) is `Command::MakeMoveVector` (new
-//!    name).
-//! 10. `Argument::GasCoin` (old name) is `Argument::Gas` (new name).
-//! 11. `Publish`/`Upgrade`'s `modules: Vec<Vec<u8>>` serialize each module as
-//!     a base64 **string** natively; old serialized each module as a plain
-//!     byte **array**.
-//!
-//! ## Residual, deliberately-not-fully-bridged divergences
-//!
-//! - `MoveCall.type_arguments` (`Vec<TypeTag>`) and `MakeMoveVector.type_`
-//!   (`Option<TypeTag>`): the new `TypeTag` serializes as a `Display`-based
-//!   string (e.g. `"u64"`, `"0x2::coin::Coin<0x2::iota::IOTA>"`). The old
-//!   `type_arguments`/`type_` fields used `move_core_types::type_input::TypeInput`,
-//!   whose exact JSON shape wasn't verified here (that crate isn't one of
-//!   the ground-truth locations given for this migration, and every fixture
-//!   and documented policy example uses an empty `type_arguments` list, so
-//!   this is untested in practice). The shadow renders these as
-//!   `Display`-based strings too, which is a reasonable compatibility bet
-//!   but is *not* independently confirmed against the old shape. Flagged for
-//!   follow-up if a customer policy is found inspecting non-empty
-//!   `type_arguments`.
-//! - System-transaction `TransactionKind` variants (`Genesis`,
-//!   `ConsensusCommitPrologueV1`, `AuthenticatorStateUpdateV1(Deprecated)`,
-//!   `EndOfEpochTransaction`, `RandomnessStateUpdate`): these are never
-//!   submitted by a user through the gas station's public `/execute_tx`
-//!   endpoint (they are validator/consensus-internal transaction kinds), so
-//!   full old-shape fidelity for their *contents* was not pursued. The old
-//!   variant *names* (tags) are preserved so a policy branching only on
-//!   `kind`'s discriminant still behaves the same, but the nested payload is
-//!   serialized using the new SDK type's own (new-shape) `Serialize` impl.
-//!   `AuthenticatorStateUpdateV1` additionally lost its payload entirely
-//!   between SDK revisions (new variant is a unit variant, deprecated), so
-//!   the shadow can only emit an empty payload for it regardless.
+//! `TypeTag`s are rendered as `Display` strings, and system-transaction
+//! `TransactionKind` variants (which can't arrive through the public API)
+//! preserve only the legacy variant *name*, with their payload serialized in
+//! the SDK type's native shape.
 
 use iota_sdk_types::{
     Address, Argument, Command, ConsensusCommitPrologueV1, GasPayment, GenesisTransaction, Input,
@@ -101,7 +30,7 @@ use iota_sdk_types::{
 use serde::Serialize;
 use serde_json::Value;
 
-/// Converts `transaction` into the pre-migration
+/// Converts `transaction` into the legacy
 /// `iota_types::transaction::TransactionData` JSON shape, for use as
 /// `input.transaction_data` in Rego policies.
 pub(crate) fn to_legacy_json(transaction: &Transaction) -> Value {
@@ -109,11 +38,8 @@ pub(crate) fn to_legacy_json(transaction: &Transaction) -> Value {
         .expect("shadow transaction-data shapes are always representable as JSON")
 }
 
-/// Old-shape equivalent of `iota_types::transaction::TransactionDataAPI::move_calls`:
 /// `(package, module, function)` for every `Command::MoveCall` in a
-/// programmable transaction (empty for any other transaction kind). Ported
-/// from `ProgrammableTransaction::move_calls` /
-/// `TransactionKind::move_calls` at the `v1.20.1` tag.
+/// programmable transaction (empty for any other transaction kind).
 pub(crate) fn move_calls(transaction: &Transaction) -> Vec<(ObjectId, &str, &str)> {
     let Transaction::V1(v1) = transaction else {
         return vec![];
@@ -134,13 +60,10 @@ pub(crate) fn move_calls(transaction: &Transaction) -> Vec<(ObjectId, &str, &str
 #[derive(Serialize)]
 enum ShadowTransactionData {
     V1(ShadowTransactionDataV1),
-    /// `Transaction` is `#[non_exhaustive]` in `iota_sdk_types`, but the
-    /// pinned rev this crate builds against (`b77fcd5`) defines only `V1`.
-    /// A successfully-deserialized `Transaction` value can therefore never
-    /// take this arm today -- it exists solely so this keeps compiling (and
-    /// degrades instead of panicking on attacker-controlled transaction
-    /// bytes) if a future SDK bump adds a real variant here before this
-    /// file is updated to handle it explicitly.
+    /// `Transaction` is `#[non_exhaustive]` in `iota_sdk_types`; unreachable
+    /// at the pinned SDK rev (which defines only `V1`), this arm only ensures
+    /// a future SDK bump degrades instead of panicking on
+    /// attacker-controlled transaction bytes.
     Unrecognized(String),
 }
 
@@ -178,16 +101,14 @@ impl From<&TransactionV1> for ShadowTransactionDataV1 {
 enum ShadowTransactionKind {
     ProgrammableTransaction(ShadowProgrammableTransaction),
     // System-transaction kinds: never submitted by a user through the gas
-    // station's public API. Tag preserved for old-name compatibility; nested
-    // payload uses the new SDK type's own `Serialize` impl (see module docs).
+    // station's public API. Tag preserved for legacy-name compatibility;
+    // nested payload uses the SDK type's own `Serialize` impl (see module docs).
     Genesis(GenesisTransaction),
     ConsensusCommitPrologueV1(ConsensusCommitPrologueV1),
     AuthenticatorStateUpdateV1(()),
     EndOfEpochTransaction(Vec<iota_sdk_types::EndOfEpochTransactionKind>),
     RandomnessStateUpdate(RandomnessStateUpdate),
-    /// See `ShadowTransactionData::Unrecognized`: unreachable with the
-    /// currently pinned SDK rev (all 6 variants above are matched
-    /// exhaustively), kept only for forward-compat with a future SDK bump.
+    /// See `ShadowTransactionData::Unrecognized`.
     Unrecognized(String),
 }
 
@@ -236,9 +157,7 @@ impl From<&iota_sdk_types::ProgrammableTransaction> for ShadowProgrammableTransa
 enum ShadowCallArg {
     Pure(Vec<u8>),
     Object(ShadowObjectArg),
-    /// See `ShadowTransactionData::Unrecognized`. `Input` is
-    /// `#[non_exhaustive]` but the pinned rev defines only the 4 variants
-    /// matched below, so this is unreachable today for the same reason.
+    /// See `ShadowTransactionData::Unrecognized`.
     Unrecognized(String),
 }
 
@@ -274,10 +193,8 @@ enum ShadowObjectArg {
     Receiving(ShadowObjectRef),
 }
 
-/// Mirrors old `type ObjectRef = (ObjectID, SequenceNumber, ObjectDigest)`:
-/// a 3-element tuple (a 3-field tuple struct serializes identically to a
-/// plain 3-tuple), with the version as a plain number rather than the new
-/// SDK's `ReadableDisplay`-string `Version`.
+/// Mirrors legacy `type ObjectRef = (ObjectID, SequenceNumber, ObjectDigest)`:
+/// a 3-element tuple with the version as a plain JSON number.
 #[derive(Serialize)]
 struct ShadowObjectRef(ObjectId, u64, ObjectDigest);
 
@@ -301,12 +218,7 @@ enum ShadowCommand {
     Publish(Vec<Vec<u8>>, Vec<ObjectId>),
     MakeMoveVec(Option<String>, Vec<ShadowArgument>),
     Upgrade(Vec<Vec<u8>>, Vec<ObjectId>, ObjectId, ShadowArgument),
-    /// See `ShadowTransactionData::Unrecognized`. `Command` is
-    /// `#[non_exhaustive]` but the pinned rev defines only the 7 variants
-    /// matched below, so this is unreachable today for the same reason. Note
-    /// this arm is *not* used by [`super::move_calls`] (which only ever
-    /// looks for `Command::MoveCall` and otherwise ignores/skips a command,
-    /// exactly like this arm's semantics for that security-relevant path).
+    /// See `ShadowTransactionData::Unrecognized`.
     Unrecognized(String),
 }
 
@@ -390,9 +302,7 @@ enum ShadowArgument {
     Input(u16),
     Result(u16),
     NestedResult(u16, u16),
-    /// See `ShadowTransactionData::Unrecognized`. `Argument` is
-    /// `#[non_exhaustive]` but the pinned rev defines only the 4 variants
-    /// matched below, so this is unreachable today for the same reason.
+    /// See `ShadowTransactionData::Unrecognized`.
     Unrecognized(String),
 }
 
@@ -433,9 +343,7 @@ impl From<&GasPayment> for ShadowGasData {
 enum ShadowTransactionExpiration {
     None,
     Epoch(u64),
-    /// See `ShadowTransactionData::Unrecognized`. `TransactionExpiration` is
-    /// `#[non_exhaustive]` but the pinned rev defines only the 2 variants
-    /// matched below, so this is unreachable today for the same reason.
+    /// See `ShadowTransactionData::Unrecognized`.
     Unrecognized(String),
 }
 

--- a/src/access_controller/rule.rs
+++ b/src/access_controller/rule.rs
@@ -515,22 +515,8 @@ impl TransactionContext {
         headers: HeaderMap,
     ) -> Self {
         let Transaction::V1(v1) = transaction else {
-            // `Transaction` is `#[non_exhaustive]`, so this arm is required
-            // to compile as a downstream crate, but the pinned iota-sdk-types
-            // rev (b77fcd5) defines exactly one variant, `V1` -- even the
-            // SDK's own internal code (e.g. `SignedTransaction::sender_move_
-            // authenticator`) treats it as the only case. Unlike the
-            // non-exhaustive matches in `rego_input.rs` (which only affect
-            // the *cosmetic* Rego JSON payload and so degrade gracefully),
-            // `sender`/`gas_payment.budget` extracted below feed directly
-            // into the `sender-address`/`transaction-gas-budget` access
-            // control predicates -- security-relevant, not cosmetic. There is
-            // no safe non-panicking fallback here that wouldn't risk
-            // mis-attributing those fields (e.g. defaulting to a zero
-            // address could accidentally satisfy an allow-list rule). If a
-            // future SDK bump ever adds a second `Transaction` variant, this
-            // needs a real design decision (most likely: make this fallible
-            // and have the caller deny the request), not a silent default.
+            // The fields extracted below feed access-control predicates, so
+            // there is no safe fallback for an unknown future variant.
             unreachable!("no non-`V1` `Transaction` variant exists in the pinned SDK rev");
         };
         let ptb_command_count = match &v1.kind {

--- a/src/access_controller/rule.rs
+++ b/src/access_controller/rule.rs
@@ -5,13 +5,7 @@ use std::collections::BTreeMap;
 
 use anyhow::Context;
 use axum::http::HeaderMap;
-use fastcrypto::encoding::Base64;
-use iota_types::{
-    base_types::IotaAddress,
-    digests::TransactionDigest,
-    signature::GenericSignature,
-    transaction::{TransactionData, TransactionDataAPI, TransactionDataV1, TransactionKind},
-};
+use iota_sdk_types::{Address, Transaction, TransactionDigest, UserSignature};
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
@@ -25,9 +19,11 @@ use crate::{
         predicates::{
             Action, CountBy, RegoExpression, ValueAggregate, ValueIotaAddress, ValueNumber,
         },
+        rego_input,
         reports::{PredicateReport, RuleReport},
         utils::header_map_to_btree_map,
     },
+    base64::Base64,
     rpc::rpc_types::ExecuteTransactionRequestType,
     tracker::{
         stats_tracker_storage::{Aggregate, AggregateType},
@@ -60,7 +56,7 @@ impl AccessRuleBuilder {
         self.rule
     }
 
-    pub fn sender_address(mut self, sender_address: impl Into<IotaAddress>) -> Self {
+    pub fn sender_address(mut self, sender_address: impl Into<Address>) -> Self {
         let iota_address = sender_address.into();
         match &mut self.rule.sender_address {
             ValueIotaAddress::All => {
@@ -109,7 +105,7 @@ impl AccessRuleBuilder {
         self
     }
 
-    pub fn move_call_package_address(mut self, address: impl Into<IotaAddress>) -> Self {
+    pub fn move_call_package_address(mut self, address: impl Into<Address>) -> Self {
         let iota_address = address.into();
         if let Some(address) = &mut self.rule.move_call_package_address {
             match address {
@@ -471,9 +467,9 @@ impl RegoInputPayload {
 #[derive(Clone)]
 pub struct TransactionContext {
     pub transaction_digest: TransactionDigest,
-    pub sender_address: IotaAddress,
+    pub sender_address: Address,
     pub transaction_budget: u64,
-    pub move_call_package_addresses: Vec<IotaAddress>,
+    pub move_call_package_addresses: Vec<Address>,
     pub ptb_command_count: Option<usize>,
     pub transaction_data: Value,
 
@@ -489,7 +485,7 @@ pub struct TransactionContext {
 impl Default for TransactionContext {
     fn default() -> Self {
         Self {
-            sender_address: IotaAddress::default(),
+            sender_address: Address::ZERO,
             transaction_budget: 0,
             move_call_package_addresses: vec![],
             ptb_command_count: None,
@@ -509,8 +505,8 @@ impl Default for TransactionContext {
 
 impl TransactionContext {
     pub fn new(
-        _signature: &GenericSignature,
-        transaction_data: &TransactionData,
+        _signature: &UserSignature,
+        transaction: &Transaction,
         stats_tracker: StatsTracker,
         reservation_id: u64,
         tx_bytes: Base64,
@@ -518,21 +514,35 @@ impl TransactionContext {
         request_type: Option<ExecuteTransactionRequestType>,
         headers: HeaderMap,
     ) -> Self {
-        let ptb_command_count = match transaction_data {
-            TransactionData::V1(TransactionDataV1 {
-                kind: TransactionKind::ProgrammableTransaction(pt),
-                ..
-            }) => Some(pt.commands.len()),
-            TransactionData::V1(TransactionDataV1 { kind: _, .. }) => None,
+        let Transaction::V1(v1) = transaction else {
+            // `Transaction` is `#[non_exhaustive]`, so this arm is required
+            // to compile as a downstream crate, but the pinned iota-sdk-types
+            // rev (b77fcd5) defines exactly one variant, `V1` -- even the
+            // SDK's own internal code (e.g. `SignedTransaction::sender_move_
+            // authenticator`) treats it as the only case. Unlike the
+            // non-exhaustive matches in `rego_input.rs` (which only affect
+            // the *cosmetic* Rego JSON payload and so degrade gracefully),
+            // `sender`/`gas_payment.budget` extracted below feed directly
+            // into the `sender-address`/`transaction-gas-budget` access
+            // control predicates -- security-relevant, not cosmetic. There is
+            // no safe non-panicking fallback here that wouldn't risk
+            // mis-attributing those fields (e.g. defaulting to a zero
+            // address could accidentally satisfy an allow-list rule). If a
+            // future SDK bump ever adds a second `Transaction` variant, this
+            // needs a real design decision (most likely: make this fallible
+            // and have the caller deny the request), not a silent default.
+            unreachable!("no non-`V1` `Transaction` variant exists in the pinned SDK rev");
         };
-        // TODO handle the error properly
-        let transaction_value = serde_json::to_value(&transaction_data)
-            .expect("Failed to convert transaction data to JSON value");
+        let ptb_command_count = match &v1.kind {
+            iota_sdk_types::TransactionKind::Programmable(pt) => Some(pt.commands.len()),
+            _ => None,
+        };
+        let transaction_value = rego_input::to_legacy_json(transaction);
         Self {
-            transaction_digest: transaction_data.digest(),
-            sender_address: transaction_data.sender().clone(),
-            transaction_budget: transaction_data.gas_budget(),
-            move_call_package_addresses: get_move_call_package_addresses(transaction_data),
+            transaction_digest: transaction.digest(),
+            sender_address: v1.sender,
+            transaction_budget: v1.gas_payment.budget,
+            move_call_package_addresses: get_move_call_package_addresses(transaction),
             ptb_command_count,
             stats_tracker,
             transaction_data: transaction_value,
@@ -544,7 +554,7 @@ impl TransactionContext {
         }
     }
 
-    pub fn with_sender_address(mut self, sender_address: IotaAddress) -> Self {
+    pub fn with_sender_address(mut self, sender_address: Address) -> Self {
         self.sender_address = sender_address;
         self
     }
@@ -556,7 +566,7 @@ impl TransactionContext {
 
     pub fn with_move_call_package_addresses(
         mut self,
-        move_call_package_addresses: Vec<IotaAddress>,
+        move_call_package_addresses: Vec<Address>,
     ) -> Self {
         self.move_call_package_addresses = move_call_package_addresses;
         self
@@ -603,12 +613,14 @@ impl TransactionContext {
     }
 }
 
-fn get_move_call_package_addresses(transaction_data: &TransactionData) -> Vec<IotaAddress> {
-    let TransactionData::V1(data_v1) = transaction_data;
-    data_v1
-        .move_calls()
-        .iter()
-        .map(|call| call.0.clone().into())
+/// Old-shape equivalent of `TransactionDataAPI::move_calls`'s package list.
+/// See `rego_input::move_calls` for the port itself; this just adapts its
+/// return type (`iota_sdk_types::ObjectId`) into the `Address` type
+/// `ValueIotaAddress`/`move-call-package-address` expect.
+fn get_move_call_package_addresses(transaction: &Transaction) -> Vec<Address> {
+    rego_input::move_calls(transaction)
+        .into_iter()
+        .map(|(package, _module, _function)| Address::from(package))
         .collect()
 }
 
@@ -618,12 +630,10 @@ mod test {
     use std::{str::FromStr, vec};
 
     use axum::http::{HeaderMap, HeaderName, HeaderValue};
-    use iota_types::{
-        base_types::IotaAddress,
-        transaction::{
-            GasData, ProgrammableTransaction, TransactionData, TransactionDataAPI,
-            TransactionDataV1, TransactionExpiration, TransactionKind,
-        },
+    use iota_sdk_types::{
+        Address, Argument, Command, GasPayment, Identifier, MoveCall, ObjectId,
+        ProgrammableTransaction, Transaction, TransactionExpiration, TransactionKind,
+        TransactionV1,
     };
 
     use crate::{
@@ -632,15 +642,51 @@ mod test {
                 Action, CountBy, Location, RegoExpression, SourceWithData, ValueAggregate,
                 ValueIotaAddress, ValueNumber,
             },
+            rego_input,
             rule::{AccessRule, AccessRuleBuilder, TransactionContext},
         },
         test_env::{new_stats_tracker_for_testing, random_address},
     };
 
+    /// Builds a minimal single-`MoveCall` programmable transaction, useful
+    /// for exercising the Rego-input compat layer end-to-end.
+    fn move_call_transaction(
+        sender: Address,
+        package: Address,
+        module: &str,
+        function: &str,
+        pure_inputs: Vec<Vec<u8>>,
+    ) -> Transaction {
+        let arguments = (0..pure_inputs.len() as u16).map(Argument::Input).collect();
+        Transaction::V1(TransactionV1 {
+            kind: TransactionKind::Programmable(ProgrammableTransaction {
+                inputs: pure_inputs
+                    .into_iter()
+                    .map(iota_sdk_types::Input::Pure)
+                    .collect(),
+                commands: vec![Command::MoveCall(MoveCall {
+                    package: ObjectId::from(package),
+                    module: Identifier::new_unchecked(module),
+                    function: Identifier::new_unchecked(function),
+                    type_arguments: vec![],
+                    arguments,
+                })],
+            }),
+            sender,
+            gas_payment: GasPayment {
+                objects: vec![],
+                owner: sender,
+                price: 0,
+                budget: 0,
+            },
+            expiration: TransactionExpiration::None,
+        })
+    }
+
     #[tokio::test]
     async fn test_constraint_sender_address() {
-        let matched_sender = IotaAddress::from_bytes([0; 32]).unwrap();
-        let unmatched_sender = IotaAddress::from_bytes([1; 32]).unwrap();
+        let matched_sender = Address::from_bytes([0; 32]).unwrap();
+        let unmatched_sender = Address::from_bytes([1; 32]).unwrap();
 
         let matched_data = TransactionContext::default().with_sender_address(matched_sender);
         let unmatched_data = TransactionContext::default().with_sender_address(unmatched_sender);
@@ -670,8 +716,8 @@ mod test {
 
     #[tokio::test]
     async fn test_constraint_move_call_package_addr() {
-        let matched_package_id = IotaAddress::from_bytes([1; 32]).unwrap();
-        let unmatch_package_id = IotaAddress::from_bytes([2; 32]).unwrap();
+        let matched_package_id = Address::from_bytes([1; 32]).unwrap();
+        let unmatch_package_id = Address::from_bytes([2; 32]).unwrap();
 
         let rule = AccessRuleBuilder::new()
             .move_call_package_address(matched_package_id)
@@ -688,8 +734,8 @@ mod test {
 
     #[tokio::test]
     async fn test_constraint_mix_ups_sender_budget_package_address() {
-        let sender_address = IotaAddress::from_bytes([1; 32]).unwrap();
-        let move_call_package_address = IotaAddress::from_bytes([2; 32]).unwrap();
+        let sender_address = Address::from_bytes([1; 32]).unwrap();
+        let move_call_package_address = Address::from_bytes([2; 32]).unwrap();
         let gas_limit = 100;
 
         let rule = AccessRuleBuilder::new()
@@ -709,7 +755,7 @@ mod test {
         let unmatched_data_package_address = TransactionContext::default()
             .with_sender_address(sender_address)
             .with_gas_budget(gas_limit)
-            .with_move_call_package_addresses(vec![IotaAddress::from_bytes([3; 32]).unwrap()]);
+            .with_move_call_package_addresses(vec![Address::from_bytes([3; 32]).unwrap()]);
 
         assert!(
             !rule
@@ -762,8 +808,8 @@ mod test {
 
     #[tokio::test]
     async fn test_constraint_mix_ups_sender_package_address() {
-        let sender_address = IotaAddress::from_bytes([1; 32]).unwrap();
-        let move_call_package_address = IotaAddress::from_bytes([2; 32]).unwrap();
+        let sender_address = Address::from_bytes([1; 32]).unwrap();
+        let move_call_package_address = Address::from_bytes([2; 32]).unwrap();
 
         let rule = AccessRuleBuilder::new()
             .sender_address(sender_address)
@@ -779,7 +825,7 @@ mod test {
 
         let unmatched_data = TransactionContext::default()
             .with_sender_address(sender_address)
-            .with_move_call_package_addresses(vec![IotaAddress::from_bytes([3; 32]).unwrap()]);
+            .with_move_call_package_addresses(vec![Address::from_bytes([3; 32]).unwrap()]);
 
         assert!(!rule.matches(&unmatched_data).await.unwrap().is_matched);
     }
@@ -851,20 +897,22 @@ mod test {
                 input.transaction_data.V1.sender == "0x1212121212121212121212121212121212121212121212121212121212121212"
             }
         "#;
-        let mut transaction_data = TransactionData::V1(TransactionDataV1 {
-            kind: TransactionKind::ProgrammableTransaction(ProgrammableTransaction {
-                commands: vec![],
-                inputs: vec![],
-            }),
-            expiration: TransactionExpiration::None,
-            gas_data: GasData {
-                payment: vec![],
-                owner: IotaAddress::default(),
-                budget: 0,
-                price: 0,
-            },
-            sender: IotaAddress::from_bytes([0x12; 32]).unwrap(),
-        });
+        let build_transaction = |sender_byte: u8| {
+            Transaction::V1(TransactionV1 {
+                kind: TransactionKind::Programmable(ProgrammableTransaction {
+                    commands: vec![],
+                    inputs: vec![],
+                }),
+                expiration: TransactionExpiration::None,
+                gas_payment: GasPayment {
+                    objects: vec![],
+                    owner: Address::ZERO,
+                    budget: 0,
+                    price: 0,
+                },
+                sender: Address::from_bytes([sender_byte; 32]).unwrap(),
+            })
+        };
         let location = Location::new_memory(rego_content, "data.test.allow_sender");
         let mut source = SourceWithData::new(location.clone());
         source.fetch().await.unwrap();
@@ -876,16 +924,108 @@ mod test {
             .allow()
             .build();
         let matched_data = TransactionContext::default()
-            .with_transaction_data(serde_json::to_value(&transaction_data).unwrap());
+            .with_transaction_data(rego_input::to_legacy_json(&build_transaction(0x12)));
         assert!(rule.matches(&matched_data).await.unwrap().is_matched);
 
         // Test with unmatched sender address
-        *transaction_data.sender_mut_for_testing() = IotaAddress::from_bytes([0x13; 32]).unwrap();
         let unmatched_data = TransactionContext::default()
-            .with_transaction_data(serde_json::to_value(&transaction_data).unwrap());
+            .with_transaction_data(rego_input::to_legacy_json(&build_transaction(0x13)));
         assert!(
             !rule
                 .match_rego_expression(&unmatched_data)
+                .unwrap()
+                .is_matched
+        );
+    }
+
+    /// End-to-end test running the "Rego Filtering Code Example" from
+    /// `docs/access-controller.md` **verbatim** against a transaction built
+    /// through the SDK-migration compat layer (`rego_input::to_legacy_json`),
+    /// asserting it evaluates the way the docs describe: matches only a
+    /// single move call to the documented package/module/function with a
+    /// first argument that BCS-decodes to the string `"hello"`.
+    #[tokio::test]
+    async fn test_documented_rego_move_call_matches_example() {
+        // Verbatim from docs/access-controller.md, "Rego Filtering Code Example".
+        let rego_content = r#"
+package matchers
+
+default move_call_matches = false
+
+move_call_matches if {
+    cmds := input.transaction_data.V1.kind.ProgrammableTransaction.commands
+    count(cmds) == 1
+
+
+    mc := cmds[0].MoveCall
+    mc["package"]  == "0xb674e2ed79db3c25fa4c00d5c7d62a9c18089e1fc4c2de5b5ee8b2836a85ae26"
+    mc.module   == "allowed_module_name"
+    mc.function == "allowed_function_name"
+
+    argv_1 := input.transaction_data.V1.kind.ProgrammableTransaction.inputs[0].Pure
+    bcs.decode_typed(argv_1, "string") == "hello"
+}
+"#;
+        let location = Location::new_memory(rego_content, "data.matchers.move_call_matches");
+        let mut source = SourceWithData::new(location);
+        source.fetch().await.unwrap();
+        let rego_expression =
+            RegoExpression::from_source(source).expect("valid, documented rego policy");
+        let rule = AccessRuleBuilder::new()
+            .rego_expression(rego_expression)
+            .allow()
+            .build();
+
+        let package = Address::from_str(
+            "0xb674e2ed79db3c25fa4c00d5c7d62a9c18089e1fc4c2de5b5ee8b2836a85ae26",
+        )
+        .unwrap();
+        let sender = Address::from_bytes([0xa2; 32]).unwrap();
+        let hello_bcs = bcs::to_bytes(&"hello".to_string()).unwrap();
+
+        // Matches: exactly the documented package/module/function, first
+        // argument BCS-decodes to "hello".
+        let matching = TransactionContext::default().with_transaction_data(
+            rego_input::to_legacy_json(&move_call_transaction(
+                sender,
+                package,
+                "allowed_module_name",
+                "allowed_function_name",
+                vec![hello_bcs.clone()],
+            )),
+        );
+        assert!(rule.matches(&matching).await.unwrap().is_matched);
+
+        // Doesn't match: right package/module, wrong function.
+        let wrong_function = TransactionContext::default().with_transaction_data(
+            rego_input::to_legacy_json(&move_call_transaction(
+                sender,
+                package,
+                "allowed_module_name",
+                "some_other_function",
+                vec![hello_bcs.clone()],
+            )),
+        );
+        assert!(
+            !rule
+                .match_rego_expression(&wrong_function)
+                .unwrap()
+                .is_matched
+        );
+
+        // Doesn't match: right call, but wrong decoded argument value.
+        let wrong_argument = TransactionContext::default().with_transaction_data(
+            rego_input::to_legacy_json(&move_call_transaction(
+                sender,
+                package,
+                "allowed_module_name",
+                "allowed_function_name",
+                vec![bcs::to_bytes(&"goodbye".to_string()).unwrap()],
+            )),
+        );
+        assert!(
+            !rule
+                .match_rego_expression(&wrong_argument)
                 .unwrap()
                 .is_matched
         );

--- a/src/base64.rs
+++ b/src/base64.rs
@@ -1,0 +1,103 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! A local Base64 newtype, replacing `fastcrypto::encoding::Base64`.
+//!
+//! - Serializes/deserializes as a plain base64 string, matching how this type is used
+//!   today in JSON DTOs (e.g. `tx_bytes` / `user_sig` fields).
+//! - Derives `schemars::JsonSchema`: since this is a newtype (single-field tuple struct),
+//!   schemars generates a schema transparently delegating to the inner `String` field, so
+//!   this type appears in the generated public API schema exactly as a `String` would.
+//! - Uses the standard, padded base64 alphabet via the `base64ct` crate, which is exactly
+//!   what `fastcrypto::encoding::Base64` used under the hood.
+
+use base64ct::Encoding as _;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+#[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq, JsonSchema)]
+#[serde(try_from = "String")]
+pub struct Base64(String);
+
+impl Base64 {
+    /// Encodes bytes into a base64 string (standard alphabet, padded).
+    pub fn encode<T: AsRef<[u8]>>(data: T) -> String {
+        base64ct::Base64::encode_string(data.as_ref())
+    }
+
+    /// Decodes a base64 string into bytes.
+    pub fn decode(s: &str) -> anyhow::Result<Vec<u8>> {
+        base64ct::Base64::decode_vec(s).map_err(|_| anyhow::anyhow!("Invalid base64 string"))
+    }
+
+    /// Wraps the base64 encoding of the given bytes.
+    pub fn from_bytes(bytes: &[u8]) -> Self {
+        Self(Self::encode(bytes))
+    }
+
+    /// Decodes this Base64 value into bytes.
+    pub fn to_vec(&self) -> anyhow::Result<Vec<u8>> {
+        Self::decode(&self.0)
+    }
+
+    /// Returns the underlying base64-encoded string representation.
+    pub fn encoded(&self) -> String {
+        self.0.clone()
+    }
+}
+
+impl TryFrom<String> for Base64 {
+    type Error = anyhow::Error;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        // Error on invalid encoding, matching the previous fastcrypto behavior.
+        Self::decode(&value)?;
+        Ok(Self(value))
+    }
+}
+
+impl fmt::Display for Base64 {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trips_known_base64_string() {
+        // "Hello world!" -> base64 standard, padded. This is the same example used in
+        // fastcrypto's own doctest for `Base64::encode`.
+        let input = b"Hello world!";
+        let expected_b64 = "SGVsbG8gd29ybGQh";
+
+        let encoded = Base64::from_bytes(input);
+        assert_eq!(encoded.encoded(), expected_b64);
+        assert_eq!(Base64::encode(input), expected_b64);
+
+        let decoded = encoded.to_vec().unwrap();
+        assert_eq!(decoded, input);
+
+        let via_try_from = Base64::try_from(expected_b64.to_string()).unwrap();
+        assert_eq!(via_try_from, encoded);
+        assert_eq!(via_try_from.to_vec().unwrap(), input);
+    }
+
+    #[test]
+    fn rejects_invalid_base64() {
+        assert!(Base64::try_from("not-valid-base64!!".to_string()).is_err());
+    }
+
+    #[test]
+    fn serializes_as_plain_string() {
+        let value = Base64::from_bytes(b"Hello world!");
+        let json = serde_json::to_string(&value).unwrap();
+        assert_eq!(json, "\"SGVsbG8gd29ybGQh\"");
+
+        let deserialized: Base64 = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized, value);
+    }
+}

--- a/src/benchmarks/kms_stress.rs
+++ b/src/benchmarks/kms_stress.rs
@@ -3,24 +3,34 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::tx_signer::{SidecarTxSigner, TxSigner};
-use iota_types::base_types::{random_object_ref, IotaAddress};
-use iota_types::transaction::{ProgrammableTransaction, TransactionData, TransactionKind};
+use iota_sdk_types::{
+    Address, GasPayment, ObjectDigest, ObjectId, ObjectReference, ProgrammableTransaction,
+    Transaction, TransactionExpiration, TransactionKind, TransactionV1, Version,
+};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 pub async fn run_kms_stress_test(kms_url: String, num_tasks: usize) {
     let signer = SidecarTxSigner::new(kms_url).await;
-    let test_tx_data = TransactionData::new(
-        TransactionKind::ProgrammableTransaction(ProgrammableTransaction {
+    let test_tx_data = Transaction::V1(TransactionV1 {
+        kind: TransactionKind::Programmable(ProgrammableTransaction {
             inputs: vec![],
             commands: vec![],
         }),
-        IotaAddress::ZERO,
-        random_object_ref(),
-        1000,
-        1000,
-    );
+        sender: Address::ZERO,
+        gas_payment: GasPayment {
+            objects: vec![ObjectReference::new(
+                ObjectId::random(),
+                Version::from_u64(0),
+                ObjectDigest::random(),
+            )],
+            owner: Address::ZERO,
+            price: 1000,
+            budget: 1000,
+        },
+        expiration: TransactionExpiration::None,
+    });
     // Shared atomic counters for successes and failures
     let success_counter = Arc::new(AtomicUsize::new(0));
     let failure_counter = Arc::new(AtomicUsize::new(0));

--- a/src/benchmarks/mod.rs
+++ b/src/benchmarks/mod.rs
@@ -6,17 +6,25 @@ pub mod kms_stress;
 
 use crate::rpc::client::GasStationRpcClient;
 use clap::ValueEnum;
-use iota_config::node::DEFAULT_VALIDATOR_GAS_PRICE;
-use iota_sdk_types::Intent;
-use iota_sdk_types::IntentMessage;
-use iota_types::crypto::{get_account_key_pair, Signature};
-use iota_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
-use iota_types::transaction::{TransactionData, TransactionKind};
+use iota_sdk_crypto::ed25519::Ed25519PrivateKey;
+use iota_sdk_crypto::simple::SimpleKeypair;
+use iota_sdk_crypto::IotaSigner;
+use iota_sdk_types::{
+    GasPayment, ProgrammableTransaction, Transaction, TransactionExpiration, TransactionKind,
+    TransactionV1,
+};
 use parking_lot::RwLock;
 use rand::rngs::OsRng;
 use rand::Rng;
 use std::sync::Arc;
 use tokio::time::{interval, Duration, Instant};
+
+/// Was `iota_config::node::DEFAULT_VALIDATOR_GAS_PRICE` (itself a re-export of
+/// `iota_types::transaction::DEFAULT_VALIDATOR_GAS_PRICE`, confirmed still
+/// `1000` at the `v1.20.1` tag). Not part of any wire format -- just a
+/// stand-in gas price for this benchmark's synthetic transactions -- so a
+/// local constant replaces the dependency instead of a real SDK equivalent.
+const DEFAULT_VALIDATOR_GAS_PRICE: u64 = 1000;
 
 #[derive(Copy, Clone, ValueEnum)]
 pub enum BenchmarkMode {
@@ -58,7 +66,8 @@ impl BenchmarkMode {
             let client = client.clone();
             let stats = stats.clone();
             let handle = tokio::spawn(async move {
-                let (sender, keypair) = get_account_key_pair();
+                let keypair = SimpleKeypair::from(Ed25519PrivateKey::generate(OsRng));
+                let sender = keypair.public_key().derive_address();
                 let mut rng = OsRng;
                 loop {
                     let now = Instant::now();
@@ -77,20 +86,31 @@ impl BenchmarkMode {
                         continue;
                     }
 
-                    let pt_builder = ProgrammableTransactionBuilder::new();
-                    let pt = pt_builder.finish();
-                    let tx_data = TransactionData::new_with_gas_coins_allow_sponsor(
-                        TransactionKind::ProgrammableTransaction(pt),
+                    let pt = ProgrammableTransaction {
+                        inputs: vec![],
+                        commands: vec![],
+                    };
+                    let tx = Transaction::V1(TransactionV1 {
+                        kind: TransactionKind::Programmable(pt),
                         sender,
-                        gas_coins,
-                        budget,
-                        DEFAULT_VALIDATOR_GAS_PRICE,
-                        sponsor,
-                    );
-                    let intent_msg = IntentMessage::new(Intent::iota_transaction(), &tx_data);
-                    let user_sig = Signature::new_secure(&intent_msg, &keypair).into();
+                        gas_payment: GasPayment {
+                            objects: gas_coins,
+                            owner: sponsor,
+                            price: DEFAULT_VALIDATOR_GAS_PRICE,
+                            budget,
+                        },
+                        expiration: TransactionExpiration::None,
+                    });
+                    let user_sig = match keypair.sign_transaction(&tx) {
+                        Ok(sig) => sig,
+                        Err(err) => {
+                            stats.write().update_error();
+                            println!("Error: {}", err);
+                            continue;
+                        }
+                    };
                     let result = client
-                        .execute_tx(reservation_id, &tx_data, &user_sig, None, None)
+                        .execute_tx(reservation_id, &tx, &user_sig, None, None)
                         .await;
                     if let Err(err) = result {
                         stats.write().update_error();

--- a/src/bin/tool.rs
+++ b/src/bin/tool.rs
@@ -253,20 +253,9 @@ pub enum Network {
     Mainnet,
 }
 
-// gRPC equivalents of the old JSON-RPC `iota_sdk::{IOTA_MAINNET_URL,
-// IOTA_TESTNET_URL, IOTA_DEVNET_URL}` constants. The new SDK's
-// `iota_sdk_grpc_client::Client::new_mainnet`/`_testnet`/`_devnet` build a
-// `Client` from the equivalent hosts, but those hosts (`MAINNET_HOST`/
-// `TESTNET_HOST`/`DEVNET_HOST` in `iota-sdk-grpc-client/src/client.rs`) are
-// `pub(crate)` (not importable here), and the constructors themselves
-// require the `tls-ring` feature to build a `Client` for an `https://` URI --
-// a feature this crate doesn't enable on `iota-sdk-grpc-client`, since
-// generating a sample config never actually opens a connection. The values
-// below are copied verbatim from that file; they are gRPC hosts, not
-// JSON-RPC hosts.
-const IOTA_GRPC_MAINNET_URL: &str = "https://grpc.mainnet.iota.cafe:443";
-const IOTA_GRPC_TESTNET_URL: &str = "https://grpc.testnet.iota.cafe:443";
-const IOTA_GRPC_DEVNET_URL: &str = "https://grpc.devnet.iota.cafe:443";
+const IOTA_GRPC_MAINNET_URL: &str = "https://grpc.mainnet.iota.cafe";
+const IOTA_GRPC_TESTNET_URL: &str = "https://grpc.testnet.iota.cafe";
+const IOTA_GRPC_DEVNET_URL: &str = "https://grpc.devnet.iota.cafe";
 
 fn get_fullnode_url(network: Network, is_docker_compose: bool) -> &'static str {
     match network {

--- a/src/bin/tool.rs
+++ b/src/bin/tool.rs
@@ -2,14 +2,16 @@
 // Modifications Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use base64ct::Encoding;
 use clap::*;
 use iota_gas_station::benchmarks::kms_stress::run_kms_stress_test;
 use iota_gas_station::benchmarks::BenchmarkMode;
 use iota_gas_station::config::{GasStationConfig, GasStationStorageConfig, TxSignerConfig};
 use iota_gas_station::rpc::client::GasStationRpcClient;
-use iota_sdk::{IOTA_DEVNET_URL, IOTA_MAINNET_URL, IOTA_TESTNET_URL};
-use iota_types::base_types::IotaAddress;
-use iota_types::crypto::{get_account_key_pair, EncodeDecodeBase64, IotaKeyPair};
+use iota_sdk_crypto::ed25519::Ed25519PrivateKey;
+use iota_sdk_crypto::simple::SimpleKeypair;
+use iota_sdk_crypto::{ToFromBech32, ToFromFlaggedBytes};
+use iota_sdk_types::Address;
 use std::path::PathBuf;
 
 #[derive(Parser)]
@@ -133,17 +135,15 @@ impl ToolCommand {
                 force,
                 network,
             } => {
-                let mut new_iota_address: Option<IotaAddress> = None;
+                let mut new_iota_address: Option<Address> = None;
                 let signer_config = if with_sidecar_signer {
                     TxSignerConfig::Sidecar {
                         sidecar_url: "http://localhost:3000".to_string(),
                     }
                 } else {
-                    let (iota_address, keypair) = get_account_key_pair();
-                    new_iota_address = Some(iota_address);
-                    TxSignerConfig::Local {
-                        keypair: keypair.into(),
-                    }
+                    let keypair = SimpleKeypair::from(Ed25519PrivateKey::generate(rand::rngs::OsRng));
+                    new_iota_address = Some(keypair.public_key().derive_address());
+                    TxSignerConfig::Local { keypair }
                 };
                 let redis_url = if docker_compose {
                     "redis://redis:6379".to_string()
@@ -205,14 +205,17 @@ impl ToolCommand {
                 }
             },
             ToolCommand::ConvertKeyConfig { key } => {
-                let key = IotaKeyPair::decode(&key).unwrap();
-                println!("{}", key.encode_base64());
+                let keypair = SimpleKeypair::from_bech32(&key).unwrap();
+                println!(
+                    "{}",
+                    base64ct::Base64::encode_string(&keypair.to_flagged_bytes())
+                );
             }
             ToolCommand::GeneratePrivateKey => {
-                let (iota_address, keypair) = get_account_key_pair();
-                let iota_keypair = IotaKeyPair::Ed25519(keypair);
-                let bech32_key = iota_keypair.encode().unwrap();
-                let encoded_key = iota_keypair.encode_base64();
+                let keypair = SimpleKeypair::from(Ed25519PrivateKey::generate(rand::rngs::OsRng));
+                let iota_address = keypair.public_key().derive_address();
+                let bech32_key = keypair.to_bech32().unwrap();
+                let encoded_key = base64ct::Base64::encode_string(&keypair.to_flagged_bytes());
                 println!(
                     "IOTA Address: {}\nPrivate key (iotaprivkey): {}\nBase64 private key: {}",
                     iota_address, bech32_key, encoded_key,
@@ -250,6 +253,21 @@ pub enum Network {
     Mainnet,
 }
 
+// gRPC equivalents of the old JSON-RPC `iota_sdk::{IOTA_MAINNET_URL,
+// IOTA_TESTNET_URL, IOTA_DEVNET_URL}` constants. The new SDK's
+// `iota_sdk_grpc_client::Client::new_mainnet`/`_testnet`/`_devnet` build a
+// `Client` from the equivalent hosts, but those hosts (`MAINNET_HOST`/
+// `TESTNET_HOST`/`DEVNET_HOST` in `iota-sdk-grpc-client/src/client.rs`) are
+// `pub(crate)` (not importable here), and the constructors themselves
+// require the `tls-ring` feature to build a `Client` for an `https://` URI --
+// a feature this crate doesn't enable on `iota-sdk-grpc-client`, since
+// generating a sample config never actually opens a connection. The values
+// below are copied verbatim from that file; they are gRPC hosts, not
+// JSON-RPC hosts.
+const IOTA_GRPC_MAINNET_URL: &str = "https://grpc.mainnet.iota.cafe:443";
+const IOTA_GRPC_TESTNET_URL: &str = "https://grpc.testnet.iota.cafe:443";
+const IOTA_GRPC_DEVNET_URL: &str = "https://grpc.devnet.iota.cafe:443";
+
 fn get_fullnode_url(network: Network, is_docker_compose: bool) -> &'static str {
     match network {
         Network::Local => {
@@ -259,9 +277,9 @@ fn get_fullnode_url(network: Network, is_docker_compose: bool) -> &'static str {
                 "http://localhost:9000"
             }
         }
-        Network::Devnet => IOTA_DEVNET_URL,
-        Network::Testnet => IOTA_TESTNET_URL,
-        Network::Mainnet => IOTA_MAINNET_URL,
+        Network::Devnet => IOTA_GRPC_DEVNET_URL,
+        Network::Testnet => IOTA_GRPC_TESTNET_URL,
+        Network::Mainnet => IOTA_GRPC_MAINNET_URL,
     }
 }
 

--- a/src/command.rs
+++ b/src/command.rs
@@ -158,7 +158,7 @@ impl Command {
             iota_client,
             daily_gas_usage_cap,
             max_gas_budget,
-            checkpoint_wait_ms,
+            checkpoint_inclusion_timeout_ms,
             core_metrics,
             rescan_config,
         )

--- a/src/command.rs
+++ b/src/command.rs
@@ -74,7 +74,7 @@ impl Command {
             coin_init_config,
             daily_gas_usage_cap,
             max_gas_budget,
-            checkpoint_wait_ms,
+            checkpoint_inclusion_timeout_ms,
             mut access_controller,
         } = config;
 

--- a/src/command.rs
+++ b/src/command.rs
@@ -3,20 +3,21 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::config::cold_params::ColdParams;
-use crate::config::GasStationConfig;
+use crate::config::{Config, GasStationConfig};
 use crate::gas_station::gas_station_core::GasStationContainer;
 use crate::gas_station::rescan_trigger::RescanGasObjectsTrigger;
 use crate::gas_station_initializer::GasStationInitializer;
 use crate::iota_client::IotaClient;
-use crate::metrics::{GasStationCoreMetrics, GasStationRpcMetrics, StorageMetrics};
+use crate::metrics::{
+    start_prometheus_server, GasStationCoreMetrics, GasStationRpcMetrics, StorageMetrics,
+};
 use crate::rpc::GasStationServer;
 use crate::storage::{connect_storage, get_storage_namespace};
 use crate::tracker::stats_tracker_storage::redis::connect_stats_storage;
 use crate::tracker::StatsTracker;
-use crate::{TRANSACTION_LOGGING_ENV_NAME, TRANSACTION_LOGGING_TARGET_NAME, VERSION};
+use crate::VERSION;
 use arc_swap::ArcSwap;
 use clap::*;
-use iota_config::Config;
 use std::net::{IpAddr, SocketAddr};
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -73,21 +74,14 @@ impl Command {
             coin_init_config,
             daily_gas_usage_cap,
             max_gas_budget,
+            checkpoint_wait_ms,
             mut access_controller,
         } = config;
 
-        let metric_address = SocketAddr::new(IpAddr::V4(rpc_host_ip), metrics_port);
-        let registry_service = iota_metrics::start_prometheus_server(metric_address);
-        let prometheus_registry = registry_service.default_registry();
-        let mut telemetry_config = telemetry_subscribers::TelemetryConfig::new()
-            .with_log_level("off,iota_gas_station=debug")
-            .with_env()
-            .with_prom_registry(&prometheus_registry);
+        crate::logging::init();
 
-        if std::env::var(TRANSACTION_LOGGING_ENV_NAME) == Ok("true".to_string()) {
-            telemetry_config = telemetry_config.with_trace_target(TRANSACTION_LOGGING_TARGET_NAME);
-        }
-        let _guard = telemetry_config.init();
+        let metric_address = SocketAddr::new(IpAddr::V4(rpc_host_ip), metrics_port);
+        let prometheus_registry = start_prometheus_server(metric_address);
         info!("Metrics server started at {:?}", metric_address);
 
         let signer = signer_config.new_signer().await;
@@ -103,7 +97,9 @@ impl Command {
             storage_metrics,
         )
         .await;
-        let iota_client = IotaClient::new(&fullnode_url, fullnode_basic_auth).await;
+        let iota_client = IotaClient::new(&fullnode_url, fullnode_basic_auth)
+            .await
+            .expect("Failed to connect to fullnode gRPC endpoint");
 
         let mut rescan_config = RescanGasObjectsTrigger::new(
             coin_init_config
@@ -162,6 +158,7 @@ impl Command {
             iota_client,
             daily_gas_usage_cap,
             max_gas_budget,
+            checkpoint_wait_ms,
             core_metrics,
             rescan_config,
         )

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -37,7 +37,7 @@ pub const DEFAULT_DAILY_GAS_USAGE_CAP: u64 = 1500 * NANOS_PER_IOTA;
 // 2 IOTA.
 pub const DEFAULT_MAX_GAS_BUDGET: u64 = 2 * NANOS_PER_IOTA;
 // 5 seconds.
-pub const DEFAULT_CHECKPOINT_WAIT_MS: u64 = 5_000;
+pub const DEFAULT_CHECKPOINT_INCLUSION_TIMEOUT_MS: u64 = 5_000;
 
 // Use 127.0.0.1 for tests to avoid OS complaining about permissions.
 #[cfg(test)]
@@ -51,8 +51,8 @@ fn default_max_gas_budget() -> u64 {
 }
 
 /// Helper function for serde deserialization.
-fn default_checkpoint_wait_ms() -> u64 {
-    DEFAULT_CHECKPOINT_WAIT_MS
+fn default_checkpoint_inclusion_timeout_ms() -> u64 {
+    DEFAULT_CHECKPOINT_INCLUSION_TIMEOUT_MS
 }
 
 #[serde_as]
@@ -79,8 +79,8 @@ pub struct GasStationConfig {
     /// milliseconds. Only used when a request asks to wait for local
     /// execution; passed through as the gRPC `execute_transaction` call's
     /// `checkpoint_inclusion_timeout_ms`.
-    #[serde(default = "default_checkpoint_wait_ms")]
-    pub checkpoint_wait_ms: u64,
+    #[serde(default = "default_checkpoint_inclusion_timeout_ms")]
+    pub checkpoint_inclusion_timeout_ms: u64,
     #[serde(default)]
     pub access_controller: AccessController,
 }
@@ -100,7 +100,7 @@ impl Default for GasStationConfig {
             coin_init_config: Some(CoinInitConfig::default()),
             daily_gas_usage_cap: DEFAULT_DAILY_GAS_USAGE_CAP,
             max_gas_budget: DEFAULT_MAX_GAS_BUDGET,
-            checkpoint_wait_ms: DEFAULT_CHECKPOINT_WAIT_MS,
+            checkpoint_inclusion_timeout_ms: DEFAULT_CHECKPOINT_INCLUSION_TIMEOUT_MS,
             access_controller: AccessController::default(),
         }
     }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -128,16 +128,8 @@ impl Default for GasStationStorageConfig {
 #[serde_as]
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "kebab-case")]
-// NOTE: no `#[cfg_attr(test, derive(PartialEq, Eq))]` here (unlike
-// `GasStationStorageConfig` above) -- `SimpleKeypair` (from `iota-sdk-crypto`)
-// deliberately does not implement `PartialEq`/`Eq` (its wrapped private-key
-// bytes are not meant to be compared), and since neither trait nor type is
-// local to this crate, we cannot provide the impl for it ourselves either.
-// Deriving on the whole enum would require every variant's fields to satisfy
-// the trait even though only `Sidecar` is ever compared in tests; see the
-// `TxSignerConfig::Local` case in `mod::test`'s config-compat test below for
-// how the `Local` variant is asserted on instead (via the derived public
-// key/address, not equality).
+// No test-only `PartialEq`/`Eq` derive here: `SimpleKeypair` doesn't
+// implement them.
 pub enum TxSignerConfig {
     Local {
         #[serde(with = "local_keypair")]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -36,8 +36,8 @@ const DEFAULT_COIN_POOL_REFRESH_INTERVAL_SEC: u64 = 60 * 60 * 24;
 pub const DEFAULT_DAILY_GAS_USAGE_CAP: u64 = 1500 * NANOS_PER_IOTA;
 // 2 IOTA.
 pub const DEFAULT_MAX_GAS_BUDGET: u64 = 2 * NANOS_PER_IOTA;
-// 5 seconds.
-pub const DEFAULT_CHECKPOINT_INCLUSION_TIMEOUT_MS: u64 = 5_000;
+// 10 seconds.
+pub const DEFAULT_CHECKPOINT_INCLUSION_TIMEOUT_MS: u64 = 10_000;
 
 // Use 127.0.0.1 for tests to avoid OS complaining about permissions.
 #[cfg(test)]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -16,11 +16,7 @@ use std::sync::Arc;
 
 pub mod cold_params;
 
-/// Local replacement for the (now removed) `iota_config::Config` trait.
-///
 /// Provides simple YAML load/save helpers for any type that is `Serialize + DeserializeOwned`.
-/// Behavior is kept byte-identical to the previous `iota_config::Config` implementation,
-/// including continued use of `serde_yaml` 0.8 semantics.
 pub trait Config: Serialize + DeserializeOwned {
     fn load(path: impl AsRef<Path>) -> anyhow::Result<Self> {
         Ok(serde_yaml::from_reader(fs::File::open(path)?)?)

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -3,16 +3,32 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::access_controller::AccessController;
+use crate::gas_station::gas_station_core::NANOS_PER_IOTA;
 use crate::tx_signer::{SidecarTxSigner, TestTxSigner, TxSigner};
-use iota_config::Config;
-use iota_types::crypto::{get_account_key_pair, IotaKeyPair};
-use iota_types::gas_coin::NANOS_PER_IOTA;
+use iota_sdk_crypto::simple::SimpleKeypair;
+use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
+use std::fs;
 use std::net::Ipv4Addr;
+use std::path::Path;
 use std::sync::Arc;
 
 pub mod cold_params;
+
+/// Local replacement for the (now removed) `iota_config::Config` trait.
+///
+/// Provides simple YAML load/save helpers for any type that is `Serialize + DeserializeOwned`.
+/// Behavior is kept byte-identical to the previous `iota_config::Config` implementation,
+/// including continued use of `serde_yaml` 0.8 semantics.
+pub trait Config: Serialize + DeserializeOwned {
+    fn load(path: impl AsRef<Path>) -> anyhow::Result<Self> {
+        Ok(serde_yaml::from_reader(fs::File::open(path)?)?)
+    }
+    fn save(&self, path: impl AsRef<Path>) -> anyhow::Result<()> {
+        Ok(fs::write(path, serde_yaml::to_string(self)?)?)
+    }
+}
 
 pub const DEFAULT_RPC_PORT: u16 = 9527;
 pub const DEFAULT_METRICS_PORT: u16 = 9184;
@@ -24,6 +40,8 @@ const DEFAULT_COIN_POOL_REFRESH_INTERVAL_SEC: u64 = 60 * 60 * 24;
 pub const DEFAULT_DAILY_GAS_USAGE_CAP: u64 = 1500 * NANOS_PER_IOTA;
 // 2 IOTA.
 pub const DEFAULT_MAX_GAS_BUDGET: u64 = 2 * NANOS_PER_IOTA;
+// 5 seconds.
+pub const DEFAULT_CHECKPOINT_WAIT_MS: u64 = 5_000;
 
 // Use 127.0.0.1 for tests to avoid OS complaining about permissions.
 #[cfg(test)]
@@ -34,6 +52,11 @@ pub const LOCALHOST: Ipv4Addr = Ipv4Addr::new(0, 0, 0, 0);
 /// Helper function for serde deserialization.
 fn default_max_gas_budget() -> u64 {
     DEFAULT_MAX_GAS_BUDGET
+}
+
+/// Helper function for serde deserialization.
+fn default_checkpoint_wait_ms() -> u64 {
+    DEFAULT_CHECKPOINT_WAIT_MS
 }
 
 #[serde_as]
@@ -55,6 +78,13 @@ pub struct GasStationConfig {
     pub daily_gas_usage_cap: u64,
     #[serde(default = "default_max_gas_budget")]
     pub max_gas_budget: u64,
+    /// How long the fullnode should wait for a transaction to reach full
+    /// (local) execution / checkpoint inclusion before responding, in
+    /// milliseconds. Only used when a request asks to wait for local
+    /// execution; passed through as the gRPC `execute_transaction` call's
+    /// `checkpoint_inclusion_timeout_ms`.
+    #[serde(default = "default_checkpoint_wait_ms")]
+    pub checkpoint_wait_ms: u64,
     #[serde(default)]
     pub access_controller: AccessController,
 }
@@ -74,6 +104,7 @@ impl Default for GasStationConfig {
             coin_init_config: Some(CoinInitConfig::default()),
             daily_gas_usage_cap: DEFAULT_DAILY_GAS_USAGE_CAP,
             max_gas_budget: DEFAULT_MAX_GAS_BUDGET,
+            checkpoint_wait_ms: DEFAULT_CHECKPOINT_WAIT_MS,
             access_controller: AccessController::default(),
         }
     }
@@ -101,10 +132,20 @@ impl Default for GasStationStorageConfig {
 #[serde_as]
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "kebab-case")]
-#[cfg_attr(test, derive(PartialEq, Eq))]
+// NOTE: no `#[cfg_attr(test, derive(PartialEq, Eq))]` here (unlike
+// `GasStationStorageConfig` above) -- `SimpleKeypair` (from `iota-sdk-crypto`)
+// deliberately does not implement `PartialEq`/`Eq` (its wrapped private-key
+// bytes are not meant to be compared), and since neither trait nor type is
+// local to this crate, we cannot provide the impl for it ourselves either.
+// Deriving on the whole enum would require every variant's fields to satisfy
+// the trait even though only `Sidecar` is ever compared in tests; see the
+// `TxSignerConfig::Local` case in `mod::test`'s config-compat test below for
+// how the `Local` variant is asserted on instead (via the derived public
+// key/address, not equality).
 pub enum TxSignerConfig {
     Local {
-        keypair: IotaKeyPair,
+        #[serde(with = "local_keypair")]
+        keypair: SimpleKeypair,
     },
     Sidecar {
         #[serde(alias = "sidecar-url")]
@@ -112,12 +153,51 @@ pub enum TxSignerConfig {
     },
 }
 
+/// Serializes/deserializes a `SimpleKeypair` as `base64(flag || privkey)`,
+/// matching the on-disk format the old `iota_types::crypto::IotaKeyPair`'s
+/// `Serialize`/`Deserialize` impl produced (`EncodeDecodeBase64::encode_base64`,
+/// i.e. base64 over `to_bytes()`, which is `flag || privkey`). Existing
+/// on-disk configs with a `Local` signer must keep loading byte-identically
+/// after this migration -- see `mod::test`'s config-compat test.
+///
+/// `iota-sdk-crypto`'s `ToFromFlaggedBytes` trait is the SDK's own equivalent
+/// for exactly this `flag || key-bytes` layout, but the crate bundles no
+/// base64 helper of its own, so the base64 encode/decode step uses `base64ct`
+/// directly (already a workspace dependency).
+mod local_keypair {
+    use iota_sdk_crypto::simple::SimpleKeypair;
+    use iota_sdk_crypto::ToFromFlaggedBytes;
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    pub fn serialize<S: Serializer>(
+        keypair: &SimpleKeypair,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error> {
+        use base64ct::Encoding;
+
+        let encoded = base64ct::Base64::encode_string(&keypair.to_flagged_bytes());
+        encoded.serialize(serializer)
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<SimpleKeypair, D::Error> {
+        use base64ct::Encoding;
+
+        let encoded = String::deserialize(deserializer)?;
+        let bytes = base64ct::Base64::decode_vec(&encoded).map_err(serde::de::Error::custom)?;
+        SimpleKeypair::from_flagged_bytes(&bytes).map_err(serde::de::Error::custom)
+    }
+}
+
 impl Default for TxSignerConfig {
     fn default() -> Self {
-        let (_, keypair) = get_account_key_pair();
-        Self::Local {
-            keypair: keypair.into(),
-        }
+        // Only used as a config fallback (e.g. when generating a sample
+        // config); never loaded from -- or persisted to -- a real deployment.
+        let keypair = SimpleKeypair::from(iota_sdk_crypto::ed25519::Ed25519PrivateKey::generate(
+            rand::rngs::OsRng,
+        ));
+        Self::Local { keypair }
     }
 }
 
@@ -173,12 +253,13 @@ mod test {
             max-gas-budget: 2000000000
         "#};
         let config: GasStationConfig = serde_yaml::from_str(yaml).unwrap();
-        assert_eq!(
+        // `TxSignerConfig` no longer derives `PartialEq` (see the type's own
+        // doc comment for why -- `SimpleKeypair` can't support it), so this
+        // is asserted via pattern matching instead of `assert_eq!`.
+        assert!(matches!(
             config.signer_config,
-            TxSignerConfig::Sidecar {
-                sidecar_url: "http://localhost:3000".to_string()
-            }
-        );
+            TxSignerConfig::Sidecar { ref sidecar_url } if sidecar_url == "http://localhost:3000"
+        ));
         assert_eq!(
             config.storage_config,
             GasStationStorageConfig::Redis {
@@ -204,17 +285,67 @@ mod test {
             max-gas-budget: 2000000000
         "#};
         let config: GasStationConfig = serde_yaml::from_str(yaml).unwrap();
-        assert_eq!(
+        assert!(matches!(
             config.signer_config,
-            TxSignerConfig::Sidecar {
-                sidecar_url: "http://localhost:3000".to_string()
-            }
-        );
+            TxSignerConfig::Sidecar { ref sidecar_url } if sidecar_url == "http://localhost:3000"
+        ));
         assert_eq!(
             config.storage_config,
             GasStationStorageConfig::Redis {
                 redis_url: "redis://localhost:6379".to_string()
             }
         );
+    }
+
+    /// Loads a config in the *old* on-disk format (predating this
+    /// migration): `signer-config.local.keypair` is a base64 string of
+    /// `flag || 32-byte ed25519 private key seed`, exactly what
+    /// `iota_types::crypto::IotaKeyPair`'s `Serialize` impl used to produce.
+    /// The keypair value below is taken verbatim from a real fixture
+    /// committed to this repo before this migration (`config_with_ac.yaml`,
+    /// also duplicated in `docker/config.yaml.orig`), to prove that existing
+    /// on-disk configs with a `Local` signer keep loading byte-identically
+    /// through the new `SimpleKeypair`-based field.
+    ///
+    /// The expected address was computed independently (Python, ed25519 +
+    /// unkeyed BLAKE2b-256, no scheme-flag prefix for ed25519 -- matching
+    /// both the old `IotaAddress`-derivation rules in
+    /// `iota_types::crypto::SignatureScheme::update_hasher_with_flag` and the
+    /// new `iota_sdk_types::Ed25519PublicKey::derive_address`) from the same
+    /// base64-decoded seed bytes, as a from-scratch cross-check that loading
+    /// this fixture through `SimpleKeypair` produces the exact same key
+    /// material the old `IotaKeyPair`-based config did.
+    #[test]
+    fn test_load_local_signer_old_format_config() {
+        let yaml = indoc! {r#"
+            signer-config:
+                local:
+                    keypair: AKJvlwEulZj0Enj/btnZtFpWqQgfwVU7/UaRmycpW6dq
+            rpc-host-ip: 0.0.0.0
+            rpc-port: 9527
+            metrics-port: 9184
+            storage-config:
+                redis:
+                    redis-url: "redis://localhost:6379"
+            fullnode-url: "https://api.devnet.iota.cafe"
+            daily-gas-usage-cap: 1500000000000
+            max-gas-budget: 2000000000
+        "#};
+        let config: GasStationConfig = serde_yaml::from_str(yaml).unwrap();
+        let TxSignerConfig::Local { keypair } = config.signer_config else {
+            panic!("expected a Local signer config");
+        };
+
+        let expected_address: iota_sdk_types::Address =
+            "0xf1bb78a14db34ec8206148eb2a50adf7b4a39e3123350fef20b3f06efe05995c"
+                .parse()
+                .unwrap();
+        assert_eq!(keypair.public_key().derive_address(), expected_address);
+
+        // Round-trips back to the exact same base64 string, confirming the
+        // `Serialize` side also matches the old on-disk format byte-for-byte
+        // (not just that decoding happens to produce a usable key).
+        let reserialized = serde_yaml::to_string(&TxSignerConfig::Local { keypair }).unwrap();
+        assert!(reserialized.contains("AKJvlwEulZj0Enj/btnZtFpWqQgfwVU7/UaRmycpW6dq"));
     }
 }

--- a/src/gas_station/effects_util.rs
+++ b/src/gas_station/effects_util.rs
@@ -1,0 +1,211 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! Small helpers for deriving specific pieces of information out of a raw
+//! `iota_sdk_types::TransactionEffects`.
+//!
+//! The SDK's `TransactionEffects` only exposes the compact `changed_objects:
+//! Vec<ChangedObject>` representation (see `TransactionEffectsV1`) -- there is
+//! no `TransactionEffectsAPI`-style convenience trait in this SDK revision
+//! with `created()`/`gas_object()`/etc. accessors the way the old
+//! `iota_json_rpc_types::IotaTransactionBlockEffectsAPI` had.
+//!
+//! `crate::rpc::effects` already ported this exact derivation logic once (for
+//! its JSON-RPC-shaped DTO), straight from `crates/iota-types/src/effects/v1.rs`
+//! (`impl TransactionEffectsAPI for TransactionEffectsV1`) on the
+//! `iotaledger/iota` monorepo `develop` branch -- but its helpers are private
+//! to that module and can't be reused directly. The two helpers below are the
+//! minimal subset `gas_station_core.rs` and `gas_station_initializer.rs` each
+//! need (the gas coin's post-execution reference, and the set of newly
+//! created objects), ported the same way, so there is exactly one shared
+//! definition for both call sites instead of two independent copies.
+
+use iota_sdk_types::{IdOperation, ObjectIn, ObjectOut, ObjectReference, TransactionEffects};
+
+/// The transaction's own gas coin, as it exists after execution.
+///
+/// Ported from `TransactionEffectsAPI::gas_object` (see the module doc for
+/// provenance). Panics if `gas_object_index` is unset (a system transaction
+/// that doesn't pay gas) or points at an entry that isn't a plain
+/// `ObjectWrite` -- neither can happen for the signed, gas-paying,
+/// programmable transactions this crate ever executes.
+pub(crate) fn gas_object_reference(effects: &TransactionEffects) -> ObjectReference {
+    let v1 = effects.as_v1();
+    let gas_object_index = v1
+        .gas_object_index
+        .expect("a signed, gas-paying transaction always records a gas object") as usize;
+    let changed = &v1.changed_objects[gas_object_index];
+    match &changed.output_state {
+        ObjectOut::ObjectWrite { digest, .. } => {
+            ObjectReference::new(changed.object_id, v1.lamport_version, *digest)
+        }
+        _ => panic!("gas object must be an ObjectWrite in changed_objects"),
+    }
+}
+
+/// Object references for every object created by the transaction.
+///
+/// Ported from `TransactionEffectsAPI::created` (see the module doc for
+/// provenance). Note the asymmetry called out there for package writes
+/// (package versions come from the write itself, never from
+/// `lamport_version`) is irrelevant here: a created object always reaches
+/// this function via a plain `ObjectWrite`, never a `PackageWrite` -- the
+/// only caller (`gas_station_initializer.rs`'s coin-splitting) only ever
+/// creates new `Coin<IOTA>` objects via `pay::divide_and_keep`, never packages.
+pub(crate) fn created_object_refs(effects: &TransactionEffects) -> Vec<ObjectReference> {
+    let v1 = effects.as_v1();
+    v1.changed_objects
+        .iter()
+        .filter_map(|changed| {
+            match (
+                &changed.input_state,
+                &changed.output_state,
+                &changed.id_operation,
+            ) {
+                (ObjectIn::Missing, ObjectOut::ObjectWrite { digest, .. }, IdOperation::Created) => {
+                    Some(ObjectReference::new(
+                        changed.object_id,
+                        v1.lamport_version,
+                        *digest,
+                    ))
+                }
+                _ => None,
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use iota_sdk_types::{
+        Address, ChangedObject, ExecutionStatus, GasCostSummary, ObjectDigest, ObjectId, Owner,
+        TransactionDigest, TransactionEffectsV1, Version,
+    };
+
+    fn oid(byte: u8) -> ObjectId {
+        ObjectId::new([byte; 32])
+    }
+
+    fn addr(byte: u8) -> Address {
+        Address::new([byte; 32])
+    }
+
+    fn odig(byte: u8) -> ObjectDigest {
+        ObjectDigest::new([byte; 32])
+    }
+
+    fn base_effects(changed_objects: Vec<ChangedObject>, gas_object_index: Option<u32>) -> TransactionEffects {
+        TransactionEffects::V1(Box::new(TransactionEffectsV1 {
+            status: ExecutionStatus::Success,
+            epoch: 1,
+            gas_cost_summary: GasCostSummary::new(100, 10, 50, 20, 5),
+            transaction_digest: TransactionDigest::new([1; 32]),
+            gas_object_index,
+            events_digest: None,
+            dependencies: vec![],
+            lamport_version: Version::from_u64(6),
+            changed_objects,
+            unchanged_shared_objects: vec![],
+            auxiliary_data_digest: None,
+        }))
+    }
+
+    #[test]
+    fn gas_object_reference_reads_the_indexed_changed_object() {
+        let owner = addr(0xA0);
+        let effects = base_effects(
+            vec![
+                // Not the gas object -- proves the index, not just "the only
+                // entry", drives the result.
+                ChangedObject {
+                    object_id: oid(1),
+                    input_state: ObjectIn::Missing,
+                    output_state: ObjectOut::ObjectWrite {
+                        digest: odig(2),
+                        owner: Owner::Address(owner),
+                    },
+                    id_operation: IdOperation::Created,
+                },
+                ChangedObject {
+                    object_id: oid(3),
+                    input_state: ObjectIn::Data {
+                        version: Version::from_u64(5),
+                        digest: odig(4),
+                        owner: Owner::Address(owner),
+                    },
+                    output_state: ObjectOut::ObjectWrite {
+                        digest: odig(5),
+                        owner: Owner::Address(owner),
+                    },
+                    id_operation: IdOperation::None,
+                },
+            ],
+            Some(1),
+        );
+
+        let reference = gas_object_reference(&effects);
+        assert_eq!(reference.object_id, oid(3));
+        assert_eq!(reference.version, Version::from_u64(6));
+        assert_eq!(reference.digest, odig(5));
+    }
+
+    #[test]
+    #[should_panic(expected = "always records a gas object")]
+    fn gas_object_reference_panics_without_a_gas_object_index() {
+        let effects = base_effects(vec![], None);
+        gas_object_reference(&effects);
+    }
+
+    #[test]
+    fn created_object_refs_only_includes_missing_to_object_write_created_entries() {
+        let owner = addr(0xB0);
+        let created = ChangedObject {
+            object_id: oid(10),
+            input_state: ObjectIn::Missing,
+            output_state: ObjectOut::ObjectWrite {
+                digest: odig(11),
+                owner: Owner::Address(owner),
+            },
+            id_operation: IdOperation::Created,
+        };
+        // Mutated, not created -- must be excluded.
+        let mutated = ChangedObject {
+            object_id: oid(20),
+            input_state: ObjectIn::Data {
+                version: Version::from_u64(1),
+                digest: odig(21),
+                owner: Owner::Address(owner),
+            },
+            output_state: ObjectOut::ObjectWrite {
+                digest: odig(22),
+                owner: Owner::Address(owner),
+            },
+            id_operation: IdOperation::None,
+        };
+        // Unwrapped (Missing -> ObjectWrite, but id_operation == None, not
+        // Created) -- must also be excluded.
+        let unwrapped = ChangedObject {
+            object_id: oid(30),
+            input_state: ObjectIn::Missing,
+            output_state: ObjectOut::ObjectWrite {
+                digest: odig(31),
+                owner: Owner::Address(owner),
+            },
+            id_operation: IdOperation::None,
+        };
+        let effects = base_effects(vec![created, mutated, unwrapped], Some(1));
+
+        let refs = created_object_refs(&effects);
+        assert_eq!(refs.len(), 1);
+        assert_eq!(refs[0].object_id, oid(10));
+        assert_eq!(refs[0].version, Version::from_u64(6));
+        assert_eq!(refs[0].digest, odig(11));
+    }
+
+    #[test]
+    fn created_object_refs_empty_when_nothing_created() {
+        let effects = base_effects(vec![], Some(0));
+        assert!(created_object_refs(&effects).is_empty());
+    }
+}

--- a/src/gas_station/effects_util.rs
+++ b/src/gas_station/effects_util.rs
@@ -2,33 +2,23 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Small helpers for deriving specific pieces of information out of a raw
-//! `iota_sdk_types::TransactionEffects`.
+//! `iota_sdk_types::TransactionEffects` (which only exposes the compact
+//! `changed_objects` representation).
 //!
-//! The SDK's `TransactionEffects` only exposes the compact `changed_objects:
-//! Vec<ChangedObject>` representation (see `TransactionEffectsV1`) -- there is
-//! no `TransactionEffectsAPI`-style convenience trait in this SDK revision
-//! with `created()`/`gas_object()`/etc. accessors the way the old
-//! `iota_json_rpc_types::IotaTransactionBlockEffectsAPI` had.
-//!
-//! `crate::rpc::effects` already ported this exact derivation logic once (for
-//! its JSON-RPC-shaped DTO), straight from `crates/iota-types/src/effects/v1.rs`
-//! (`impl TransactionEffectsAPI for TransactionEffectsV1`) on the
-//! `iotaledger/iota` monorepo `develop` branch -- but its helpers are private
-//! to that module and can't be reused directly. The two helpers below are the
-//! minimal subset `gas_station_core.rs` and `gas_station_initializer.rs` each
-//! need (the gas coin's post-execution reference, and the set of newly
-//! created objects), ported the same way, so there is exactly one shared
-//! definition for both call sites instead of two independent copies.
+//! `crate::rpc::effects` contains the same derivation logic for its
+//! JSON-RPC-shaped DTO, but its helpers are private to that module. The two
+//! helpers below are the minimal subset `gas_station_core.rs` and
+//! `gas_station_initializer.rs` need: the gas coin's post-execution reference
+//! and the set of newly created objects.
 
 use iota_sdk_types::{IdOperation, ObjectIn, ObjectOut, ObjectReference, TransactionEffects};
 
 /// The transaction's own gas coin, as it exists after execution.
 ///
-/// Ported from `TransactionEffectsAPI::gas_object` (see the module doc for
-/// provenance). Panics if `gas_object_index` is unset (a system transaction
-/// that doesn't pay gas) or points at an entry that isn't a plain
-/// `ObjectWrite` -- neither can happen for the signed, gas-paying,
-/// programmable transactions this crate ever executes.
+/// Panics if `gas_object_index` is unset (a system transaction that doesn't
+/// pay gas) or points at an entry that isn't a plain `ObjectWrite` -- neither
+/// can happen for the signed, gas-paying, programmable transactions this
+/// crate ever executes.
 pub(crate) fn gas_object_reference(effects: &TransactionEffects) -> ObjectReference {
     let v1 = effects.as_v1();
     let gas_object_index = v1
@@ -45,13 +35,9 @@ pub(crate) fn gas_object_reference(effects: &TransactionEffects) -> ObjectRefere
 
 /// Object references for every object created by the transaction.
 ///
-/// Ported from `TransactionEffectsAPI::created` (see the module doc for
-/// provenance). Note the asymmetry called out there for package writes
-/// (package versions come from the write itself, never from
-/// `lamport_version`) is irrelevant here: a created object always reaches
-/// this function via a plain `ObjectWrite`, never a `PackageWrite` -- the
-/// only caller (`gas_station_initializer.rs`'s coin-splitting) only ever
-/// creates new `Coin<IOTA>` objects via `pay::divide_and_keep`, never packages.
+/// `PackageWrite` entries are deliberately not handled: the only caller
+/// (`gas_station_initializer.rs`'s coin-splitting) only ever creates new
+/// `Coin<IOTA>` objects, never packages.
 pub(crate) fn created_object_refs(effects: &TransactionEffects) -> Vec<ObjectReference> {
     let v1 = effects.as_v1();
     v1.changed_objects

--- a/src/gas_station/gas_station_core.rs
+++ b/src/gas_station/gas_station_core.rs
@@ -469,7 +469,7 @@ impl GasStationContainer {
         iota_client: IotaClient,
         gas_usage_daily_cap: u64,
         max_gas_budget: u64,
-        checkpoint_wait_ms: u64,
+        checkpoint_inclusion_timeout_ms: u64,
         metrics: Arc<GasStationCoreMetrics>,
         rescan_config: RescanGasObjectsTrigger,
     ) -> Self {

--- a/src/gas_station/gas_station_core.rs
+++ b/src/gas_station/gas_station_core.rs
@@ -48,10 +48,6 @@ pub struct GasStation {
     metrics: Arc<GasStationCoreMetrics>,
     gas_usage_cap: Arc<GasUsageCap>,
     max_gas_budget: u64,
-    /// How long the fullnode should wait for checkpoint inclusion before
-    /// responding to `execute_transaction` when the caller asked to wait for
-    /// local execution (`ExecuteTransactionRequestType::WaitForLocalExecution`).
-    /// Threaded from `GasStationConfig::checkpoint_wait_ms`.
     checkpoint_wait_ms: u64,
     rescan_config: RescanGasObjectsTrigger,
 }

--- a/src/gas_station/gas_station_core.rs
+++ b/src/gas_station/gas_station_core.rs
@@ -48,7 +48,7 @@ pub struct GasStation {
     metrics: Arc<GasStationCoreMetrics>,
     gas_usage_cap: Arc<GasUsageCap>,
     max_gas_budget: u64,
-    checkpoint_wait_ms: u64,
+    checkpoint_inclusion_timeout_ms: u64,
     rescan_config: RescanGasObjectsTrigger,
 }
 
@@ -60,7 +60,7 @@ impl GasStation {
         metrics: Arc<GasStationCoreMetrics>,
         gas_usage_cap: Arc<GasUsageCap>,
         max_gas_budget: u64,
-        checkpoint_wait_ms: u64,
+        checkpoint_inclusion_timeout_ms: u64,
         rescan_config: RescanGasObjectsTrigger,
     ) -> Arc<Self> {
         let pool = Self {
@@ -70,7 +70,7 @@ impl GasStation {
             metrics,
             gas_usage_cap,
             max_gas_budget,
-            checkpoint_wait_ms,
+            checkpoint_inclusion_timeout_ms,
             rescan_config,
         };
 
@@ -258,7 +258,7 @@ impl GasStation {
         let cur_time = std::time::Instant::now();
         let effects = self
             .iota_client
-            .execute_transaction(signed_tx, 3, request_type, self.checkpoint_wait_ms)
+            .execute_transaction(signed_tx, 3, request_type, self.checkpoint_inclusion_timeout_ms)
             .await?;
         debug!(?reservation_id, "Transaction executed");
         let elapsed = cur_time.elapsed().as_millis();
@@ -480,7 +480,7 @@ impl GasStationContainer {
             metrics,
             Arc::new(GasUsageCap::new(gas_usage_daily_cap)),
             max_gas_budget,
-            checkpoint_wait_ms,
+            checkpoint_inclusion_timeout_ms,
             rescan_config,
         )
         .await;

--- a/src/gas_station/gas_station_core.rs
+++ b/src/gas_station/gas_station_core.rs
@@ -2,6 +2,7 @@
 // Modifications Copyright (c) 2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::gas_station::effects_util::gas_object_reference;
 use crate::gas_station::rescan_trigger::RescanGasObjectsTrigger;
 use crate::gas_station_initializer::NEW_COIN_BALANCE_FACTOR_THRESHOLD;
 use crate::iota_client::IotaClient;
@@ -12,13 +13,10 @@ use crate::tx_signer::TxSigner;
 use crate::types::{GasCoin, ReservationID};
 use crate::{retry_forever, retry_with_max_attempts};
 use anyhow::bail;
-use iota_json_rpc_types::{IotaTransactionBlockEffects, IotaTransactionBlockEffectsAPI};
-use iota_types::base_types::{IotaAddress, ObjectID, ObjectRef};
-use iota_types::gas_coin::NANOS_PER_IOTA;
-use iota_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
-use iota_types::signature::GenericSignature;
-use iota_types::transaction::{
-    Argument, Command, Transaction, TransactionData, TransactionDataAPI, TransactionKind,
+use iota_sdk_types::{
+    Address, Argument, Command, GasPayment, ObjectId, ObjectReference, ProgrammableTransaction,
+    SignedTransaction, Transaction, TransactionEffects, TransactionExpiration, TransactionKind,
+    TransactionV1, UserSignature,
 };
 use std::cmp::min;
 use std::sync::Arc;
@@ -28,6 +26,15 @@ use tokio::task::JoinHandle;
 use tracing::{debug, error, info, warn};
 
 use super::gas_usage_cap::GasUsageCap;
+
+/// The new SDK crates carry no protocol-constant equivalent of the old
+/// `iota_types::gas_coin::NANOS_PER_IOTA` (it was never part of the wire
+/// format, just a `u64` unit-conversion constant), so it's defined locally
+/// here instead of pulling in `iota_types` for a single constant. Re-exported
+/// (via `pub`) for the handful of other call sites in this migration stage's
+/// files (`gas_station/mod.rs`'s and `gas_station_initializer.rs`'s test
+/// modules) that used to import it from `iota_types::gas_coin`.
+pub const NANOS_PER_IOTA: u64 = 1_000_000_000;
 
 const EXPIRATION_JOB_INTERVAL: Duration = Duration::from_secs(1);
 
@@ -48,6 +55,11 @@ pub struct GasStation {
     metrics: Arc<GasStationCoreMetrics>,
     gas_usage_cap: Arc<GasUsageCap>,
     max_gas_budget: u64,
+    /// How long the fullnode should wait for checkpoint inclusion before
+    /// responding to `execute_transaction` when the caller asked to wait for
+    /// local execution (`ExecuteTransactionRequestType::WaitForLocalExecution`).
+    /// Threaded from `GasStationConfig::checkpoint_wait_ms`.
+    checkpoint_wait_ms: u64,
     rescan_config: RescanGasObjectsTrigger,
 }
 
@@ -59,6 +71,7 @@ impl GasStation {
         metrics: Arc<GasStationCoreMetrics>,
         gas_usage_cap: Arc<GasUsageCap>,
         max_gas_budget: u64,
+        checkpoint_wait_ms: u64,
         rescan_config: RescanGasObjectsTrigger,
     ) -> Arc<Self> {
         let pool = Self {
@@ -68,6 +81,7 @@ impl GasStation {
             metrics,
             gas_usage_cap,
             max_gas_budget,
+            checkpoint_wait_ms,
             rescan_config,
         };
 
@@ -78,7 +92,7 @@ impl GasStation {
         &self,
         gas_budget: u64,
         duration: Duration,
-    ) -> anyhow::Result<(IotaAddress, ReservationID, Vec<ObjectRef>)> {
+    ) -> anyhow::Result<(Address, ReservationID, Vec<ObjectReference>)> {
         let cur_time = std::time::Instant::now();
         self.gas_usage_cap.check_usage().await?;
         let sponsor = self.signer.get_address();
@@ -87,10 +101,10 @@ impl GasStation {
             .reserve_gas_coins(gas_budget, duration.as_millis() as u64)
             .await?;
         let elapsed = cur_time.elapsed().as_millis();
-        self.metrics.reserve_gas_latency_ms.observe(elapsed as u64);
+        self.metrics.reserve_gas_latency_ms.observe(elapsed as f64);
         self.metrics
             .reserved_gas_coin_count_per_request
-            .observe(gas_coins.len().try_into().unwrap_or(u64::MAX));
+            .observe(gas_coins.len() as f64);
         Ok((
             sponsor,
             reservation_id,
@@ -101,20 +115,21 @@ impl GasStation {
     pub async fn execute_transaction(
         &self,
         reservation_id: ReservationID,
-        tx_data: TransactionData,
-        user_sig: GenericSignature,
+        tx: Transaction,
+        user_sig: UserSignature,
         request_type: Option<ExecuteTransactionRequestType>,
-    ) -> anyhow::Result<IotaTransactionBlockEffects> {
-        let sponsor = tx_data.gas_data().owner;
+    ) -> anyhow::Result<TransactionEffects> {
+        let sponsor = tx.as_v1().gas_payment.owner;
         if !self.signer.is_valid_address(&sponsor) {
             bail!("Sponsor {:?} is not registered", sponsor);
         };
-        Self::check_transaction_validity(&tx_data)?;
-        let payment: Vec<_> = tx_data
-            .gas_data()
-            .payment
+        Self::check_transaction_validity(&tx)?;
+        let payment: Vec<ObjectId> = tx
+            .as_v1()
+            .gas_payment
+            .objects
             .iter()
-            .map(|oref| oref.0)
+            .map(|oref| oref.object_id)
             .collect();
         let payment_count = payment.len();
         debug!(
@@ -136,13 +151,13 @@ impl GasStation {
             "Total gas coin balance prior to execution: {}", total_gas_coin_balance,
         );
         let response = self
-            .execute_transaction_impl(reservation_id, tx_data, user_sig, request_type)
+            .execute_transaction_impl(reservation_id, tx, user_sig, request_type)
             .await;
         let updated_coins = match &response {
             Ok(effects) => {
-                let new_gas_coin = effects.gas_object().reference.to_object_ref();
-                let new_balance =
-                    total_gas_coin_balance as i64 - effects.gas_cost_summary().net_gas_usage();
+                let new_gas_coin = gas_object_reference(effects);
+                let new_balance = total_gas_coin_balance as i64
+                    - effects.as_v1().gas_cost_summary.net_gas_usage();
                 debug!(
                     ?reservation_id,
                     "New gas coin balance after execution: {}", new_balance,
@@ -157,11 +172,11 @@ impl GasStation {
                 }
                 self.metrics
                     .gas_usage_per_transaction
-                    .observe(effects.gas_cost_summary().net_gas_usage() as u64);
+                    .observe(effects.as_v1().gas_cost_summary.net_gas_usage() as f64);
                 self.metrics
                     .reserved_gas_real_gas_usage_delta
                     // If a refund occurs, ensure that the delta does not exceed the original total balance of the gas coins
-                    .observe(min(new_balance, total_gas_coin_balance as i64) as u64);
+                    .observe(min(new_balance, total_gas_coin_balance as i64) as f64);
                 vec![GasCoin {
                     object_ref: new_gas_coin,
                     balance: new_balance as u64,
@@ -226,16 +241,16 @@ impl GasStation {
     async fn execute_transaction_impl(
         &self,
         reservation_id: ReservationID,
-        tx_data: TransactionData,
-        user_sig: GenericSignature,
+        tx: Transaction,
+        user_sig: UserSignature,
         request_type: Option<ExecuteTransactionRequestType>,
-    ) -> anyhow::Result<IotaTransactionBlockEffects> {
-        let sponsor = tx_data.gas_data().owner;
+    ) -> anyhow::Result<TransactionEffects> {
+        let sponsor = tx.as_v1().gas_payment.owner;
         let cur_time = std::time::Instant::now();
         let sponsor_sig = retry_with_max_attempts!(
             async {
                 self.signer
-                    .sign_transaction(&tx_data)
+                    .sign_transaction(&tx)
                     .await
                     .tap_err(|err| error!("Failed to sign transaction: {:?}", err))
             },
@@ -244,21 +259,24 @@ impl GasStation {
         let elapsed = cur_time.elapsed().as_millis();
         self.metrics
             .transaction_signing_latency_ms
-            .observe(elapsed as u64);
+            .observe(elapsed as f64);
         debug!(?reservation_id, "Transaction signed by sponsor");
 
-        let tx = Transaction::from_generic_sig_data(tx_data, vec![sponsor_sig, user_sig]);
+        let signed_tx = SignedTransaction {
+            transaction: tx,
+            signatures: vec![sponsor_sig, user_sig],
+        };
         let cur_time = std::time::Instant::now();
         let effects = self
             .iota_client
-            .execute_transaction(tx, 3, request_type)
+            .execute_transaction(signed_tx, 3, request_type, self.checkpoint_wait_ms)
             .await?;
         debug!(?reservation_id, "Transaction executed");
         let elapsed = cur_time.elapsed().as_millis();
         self.metrics
             .transaction_execution_latency_ms
-            .observe(elapsed as u64);
-        let net_gas_usage = effects.gas_cost_summary().net_gas_usage();
+            .observe(elapsed as f64);
+        let net_gas_usage = effects.as_v1().gas_cost_summary.net_gas_usage();
         let new_daily_usage = self.gas_usage_cap.update_usage(net_gas_usage).await;
         self.metrics
             .daily_gas_usage
@@ -267,7 +285,7 @@ impl GasStation {
         Ok(effects)
     }
 
-    async fn get_total_gas_coin_balance(&self, gas_coins: Vec<ObjectID>) -> u64 {
+    async fn get_total_gas_coin_balance(&self, gas_coins: Vec<ObjectId>) -> u64 {
         let latest = self.iota_client.get_latest_gas_objects(gas_coins).await;
         latest
             .into_values()
@@ -301,33 +319,74 @@ impl GasStation {
         Ok(())
     }
 
-    fn check_transaction_validity(tx_data: &TransactionData) -> anyhow::Result<()> {
+    /// Checks that no command in the transaction uses the gas coin as a
+    /// regular argument -- only this service's own machinery is allowed to
+    /// spend it, to pay for the transaction itself.
+    ///
+    /// # Security note: fails *closed* on unrecognized commands
+    ///
+    /// `iota_sdk_types::Command` is `#[non_exhaustive]`: the SDK can add new
+    /// command variants in a future revision without that being a breaking
+    /// change for this crate. Because this is a *validity check* -- its whole
+    /// purpose is to reject unsafe transactions -- an unrecognized variant is
+    /// treated as unsafe **by default** (rejected) rather than silently
+    /// passed through. A permissive `_ => Ok(())`-style wildcard would fail
+    /// *open*: any future command variant would be silently accepted here
+    /// even though this function has never been taught whether it can
+    /// reference the gas coin in some new way.
+    ///
+    /// # Pre-existing gaps, preserved exactly as they were before this
+    /// migration (flagged, not fixed -- see this migration stage's report)
+    ///
+    /// This mirrors the pre-migration logic's scan exactly, including three
+    /// cases it does *not* cover, each carried over unchanged rather than
+    /// tightened as part of this type-system migration:
+    /// - `Command::TransferObjects`'s destination `address` argument is not
+    ///   scanned (only the `objects` being transferred are).
+    /// - `Command::SplitCoins`'s `amounts` arguments are not scanned (only
+    ///   the `coin` being split is).
+    /// - `Command::Upgrade`'s `ticket` argument is not scanned at all.
+    fn check_transaction_validity(tx: &Transaction) -> anyhow::Result<()> {
+        let commands: &[Command] = match &tx.as_v1().kind {
+            TransactionKind::Programmable(pt) => &pt.commands,
+            // Non-programmable transaction kinds (system transactions) carry
+            // no commands and so can never reference the gas coin as an
+            // `Argument`; matches the pre-migration
+            // `TransactionKind::iter_commands()`, which yielded an empty
+            // iterator for every non-`ProgrammableTransaction` kind.
+            _ => &[],
+        };
         let mut all_args = vec![];
-        for command in tx_data.kind().iter_commands() {
+        for command in commands {
             match command {
                 Command::MoveCall(call) => {
                     all_args.extend(call.arguments.iter());
                 }
-                Command::TransferObjects(args, _) => {
-                    all_args.extend(args.iter());
+                Command::TransferObjects(t) => {
+                    all_args.extend(t.objects.iter());
                 }
-                Command::SplitCoins(arg, _) => {
-                    all_args.push(arg);
+                Command::SplitCoins(s) => {
+                    all_args.push(&s.coin);
                 }
-                Command::MergeCoins(arg, args) => {
-                    all_args.push(arg);
-                    all_args.extend(args.iter());
+                Command::MergeCoins(m) => {
+                    all_args.push(&m.coin);
+                    all_args.extend(m.coins_to_merge.iter());
                 }
-                Command::Publish(_, _) => {}
-                Command::MakeMoveVec(_, args) => {
-                    all_args.extend(args.iter());
+                Command::Publish(_) => {}
+                Command::MakeMoveVector(v) => {
+                    all_args.extend(v.elements.iter());
                 }
-                Command::Upgrade(_, _, _, _) => {}
+                Command::Upgrade(_) => {}
+                // Deny-by-default for any command variant this function does
+                // not (yet) recognize -- see the doc comment above.
+                _ => bail!(
+                    "Unrecognized transaction command variant; rejecting as unsafe by default"
+                ),
             };
         }
         let uses_gas = all_args
             .into_iter()
-            .any(|arg| matches!(*arg, Argument::GasCoin));
+            .any(|arg| matches!(*arg, Argument::Gas));
         if uses_gas {
             bail!("Gas coin can only be used to pay gas")
         };
@@ -351,18 +410,23 @@ impl GasStation {
         let gas_budget = NANOS_PER_IOTA / 10;
         let (_address, _reservation_id, gas_coins) =
             self.reserve_gas(gas_budget, Duration::from_secs(3)).await?;
-        let tx_kind = TransactionKind::ProgrammableTransaction(
-            ProgrammableTransactionBuilder::new().finish(),
-        );
+        let tx_kind = TransactionKind::Programmable(ProgrammableTransaction {
+            inputs: vec![],
+            commands: vec![],
+        });
         // Since we just want to check the health of the signer, we don't need to actually execute the transaction.
-        let tx_data = TransactionData::new_with_gas_coins(
-            tx_kind,
-            IotaAddress::default(),
-            gas_coins,
-            gas_budget,
-            0,
-        );
-        self.signer.sign_transaction(&tx_data).await?;
+        let tx = Transaction::V1(TransactionV1 {
+            kind: tx_kind,
+            sender: Address::ZERO,
+            gas_payment: GasPayment {
+                objects: gas_coins,
+                owner: Address::ZERO,
+                price: 0,
+                budget: gas_budget,
+            },
+            expiration: TransactionExpiration::None,
+        });
+        self.signer.sign_transaction(&tx).await?;
         Ok(())
     }
 
@@ -416,6 +480,7 @@ impl GasStationContainer {
         iota_client: IotaClient,
         gas_usage_daily_cap: u64,
         max_gas_budget: u64,
+        checkpoint_wait_ms: u64,
         metrics: Arc<GasStationCoreMetrics>,
         rescan_config: RescanGasObjectsTrigger,
     ) -> Self {
@@ -426,6 +491,7 @@ impl GasStationContainer {
             metrics,
             Arc::new(GasUsageCap::new(gas_usage_daily_cap)),
             max_gas_budget,
+            checkpoint_wait_ms,
             rescan_config,
         )
         .await;
@@ -444,7 +510,7 @@ impl GasStationContainer {
     }
 
     #[cfg(test)]
-    pub fn get_signer_address(&self) -> IotaAddress {
+    pub fn get_signer_address(&self) -> Address {
         self.inner.signer.get_address()
     }
 }

--- a/src/gas_station/gas_station_core.rs
+++ b/src/gas_station/gas_station_core.rs
@@ -258,7 +258,12 @@ impl GasStation {
         let cur_time = std::time::Instant::now();
         let effects = self
             .iota_client
-            .execute_transaction(signed_tx, 3, request_type, self.checkpoint_inclusion_timeout_ms)
+            .execute_transaction(
+                signed_tx,
+                3,
+                request_type,
+                self.checkpoint_inclusion_timeout_ms,
+            )
             .await?;
         debug!(?reservation_id, "Transaction executed");
         let elapsed = cur_time.elapsed().as_millis();

--- a/src/gas_station/gas_station_core.rs
+++ b/src/gas_station/gas_station_core.rs
@@ -27,13 +27,6 @@ use tracing::{debug, error, info, warn};
 
 use super::gas_usage_cap::GasUsageCap;
 
-/// The new SDK crates carry no protocol-constant equivalent of the old
-/// `iota_types::gas_coin::NANOS_PER_IOTA` (it was never part of the wire
-/// format, just a `u64` unit-conversion constant), so it's defined locally
-/// here instead of pulling in `iota_types` for a single constant. Re-exported
-/// (via `pub`) for the handful of other call sites in this migration stage's
-/// files (`gas_station/mod.rs`'s and `gas_station_initializer.rs`'s test
-/// modules) that used to import it from `iota_types::gas_coin`.
 pub const NANOS_PER_IOTA: u64 = 1_000_000_000;
 
 const EXPIRATION_JOB_INTERVAL: Duration = Duration::from_secs(1);

--- a/src/gas_station/mod.rs
+++ b/src/gas_station/mod.rs
@@ -7,20 +7,6 @@ pub mod gas_station_core;
 mod gas_usage_cap;
 pub(crate) mod rescan_trigger;
 
-// NOTE on this test module's migration status: `create_test_transaction` and
-// `start_gas_station` (both in `src/test_env.rs`) are out of this migration
-// stage's scope (`test_env.rs` is `#[cfg(test)]`-gated in `lib.rs`, so it is
-// not compiled -- and therefore not part of -- `cargo check --lib`'s error
-// count; it is a later stage's file to migrate). They still return the *old*
-// `iota_types::transaction::TransactionData`/`iota_types::signature::GenericSignature`
-// pair, which no longer matches `GasStation::execute_transaction`'s new
-// `iota_sdk_types::{Transaction, UserSignature}` parameters now that this
-// stage has migrated `gas_station_core.rs`. Every call site below that goes
-// through those two helpers is therefore left exactly as it was (their
-// signatures/types will only line up again once `test_env.rs` is migrated);
-// everything else in this module (imports, `NANOS_PER_IOTA`, effects
-// inspection, and the one test that builds its transaction locally without
-// `test_env.rs`'s help) has been fully migrated to the new types.
 #[cfg(test)]
 mod tests {
     use crate::gas_station::gas_station_core::NANOS_PER_IOTA;

--- a/src/gas_station/mod.rs
+++ b/src/gas_station/mod.rs
@@ -2,21 +2,35 @@
 // Modifications Copyright (c) 2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+pub(crate) mod effects_util;
 pub mod gas_station_core;
 mod gas_usage_cap;
 pub(crate) mod rescan_trigger;
 
+// NOTE on this test module's migration status: `create_test_transaction` and
+// `start_gas_station` (both in `src/test_env.rs`) are out of this migration
+// stage's scope (`test_env.rs` is `#[cfg(test)]`-gated in `lib.rs`, so it is
+// not compiled -- and therefore not part of -- `cargo check --lib`'s error
+// count; it is a later stage's file to migrate). They still return the *old*
+// `iota_types::transaction::TransactionData`/`iota_types::signature::GenericSignature`
+// pair, which no longer matches `GasStation::execute_transaction`'s new
+// `iota_sdk_types::{Transaction, UserSignature}` parameters now that this
+// stage has migrated `gas_station_core.rs`. Every call site below that goes
+// through those two helpers is therefore left exactly as it was (their
+// signatures/types will only line up again once `test_env.rs` is migrated);
+// everything else in this module (imports, `NANOS_PER_IOTA`, effects
+// inspection, and the one test that builds its transaction locally without
+// `test_env.rs`'s help) has been fully migrated to the new types.
 #[cfg(test)]
 mod tests {
+    use crate::gas_station::gas_station_core::NANOS_PER_IOTA;
     use crate::test_env::{create_test_transaction, start_gas_station};
-    use iota_json_rpc_types::IotaTransactionBlockEffectsAPI;
-    use iota_sdk_types::Intent;
-    use iota_sdk_types::IntentMessage;
-    use iota_types::{
-        crypto::{get_account_key_pair, Signature},
-        gas_coin::NANOS_PER_IOTA,
-        programmable_transaction_builder::ProgrammableTransactionBuilder,
-        transaction::{TransactionData, TransactionKind},
+    use iota_sdk_crypto::ed25519::Ed25519PrivateKey;
+    use iota_sdk_crypto::simple::SimpleKeypair;
+    use iota_sdk_crypto::IotaSigner;
+    use iota_sdk_types::{
+        GasPayment, ProgrammableTransaction, Transaction, TransactionExpiration, TransactionKind,
+        TransactionV1,
     };
     use std::time::Duration;
 
@@ -70,13 +84,13 @@ mod tests {
             .execute_transaction(reservation_id, tx_data, user_sig, None)
             .await
             .unwrap();
-        assert!(effects.status().is_ok());
+        assert!(effects.as_v1().status.is_success());
         assert_eq!(station.query_pool_available_coin_count().await, 1);
     }
 
     #[tokio::test]
     async fn test_invalid_transaction() {
-        telemetry_subscribers::init_for_testing();
+        crate::logging::init_for_testing();
         let (_test_cluster, container) =
             start_gas_station(vec![NANOS_PER_IOTA], NANOS_PER_IOTA, None).await;
         let station = container.get_gas_station_arc();
@@ -84,17 +98,30 @@ mod tests {
             .reserve_gas(NANOS_PER_IOTA, Duration::from_secs(10))
             .await
             .unwrap();
-        let (sender, keypair) = get_account_key_pair();
-        let tx_kind = TransactionKind::programmable(ProgrammableTransactionBuilder::new().finish());
-        let tx_data = TransactionData::new_with_gas_coins_allow_sponsor(
-            tx_kind, sender, gas_coins, 1, 1, sponsor,
-        );
-        let user_sig = Signature::new_secure(
-            &IntentMessage::new(Intent::iota_transaction(), &tx_data),
-            &keypair,
-        );
+        // A fresh, unrelated keypair standing in for a "user" that is not the
+        // sponsor -- this test builds its own transaction directly (rather
+        // than going through `test_env.rs`'s `create_test_transaction`), so
+        // it is fully self-contained and needed no bridging to old types.
+        let keypair = SimpleKeypair::from(Ed25519PrivateKey::generate(rand::rngs::OsRng));
+        let sender = keypair.public_key().derive_address();
+        let tx_kind = TransactionKind::Programmable(ProgrammableTransaction {
+            inputs: vec![],
+            commands: vec![],
+        });
+        let tx = Transaction::V1(TransactionV1 {
+            kind: tx_kind,
+            sender,
+            gas_payment: GasPayment {
+                objects: gas_coins,
+                owner: sponsor,
+                price: 1,
+                budget: 1,
+            },
+            expiration: TransactionExpiration::None,
+        });
+        let user_sig = keypair.sign_transaction(&tx).unwrap();
         let result = station
-            .execute_transaction(reservation_id, tx_data, user_sig.into(), None)
+            .execute_transaction(reservation_id, tx, user_sig, None)
             .await;
         println!("{:?}", result);
         assert!(result.is_err());
@@ -103,7 +130,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_coin_expiration() {
-        telemetry_subscribers::init_for_testing();
+        crate::logging::init_for_testing();
         let (test_cluster, container) =
             start_gas_station(vec![NANOS_PER_IOTA], NANOS_PER_IOTA, None).await;
         let station = container.get_gas_station_arc();
@@ -159,7 +186,7 @@ mod tests {
             .execute_transaction(reservation_id, tx_data, user_sig, None)
             .await
             .unwrap();
-        assert!(effects.status().is_ok());
+        assert!(effects.as_v1().status.is_success());
     }
 
     #[ignore]
@@ -194,7 +221,7 @@ mod tests {
             .execute_transaction(reservation_id1, tx_data, user_sig, None)
             .await
             .unwrap();
-        assert!(effects.status().is_ok());
+        assert!(effects.as_v1().status.is_success());
     }
 
     mod check_reserve_gas_request_validity {

--- a/src/gas_station_initializer.rs
+++ b/src/gas_station_initializer.rs
@@ -84,17 +84,6 @@ impl CoinSplitEnv {
         );
         let budget = self.gas_cost_per_object * split_count;
         let effects = loop {
-            // Built entirely offline (no client attached to the builder): this
-            // service already holds the full (id, version, digest) for every
-            // coin it owns, so there is no need to pay a `get_objects`
-            // round-trip per coin the way the online (client-attached) `gas()`
-            // overload would. This same coin is both the object being split
-            // (referenced as `unresolved::Argument::Gas`, the pre-resolution
-            // equivalent of the old `Argument::GasCoin`) *and* the sole gas
-            // payment object for the transaction -- a self-funded split,
-            // exactly like the pre-migration code's single
-            // `TransactionData::new_programmable(sponsor, vec![coin.object_ref], ...)`
-            // with sender/sponsor both defaulting to `self.sponsor_address`.
             let mut builder = TransactionBuilder::new(self.sponsor_address);
             builder
                 .move_call(ObjectId::FRAMEWORK, "pay", "divide_and_keep")

--- a/src/gas_station_initializer.rs
+++ b/src/gas_station_initializer.rs
@@ -130,13 +130,13 @@ impl CoinSplitEnv {
                     10,
                     None,
                     // `request_type: None` resolves to `WaitForEffectsCert`,
-                    // which never reads `checkpoint_wait_ms` -- see
+                    // which never reads `checkpoint_inclusion_timeout_ms` -- see
                     // `IotaClient::execute_transaction`. This value is
                     // therefore inert today; it's still threaded through
                     // (rather than a made-up placeholder like `0`) so it
                     // reads correctly if a future change ever does pass
                     // `Some(WaitForLocalExecution)` here.
-                    crate::config::DEFAULT_CHECKPOINT_WAIT_MS,
+                    crate::config::DEFAULT_CHECKPOINT_INCLUSION_TIMEOUT_MS,
                 )
                 .await;
             match result {

--- a/src/gas_station_initializer.rs
+++ b/src/gas_station_initializer.rs
@@ -119,12 +119,7 @@ impl CoinSplitEnv {
                     10,
                     None,
                     // `request_type: None` resolves to `WaitForEffectsCert`,
-                    // which never reads `checkpoint_inclusion_timeout_ms` -- see
-                    // `IotaClient::execute_transaction`. This value is
-                    // therefore inert today; it's still threaded through
-                    // (rather than a made-up placeholder like `0`) so it
-                    // reads correctly if a future change ever does pass
-                    // `Some(WaitForLocalExecution)` here.
+                    // which never reads `checkpoint_inclusion_timeout_ms`.
                     crate::config::DEFAULT_CHECKPOINT_INCLUSION_TIMEOUT_MS,
                 )
                 .await;

--- a/src/gas_station_initializer.rs
+++ b/src/gas_station_initializer.rs
@@ -4,19 +4,15 @@
 
 use crate::config::CoinInitConfig;
 use crate::consistency_check::{log_consistency_warnings, validate_consistency};
+use crate::gas_station::effects_util::{created_object_refs, gas_object_reference};
 use crate::iota_client::IotaClient;
 use crate::retry_forever;
 use crate::storage::Storage;
 use crate::tx_signer::TxSigner;
 use crate::types::GasCoin;
 use anyhow::bail;
-use iota_json_rpc_types::IotaTransactionBlockEffectsAPI;
-use iota_types::base_types::IotaAddress;
-use iota_types::coin::{PAY_MODULE_NAME, PAY_SPLIT_N_FUNC_NAME};
-use iota_types::gas_coin::GAS;
-use iota_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
-use iota_types::transaction::{Argument, Transaction, TransactionData};
-use iota_types::IOTA_FRAMEWORK_PACKAGE_ID;
+use iota_sdk_transaction_builder::{unresolved, TransactionBuilder};
+use iota_sdk_types::{Address, ObjectId, SignedTransaction, StructTag, TypeTag};
 use parking_lot::Mutex;
 use std::cmp::min;
 use std::collections::VecDeque;
@@ -44,7 +40,7 @@ struct CoinSplitEnv {
     target_init_coin_balance: u64,
     gas_cost_per_object: u64,
     signer: Arc<dyn TxSigner>,
-    sponsor_address: IotaAddress,
+    sponsor_address: Address,
     iota_client: IotaClient,
     task_queue: Arc<Mutex<VecDeque<JoinHandle<Vec<GasCoin>>>>>,
     total_coin_count: Arc<AtomicUsize>,
@@ -88,45 +84,67 @@ impl CoinSplitEnv {
         );
         let budget = self.gas_cost_per_object * split_count;
         let effects = loop {
-            let mut pt_builder = ProgrammableTransactionBuilder::new();
-            let pure_arg = pt_builder.pure(split_count).unwrap();
-            pt_builder.programmable_move_call(
-                IOTA_FRAMEWORK_PACKAGE_ID,
-                PAY_MODULE_NAME.into(),
-                PAY_SPLIT_N_FUNC_NAME.into(),
-                vec![GAS::type_tag()],
-                vec![Argument::GasCoin, pure_arg],
-            );
-            let pt = pt_builder.finish();
-            let tx_data = TransactionData::new_programmable(
-                self.sponsor_address,
-                vec![coin.object_ref],
-                pt,
-                budget,
-                rgp,
-            );
+            // Built entirely offline (no client attached to the builder): this
+            // service already holds the full (id, version, digest) for every
+            // coin it owns, so there is no need to pay a `get_objects`
+            // round-trip per coin the way the online (client-attached) `gas()`
+            // overload would. This same coin is both the object being split
+            // (referenced as `unresolved::Argument::Gas`, the pre-resolution
+            // equivalent of the old `Argument::GasCoin`) *and* the sole gas
+            // payment object for the transaction -- a self-funded split,
+            // exactly like the pre-migration code's single
+            // `TransactionData::new_programmable(sponsor, vec![coin.object_ref], ...)`
+            // with sender/sponsor both defaulting to `self.sponsor_address`.
+            let mut builder = TransactionBuilder::new(self.sponsor_address);
+            builder
+                .move_call(ObjectId::FRAMEWORK, "pay", "divide_and_keep")
+                .type_tags([TypeTag::from(StructTag::new_gas())])
+                .arguments((unresolved::Argument::Gas, split_count));
+            builder
+                .gas([coin.object_ref])
+                .gas_price(rgp)
+                .gas_budget(budget);
+            let tx = builder
+                .finish()
+                .expect("coin-split transaction is built entirely offline and always well-formed");
+
             let sig = retry_forever!(async {
                 self.signer
-                    .sign_transaction(&tx_data)
+                    .sign_transaction(&tx)
                     .await
                     .tap_err(|err| error!("Failed to sign transaction: {:?}", err))
             })
             .unwrap();
-            let tx = Transaction::from_generic_sig_data(tx_data, vec![sig]);
             debug!(
                 "Sending transaction for execution. Tx digest: {:?}",
                 tx.digest()
             );
+            let signed_tx = SignedTransaction {
+                transaction: tx,
+                signatures: vec![sig],
+            };
             let result = self
                 .iota_client
-                .execute_transaction(tx.clone(), 10, None)
+                .execute_transaction(
+                    signed_tx.clone(),
+                    10,
+                    None,
+                    // `request_type: None` resolves to `WaitForEffectsCert`,
+                    // which never reads `checkpoint_wait_ms` -- see
+                    // `IotaClient::execute_transaction`. This value is
+                    // therefore inert today; it's still threaded through
+                    // (rather than a made-up placeholder like `0`) so it
+                    // reads correctly if a future change ever does pass
+                    // `Some(WaitForLocalExecution)` here.
+                    crate::config::DEFAULT_CHECKPOINT_WAIT_MS,
+                )
                 .await;
             match result {
                 Ok(effects) => {
                     assert!(
-                        effects.status().is_ok(),
+                        effects.as_v1().status.is_success(),
                         "Transaction failed. This should never happen. Tx: {:?}, effects: {:?}",
-                        tx,
+                        signed_tx,
                         effects
                     );
                     break effects;
@@ -135,7 +153,7 @@ impl CoinSplitEnv {
                     error!("Failed to execute transaction: {:?}", e);
                     coin = self
                         .iota_client
-                        .get_latest_gas_objects([coin.object_ref.0])
+                        .get_latest_gas_objects([coin.object_ref.object_id])
                         .await
                         .into_iter()
                         .next()
@@ -148,16 +166,16 @@ impl CoinSplitEnv {
         };
         let mut result = vec![];
         let new_coin_balance = (coin.balance - budget) / split_count;
-        for created in effects.created() {
+        for object_ref in created_object_refs(&effects) {
             result.extend(self.enqueue_task(GasCoin {
-                object_ref: created.reference.to_object_ref(),
+                object_ref,
                 balance: new_coin_balance,
             }));
         }
         let remaining_coin_balance = (coin.balance - new_coin_balance * (split_count - 1)) as i64
-            - effects.gas_cost_summary().net_gas_usage();
+            - effects.as_v1().gas_cost_summary.net_gas_usage();
         result.extend(self.enqueue_task(GasCoin {
-            object_ref: effects.gas_object().reference.to_object_ref(),
+            object_ref: gas_object_reference(&effects),
             balance: remaining_coin_balance as u64,
         }));
         self.increment_total_coin_count_by(result.len() - 1);
@@ -394,7 +412,7 @@ impl GasStationInitializer {
         let total_coin_count = Arc::new(AtomicUsize::new(coins.len()));
         let rgp = iota_client.get_reference_gas_price().await;
         let gas_cost_per_object = iota_client
-            .calibrate_gas_cost_per_object(sponsor_address, &coins[0])
+            .calibrate_gas_cost_per_object(sponsor_address, &coins[0], rgp)
             .await;
         info!("Calibrated gas cost per object: {:?}", gas_cost_per_object);
 
@@ -472,7 +490,7 @@ impl GasStationInitializer {
     async fn perform_consistency_check(
         iota_client: &IotaClient,
         storage: &Arc<dyn Storage>,
-        sponsor_address: IotaAddress,
+        sponsor_address: Address,
     ) {
         info!("Performing quick consistency check");
         let registry_coin_count = match storage.get_available_coin_count().await {
@@ -525,27 +543,34 @@ impl GasStationInitializer {
     }
 }
 
+// `start_iota_cluster` (in `src/test_env.rs`) and `IotaClient::new`'s
+// now-fallible, gRPC-only constructor were migrated together in the
+// `test_env.rs` migration stage: `cluster.fullnode_handle.rpc_url` (the old
+// JSON-RPC URL) was replaced with `cluster.grpc_url()` throughout this
+// module, since `IotaClient` now speaks gRPC exclusively.
 #[cfg(test)]
 mod tests {
     use crate::config::CoinInitConfig;
+    use crate::gas_station::gas_station_core::NANOS_PER_IOTA;
     use crate::gas_station_initializer::{
         GasStationInitializer, NEW_COIN_BALANCE_FACTOR_THRESHOLD,
     };
     use crate::iota_client::IotaClient;
     use crate::storage::connect_storage_for_testing;
     use crate::test_env::start_iota_cluster;
-    use iota_types::gas_coin::NANOS_PER_IOTA;
     use tokio::sync::mpsc::channel;
 
     // TODO: Add more accurate tests.
 
     #[tokio::test]
     async fn test_basic_init_flow() {
-        telemetry_subscribers::init_for_testing();
+        crate::logging::init_for_testing();
         let (cluster, signer) = start_iota_cluster(vec![1000 * NANOS_PER_IOTA]).await;
-        let fullnode_url = cluster.fullnode_handle.rpc_url;
+        let fullnode_url = cluster.grpc_url();
         let storage = connect_storage_for_testing(signer.get_address()).await;
-        let iota_client = IotaClient::new(&fullnode_url, None).await;
+        let iota_client = IotaClient::new(&fullnode_url, None)
+            .await
+            .expect("Failed to connect to fullnode gRPC endpoint");
         let (_rescan_trigger_sender, rescan_trigger_receiver) = channel::<()>(1024);
         let _init_task = GasStationInitializer::start(
             iota_client,
@@ -565,12 +590,14 @@ mod tests {
 
     #[tokio::test]
     async fn test_init_non_even_split() {
-        telemetry_subscribers::init_for_testing();
+        crate::logging::init_for_testing();
         let (cluster, signer) = start_iota_cluster(vec![10000000 * NANOS_PER_IOTA]).await;
-        let fullnode_url = cluster.fullnode_handle.rpc_url;
+        let fullnode_url = cluster.grpc_url();
         let storage = connect_storage_for_testing(signer.get_address()).await;
         let target_init_balance = 12345 * NANOS_PER_IOTA;
-        let iota_client = IotaClient::new(&fullnode_url, None).await;
+        let iota_client = IotaClient::new(&fullnode_url, None)
+            .await
+            .expect("Failed to connect to fullnode gRPC endpoint");
         let (_rescan_trigger_sender, rescan_trigger_receiver) = channel::<()>(1024);
         let _init_task = GasStationInitializer::start(
             iota_client,
@@ -590,12 +617,14 @@ mod tests {
 
     #[tokio::test]
     async fn test_add_new_funds_to_pool() {
-        telemetry_subscribers::init_for_testing();
+        crate::logging::init_for_testing();
         let (cluster, signer) = start_iota_cluster(vec![1000 * NANOS_PER_IOTA]).await;
         let sponsor = signer.get_address();
-        let fullnode_url = cluster.fullnode_handle.rpc_url.clone();
+        let fullnode_url = cluster.grpc_url();
         let storage = connect_storage_for_testing(signer.get_address()).await;
-        let iota_client = IotaClient::new(&fullnode_url, None).await;
+        let iota_client = IotaClient::new(&fullnode_url, None)
+            .await
+            .expect("Failed to connect to fullnode gRPC endpoint");
         let (_rescan_trigger_sender, rescan_trigger_receiver) = channel::<()>(1024);
         let _init_task = GasStationInitializer::start(
             iota_client,
@@ -650,12 +679,14 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_aggregate_coin_stats() {
-        telemetry_subscribers::init_for_testing();
+        crate::logging::init_for_testing();
         let initial_balance = 1000 * NANOS_PER_IOTA;
         let (cluster, signer) = start_iota_cluster(vec![initial_balance]).await;
         let sponsor = signer.get_address();
-        let fullnode_url = cluster.fullnode_handle.rpc_url;
-        let iota_client = IotaClient::new(&fullnode_url, None).await;
+        let fullnode_url = cluster.grpc_url();
+        let iota_client = IotaClient::new(&fullnode_url, None)
+            .await
+            .expect("Failed to connect to fullnode gRPC endpoint");
 
         // Get aggregate stats from network
         let (coin_count, total_balance) = iota_client
@@ -685,11 +716,13 @@ mod tests {
 
     #[tokio::test]
     async fn test_ignore_locks_bypasses_maintenance_lock() {
-        telemetry_subscribers::init_for_testing();
+        crate::logging::init_for_testing();
         let (cluster, signer) = start_iota_cluster(vec![1000 * NANOS_PER_IOTA]).await;
-        let fullnode_url = cluster.fullnode_handle.rpc_url;
+        let fullnode_url = cluster.grpc_url();
         let storage = connect_storage_for_testing(signer.get_address()).await;
-        let iota_client = IotaClient::new(&fullnode_url, None).await;
+        let iota_client = IotaClient::new(&fullnode_url, None)
+            .await
+            .expect("Failed to connect to fullnode gRPC endpoint");
 
         let lock_acquired = storage.acquire_maintenance_lock(300).await.unwrap();
         assert!(lock_acquired, "Should be able to acquire maintenance lock");
@@ -726,11 +759,13 @@ mod tests {
         expected = "Another instance is already performing maintenance. Please wait for it to complete or use the --ignore-locks flag to force a full rescan."
     )]
     async fn test_maintenance_lock_blocks_without_ignore_locks() {
-        telemetry_subscribers::init_for_testing();
+        crate::logging::init_for_testing();
         let (cluster, signer) = start_iota_cluster(vec![1000 * NANOS_PER_IOTA]).await;
-        let fullnode_url = cluster.fullnode_handle.rpc_url;
+        let fullnode_url = cluster.grpc_url();
         let storage = connect_storage_for_testing(signer.get_address()).await;
-        let iota_client = IotaClient::new(&fullnode_url, None).await;
+        let iota_client = IotaClient::new(&fullnode_url, None)
+            .await
+            .expect("Failed to connect to fullnode gRPC endpoint");
 
         let lock_acquired = storage.acquire_maintenance_lock(300).await.unwrap();
         assert!(lock_acquired, "Should be able to acquire maintenance lock");
@@ -753,11 +788,13 @@ mod tests {
 
     #[tokio::test]
     async fn test_ignore_locks_bypasses_init_lock() {
-        telemetry_subscribers::init_for_testing();
+        crate::logging::init_for_testing();
         let (cluster, signer) = start_iota_cluster(vec![1000 * NANOS_PER_IOTA]).await;
-        let fullnode_url = cluster.fullnode_handle.rpc_url;
+        let fullnode_url = cluster.grpc_url();
         let storage = connect_storage_for_testing(signer.get_address()).await;
-        let iota_client = IotaClient::new(&fullnode_url, None).await;
+        let iota_client = IotaClient::new(&fullnode_url, None)
+            .await
+            .expect("Failed to connect to fullnode gRPC endpoint");
 
         let lock_acquired = storage.acquire_init_lock(300).await.unwrap();
         assert!(lock_acquired, "Should be able to acquire init lock");
@@ -791,11 +828,13 @@ mod tests {
     #[tokio::test]
     #[should_panic(expected = "Initial coin initialization failed")]
     async fn test_init_lock_blocks_without_ignore_locks() {
-        telemetry_subscribers::init_for_testing();
+        crate::logging::init_for_testing();
         let (cluster, signer) = start_iota_cluster(vec![1000 * NANOS_PER_IOTA]).await;
-        let fullnode_url = cluster.fullnode_handle.rpc_url;
+        let fullnode_url = cluster.grpc_url();
         let storage = connect_storage_for_testing(signer.get_address()).await;
-        let iota_client = IotaClient::new(&fullnode_url, None).await;
+        let iota_client = IotaClient::new(&fullnode_url, None)
+            .await
+            .expect("Failed to connect to fullnode gRPC endpoint");
 
         let lock_acquired = storage.acquire_init_lock(300).await.unwrap();
         assert!(lock_acquired, "Should be able to acquire init lock");

--- a/src/gas_station_initializer.rs
+++ b/src/gas_station_initializer.rs
@@ -196,7 +196,9 @@ pub struct GasStationInitializer {
 
 impl Drop for GasStationInitializer {
     fn drop(&mut self) {
-        self.cancel_sender.take().unwrap().send(()).unwrap();
+        // Best-effort: the send fails only if the task has already exited
+        // (e.g. it panicked), in which case there is nothing left to cancel.
+        let _ = self.cancel_sender.take().unwrap().send(());
     }
 }
 
@@ -385,6 +387,19 @@ impl GasStationInitializer {
         let coins = iota_client
             .get_all_owned_iota_coins_above_balance_threshold(sponsor_address, balance_threshold)
             .await;
+        // `list_owned_objects` is index-backed and can lag behind execution, so
+        // the scan may return coins at versions (and balances) that are already
+        // outdated -- e.g. a coin this task split during the previous refresh
+        // cycle. Re-resolve every candidate to its live state with a point read
+        // and re-apply the threshold, so calibration and splitting never
+        // operate on stale object refs.
+        let coins: Vec<GasCoin> = iota_client
+            .get_latest_gas_objects(coins.iter().map(|coin| coin.object_ref.object_id))
+            .await
+            .into_values()
+            .flatten()
+            .filter(|coin| coin.balance >= balance_threshold)
+            .collect();
         if coins.is_empty() {
             info!(
                 "No coins with balance above {} found. Skipping new coin initialization",

--- a/src/gas_station_initializer.rs
+++ b/src/gas_station_initializer.rs
@@ -527,11 +527,6 @@ impl GasStationInitializer {
     }
 }
 
-// `start_iota_cluster` (in `src/test_env.rs`) and `IotaClient::new`'s
-// now-fallible, gRPC-only constructor were migrated together in the
-// `test_env.rs` migration stage: `cluster.fullnode_handle.rpc_url` (the old
-// JSON-RPC URL) was replaced with `cluster.grpc_url()` throughout this
-// module, since `IotaClient` now speaks gRPC exclusively.
 #[cfg(test)]
 mod tests {
     use crate::config::CoinInitConfig;

--- a/src/iota_client.rs
+++ b/src/iota_client.rs
@@ -8,6 +8,7 @@ use crate::rpc::rpc_types::ExecuteTransactionRequestType;
 use crate::types::GasCoin;
 use crate::{retry_forever, retry_with_max_attempts};
 use iota_sdk_grpc_client::api::Error as GrpcError;
+use iota_sdk_grpc_client::read_mask_fields::{SimulateExecutedTransactionField, TransactionField};
 use iota_sdk_grpc_client::{Client, HeadersInterceptor, ReadMask};
 use iota_sdk_grpc_types::v1::object::Object;
 use iota_sdk_transaction_builder::TransactionBuilder;
@@ -281,7 +282,7 @@ impl IotaClient {
                     .simulate_transaction(
                         tx.clone(),
                         true,
-                        Some(ReadMask::from(&["executed_transaction.effects"])),
+                        Some(ReadMask::from(&[SimulateExecutedTransactionField::EFFECTS])),
                     )
                     .await
             })
@@ -325,7 +326,10 @@ impl IotaClient {
             };
         // Narrow read mask: this service only ever reads the digest (for
         // logging) and the effects.
-        let mask = ReadMask::from(&["transaction.digest", "effects"]);
+        let mask = ReadMask::from(&[
+            TransactionField::TRANSACTION_DIGEST,
+            TransactionField::EFFECTS,
+        ]);
         let outcome = retry_with_max_attempts!(
             async {
                 attempt(async {

--- a/src/iota_client.rs
+++ b/src/iota_client.rs
@@ -56,9 +56,7 @@ impl IotaClient {
     /// here means the URL/config itself was unusable (bad scheme, HTTPS
     /// requested without the `tls-ring` feature, ...) -- not that the
     /// fullnode was unreachable, which only ever surfaces later from an
-    /// actual RPC call. Returning a `Result` instead of panicking lets the
-    /// caller (`src/command.rs`) report that distinctly, instead of the old
-    /// `IotaClientBuilder::build().unwrap()` panic-on-construct behavior.
+    /// actual RPC call.
     pub async fn new(
         fullnode_url: &str,
         basic_auth: Option<(String, String)>,

--- a/src/iota_client.rs
+++ b/src/iota_client.rs
@@ -337,14 +337,7 @@ impl IotaClient {
                 ExecuteTransactionRequestType::WaitForLocalExecution => Some(checkpoint_wait_ms),
             };
         // Narrow read mask: this service only ever reads the digest (for
-        // logging) and the effects. The default mask also pulls
-        // events/input_objects/output_objects, which are never used here;
-        // balance_changes/object_changes aren't in any default mask and are
-        // deliberately not requested either way -- we could not
-        // independently verify (from the ground-truth source/docs available
-        // here) the claim that requesting them can turn a pruned-object
-        // lookup into a hard `FAILED_PRECONDITION`, but not requesting them
-        // is the safe default regardless, since this service never reads them.
+        // logging) and the effects.
         let mask = ReadMask::from(&["transaction.digest", "effects"]);
         let outcome = retry_with_max_attempts!(
             async {

--- a/src/iota_client.rs
+++ b/src/iota_client.rs
@@ -305,7 +305,7 @@ impl IotaClient {
 
     /// Executes a fully-signed transaction.
     ///
-    /// `checkpoint_wait_ms` is only used when `request_type` is
+    /// `checkpoint_inclusion_timeout_ms` is only used when `request_type` is
     /// `WaitForLocalExecution`; it maps to the gRPC call's
     /// `checkpoint_inclusion_timeout_ms`, which asks the server to wait up to
     /// that long for checkpoint inclusion before responding.

--- a/src/iota_client.rs
+++ b/src/iota_client.rs
@@ -427,8 +427,7 @@ fn gas_used_from_effects(effects: &TransactionEffects) -> u64 {
 /// never succeed no matter how many times they're retried, so letting
 /// `retry_forever!` spin on them would just be a silent hang with extra
 /// network chatter; everything else (`Unavailable`, `DeadlineExceeded`,
-/// transport resets, ...) is assumed transient, matching the old JSON-RPC
-/// client's blanket-retry behavior.
+/// transport resets, ...) is assumed transient.
 fn is_transient(err: &GrpcError) -> bool {
     let code = match err {
         GrpcError::Grpc(status) => status.code(),

--- a/src/iota_client.rs
+++ b/src/iota_client.rs
@@ -3,15 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! gRPC client wrapper around `iota-sdk-grpc-client`.
-//!
-//! This replaces the old JSON-RPC (`iota_sdk::IotaClient`) wrapper. The
-//! underlying `iota_sdk_grpc_client::Client` has no retry/backoff or
-//! per-request timeout of its own (only a one-time connect timeout and
-//! HTTP/2 keepalive, see `Client::new`), so every network call here stays
-//! wrapped in this crate's own `retry_forever!`/`retry_with_max_attempts!`
-//! macros (`src/errors.rs`), same as the old client -- see `attempt` and
-//! `is_transient` below for how a per-attempt timeout and a retryability
-//! classifier are layered on top of those macros without changing them.
 
 use crate::rpc::rpc_types::ExecuteTransactionRequestType;
 use crate::types::GasCoin;

--- a/src/iota_client.rs
+++ b/src/iota_client.rs
@@ -326,7 +326,9 @@ impl IotaClient {
         let checkpoint_inclusion_timeout_ms =
             match request_type.unwrap_or(ExecuteTransactionRequestType::WaitForEffectsCert) {
                 ExecuteTransactionRequestType::WaitForEffectsCert => None,
-                ExecuteTransactionRequestType::WaitForLocalExecution => Some(checkpoint_inclusion_timeout_ms),
+                ExecuteTransactionRequestType::WaitForLocalExecution => {
+                    Some(checkpoint_inclusion_timeout_ms)
+                }
             };
         // Narrow read mask: this service only ever reads the digest (for
         // logging) and the effects.

--- a/src/iota_client.rs
+++ b/src/iota_client.rs
@@ -247,10 +247,8 @@ impl IotaClient {
     /// `gas_payment.objects` empty, the authority fabricates its own mock
     /// gas coin owned by `gas_payment.owner`, and with `gas_payment.budget ==
     /// 0` under skipped checks the server rewrites the budget to the
-    /// protocol max and reports back the actual cost incurred (verified
-    /// against `crates/iota-grpc-server/src/**/simulate.rs` and
-    /// `crates/iota-core/src/authority.rs` on the `iotaledger/iota` monorepo
-    /// `develop` branch). `gas_coin` itself is a real, separate object: it's
+    /// protocol max and reports back the actual cost incurred.
+    /// `gas_coin` itself is a real, separate object: it's
     /// the *input* being split by the move call, not the fee-paying gas
     /// object, so its object reference must be real and correct.
     pub async fn calibrate_gas_cost_per_object(

--- a/src/iota_client.rs
+++ b/src/iota_client.rs
@@ -183,24 +183,16 @@ impl IotaClient {
         result
     }
 
-    /// Fetches one chunk via a single batched `get_objects` call when possible.
+    /// Fetches one chunk via a single batched `get_objects` call.
     ///
-    /// `get_objects` guarantees response order matches the request order
-    /// (`iota-sdk-grpc-client`'s `api/ledger/objects.rs`: "Server guarantees
-    /// results are returned in request order"), so no client-side
-    /// reordering is needed. It also, however, fails the *entire* batch as
-    /// soon as any single requested object comes back with a per-item error
-    /// -- including the common, expected case of "this object no longer
-    /// exists" (that same module's `get_objects` drains the response stream
-    /// via `collect_stream`, which propagates the first per-item error with
-    /// `?`, discarding every item collected so far). A missing gas coin is
-    /// routine here (coins get consumed/smashed during execution), so we
-    /// fall back to resolving the chunk one object at a time only when the
-    /// batch call fails, keeping the common (nothing missing) case batched.
-    ///
-    /// TODO: the SDK fixed this in iotaledger/iota-rust-sdk#1292 (`get_objects`
-    /// now returns one result per request instead of failing the whole batch);
-    /// once this crate's pinned rev includes it, drop the one-by-one fallback.
+    /// `get_objects` returns one result per requested ref, in request order
+    /// (`iota-sdk-grpc-client`'s `api/ledger/objects.rs`: results line up
+    /// with the requested refs, and a count mismatch fails the call), so no
+    /// client-side reordering is needed. A missing gas coin is routine here
+    /// (coins get consumed/smashed during execution) and surfaces as a
+    /// per-item `NOT_FOUND` in that ref's slot only, leaving the rest of the
+    /// batch intact -- it maps to `None`, like any object that isn't a
+    /// recognizable gas coin.
     async fn fetch_gas_object_chunk(
         &self,
         chunk: &[ObjectId],
@@ -210,36 +202,19 @@ impl IotaClient {
         let outcome = retry_forever!(async {
             attempt(async { self.client.get_objects(&refs, None).await }).await
         });
-        match into_anyhow(outcome) {
-            Ok(envelope) => {
-                let objects = envelope.into_inner();
-                debug_assert_eq!(objects.len(), chunk.len());
-                for (id, object) in chunk.iter().zip(objects.iter()) {
-                    result.insert(*id, coin_from_object(object));
+        let objects = into_anyhow(outcome)
+            .unwrap_or_else(|err| panic!("failed to fetch gas objects: {err}"))
+            .into_inner();
+        for (id, object) in chunk.iter().zip(objects) {
+            let coin = match object {
+                Ok(object) => coin_from_object(&object),
+                Err(err) if err.is_not_found() => {
+                    debug!("Object no longer exists: {:?}", id);
+                    None
                 }
-            }
-            Err(_) => {
-                for id in chunk {
-                    result.insert(*id, self.fetch_gas_object_one(*id).await);
-                }
-            }
-        }
-    }
-
-    /// Resolves a single object, treating "not found" as `None` (the object
-    /// no longer exists) rather than a failure.
-    async fn fetch_gas_object_one(&self, id: ObjectId) -> Option<GasCoin> {
-        let outcome = retry_forever!(async {
-            attempt(async { self.client.get_objects(&[(id, None)], None).await }).await
-        });
-        match outcome {
-            Ok(Ok(envelope)) => envelope.into_inner().first().and_then(coin_from_object),
-            Ok(Err(err)) if is_not_found(&err) => {
-                debug!("Object no longer exists: {:?}", id);
-                None
-            }
-            Ok(Err(err)) => panic!("failed to fetch gas object {id}: {err}"),
-            Err(err) => panic!("failed to fetch gas object {id}: exhausted retries: {err}"),
+                Err(err) => panic!("failed to fetch gas object {id}: {err}"),
+            };
+            result.insert(*id, coin);
         }
     }
 
@@ -373,11 +348,16 @@ impl IotaClient {
     #[cfg(test)]
     pub async fn wait_for_object(&self, obj_ref: iota_sdk_types::ObjectReference) {
         loop {
-            let found = self
+            // A missing object is a per-item error inside an `Ok` envelope,
+            // so the call-level `Result` alone doesn't mean "found".
+            let found = match self
                 .client
                 .get_objects(&[(obj_ref.object_id, Some(obj_ref.version))], None)
                 .await
-                .is_ok();
+            {
+                Ok(envelope) => envelope.into_inner().iter().all(|item| item.is_ok()),
+                Err(_) => false,
+            };
             if found {
                 break;
             }
@@ -431,15 +411,6 @@ fn is_transient(err: &GrpcError) -> bool {
             | tonic::Code::Unauthenticated
             | tonic::Code::FailedPrecondition
             | tonic::Code::Unimplemented
-    )
-}
-
-/// `err` is specifically "the requested object does not exist / this version
-/// does not exist", as opposed to any other server-side per-item error.
-fn is_not_found(err: &GrpcError) -> bool {
-    matches!(
-        err,
-        GrpcError::Server(status) if tonic::Code::from_i32(status.code) == tonic::Code::NotFound
     )
 }
 

--- a/src/iota_client.rs
+++ b/src/iota_client.rs
@@ -402,8 +402,7 @@ impl IotaClient {
 }
 
 /// Builds a [`GasCoin`] from a `get_objects`/`list_owned_objects` result
-/// object, or `None` if it isn't a (recognizable) IOTA gas coin. Mirrors the
-/// old JSON-RPC client's `try_get_iota_coin_balance`.
+/// object, or `None` if it isn't a (recognizable) IOTA gas coin.
 fn coin_from_object(object: &Object) -> Option<GasCoin> {
     let object_ref = object.object_reference().ok()?;
     let sdk_object = object.object().ok()?;

--- a/src/iota_client.rs
+++ b/src/iota_client.rs
@@ -197,6 +197,10 @@ impl IotaClient {
     /// routine here (coins get consumed/smashed during execution), so we
     /// fall back to resolving the chunk one object at a time only when the
     /// batch call fails, keeping the common (nothing missing) case batched.
+    ///
+    /// TODO: the SDK fixed this in iotaledger/iota-rust-sdk#1292 (`get_objects`
+    /// now returns one result per request instead of failing the whole batch);
+    /// once this crate's pinned rev includes it, drop the one-by-one fallback.
     async fn fetch_gas_object_chunk(
         &self,
         chunk: &[ObjectId],

--- a/src/iota_client.rs
+++ b/src/iota_client.rs
@@ -2,49 +2,90 @@
 // Modifications Copyright (c) 2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+//! gRPC client wrapper around `iota-sdk-grpc-client`.
+//!
+//! This replaces the old JSON-RPC (`iota_sdk::IotaClient`) wrapper. The
+//! underlying `iota_sdk_grpc_client::Client` has no retry/backoff or
+//! per-request timeout of its own (only a one-time connect timeout and
+//! HTTP/2 keepalive, see `Client::new`), so every network call here stays
+//! wrapped in this crate's own `retry_forever!`/`retry_with_max_attempts!`
+//! macros (`src/errors.rs`), same as the old client -- see `attempt` and
+//! `is_transient` below for how a per-attempt timeout and a retryability
+//! classifier are layered on top of those macros without changing them.
+
 use crate::rpc::rpc_types::ExecuteTransactionRequestType;
 use crate::types::GasCoin;
 use crate::{retry_forever, retry_with_max_attempts};
-use futures_util::stream::FuturesUnordered;
-use futures_util::StreamExt;
-use iota_json_rpc_types::IotaTransactionBlockEffectsAPI;
-use iota_json_rpc_types::{
-    IotaData, IotaObjectDataOptions, IotaObjectResponse, IotaTransactionBlockEffects,
-    IotaTransactionBlockResponseOptions,
+use iota_sdk_grpc_client::api::Error as GrpcError;
+use iota_sdk_grpc_client::{Client, HeadersInterceptor, ReadMask};
+use iota_sdk_grpc_types::v1::object::Object;
+use iota_sdk_transaction_builder::TransactionBuilder;
+use iota_sdk_types::{
+    Address, Coin, Identifier, Input, ObjectId, SignedTransaction, StructTag, TransactionEffects,
+    TypeTag, Version,
 };
-use iota_sdk::IotaClientBuilder;
-use iota_types::base_types::{IotaAddress, ObjectID, ObjectRef};
-use iota_types::coin::{PAY_MODULE_NAME, PAY_SPLIT_N_FUNC_NAME};
-use iota_types::gas_coin::GAS;
-use iota_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
-use iota_types::transaction::{
-    Argument, ObjectArg, ProgrammableTransaction, Transaction, TransactionKind,
-};
-use iota_types::IOTA_FRAMEWORK_PACKAGE_ID;
-use itertools::Itertools;
 use std::collections::HashMap;
 use std::time::Duration;
-use tap::TapFallible;
 use tracing::{debug, info};
+
+/// Per-attempt timeout for a single gRPC call. Without this, a stalled
+/// stream (e.g. a fullnode that accepted the connection but never responds)
+/// would block a single `retry_forever!`/`retry_with_max_attempts!` attempt
+/// forever, instead of ever cycling through the retry strategy -- see
+/// `attempt` below.
+const GRPC_CALL_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Matches the server's own default (`GrpcApiConfig::max_message_size_bytes`
+/// in `iota-config`'s `node.rs`, 128 MiB) so large batched responses -- e.g.
+/// a 1000-coin `list_owned_objects` page carrying full object BCS -- are not
+/// truncated by tonic's 4 MiB default decode limit.
+const MAX_DECODING_MESSAGE_SIZE_BYTES: usize = 128 * 1024 * 1024;
+
+/// The server's own maximum page size for `list_owned_objects` (see
+/// `MAX_PAGE_SIZE` in `iota-grpc-server`'s `state_service/list_owned_objects.rs`).
+/// Strictly better than the old JSON-RPC client's default page size of 50.
+const COIN_LIST_PAGE_SIZE: u32 = 1000;
+
+/// Chunk size for batched `get_objects` calls. `get_objects` is a single
+/// (non-paginated) call that streams its response, so this isn't required
+/// by the API the way `COIN_LIST_PAGE_SIZE` is -- it just bounds how many
+/// objects (and how much BCS) go into one request/response pair.
+const OBJECT_FETCH_CHUNK_SIZE: usize = 1000;
 
 #[derive(Clone)]
 pub struct IotaClient {
-    iota_client: iota_sdk::IotaClient,
+    client: Client,
 }
 
 impl IotaClient {
-    pub async fn new(fullnode_url: &str, basic_auth: Option<(String, String)>) -> Self {
-        let mut iota_client_builder = IotaClientBuilder::default().max_concurrent_requests(100000);
+    /// Connects to the fullnode's gRPC endpoint.
+    ///
+    /// The underlying channel connects lazily (`Client::new` never touches
+    /// the network, see `iota_sdk_grpc_client::Client::new`), so failure
+    /// here means the URL/config itself was unusable (bad scheme, HTTPS
+    /// requested without the `tls-ring` feature, ...) -- not that the
+    /// fullnode was unreachable, which only ever surfaces later from an
+    /// actual RPC call. Returning a `Result` instead of panicking lets the
+    /// caller (`src/command.rs`) report that distinctly, instead of the old
+    /// `IotaClientBuilder::build().unwrap()` panic-on-construct behavior.
+    pub async fn new(
+        fullnode_url: &str,
+        basic_auth: Option<(String, String)>,
+    ) -> anyhow::Result<Self> {
+        let mut headers = HeadersInterceptor::new();
         if let Some((username, password)) = basic_auth {
-            iota_client_builder = iota_client_builder.basic_auth(username, password);
+            headers.basic_auth(username, Some(password));
         }
-        let iota_client = iota_client_builder.build(fullnode_url).await.unwrap();
-        Self { iota_client }
+        let client = Client::new(fullnode_url)
+            .map_err(|err| anyhow::anyhow!("invalid fullnode gRPC url {fullnode_url:?}: {err}"))?
+            .with_headers(headers)
+            .with_max_decoding_message_size(MAX_DECODING_MESSAGE_SIZE_BYTES);
+        Ok(Self { client })
     }
 
     pub async fn get_all_owned_iota_coins_above_balance_threshold(
         &self,
-        address: IotaAddress,
+        address: Address,
         balance_threshold: u64,
     ) -> Vec<GasCoin> {
         info!(
@@ -54,26 +95,33 @@ impl IotaClient {
         let mut cursor = None;
         let mut coins = Vec::new();
         loop {
-            let page = retry_forever!(async {
-                self.iota_client
-                    .coin_read_api()
-                    .get_coins(address, None, cursor, None)
-                    .await
-                    .tap_err(|err| debug!("Failed to get owned gas coins: {:?}", err))
-            })
-            .unwrap();
-            for coin in page.data {
-                if coin.balance >= balance_threshold {
-                    coins.push(GasCoin {
-                        object_ref: coin.object_ref(),
-                        balance: coin.balance,
-                    });
+            let outcome = retry_forever!(async {
+                attempt(async {
+                    self.client
+                        .list_owned_objects(
+                            address,
+                            Some(StructTag::new_gas_coin()),
+                            Some(COIN_LIST_PAGE_SIZE),
+                            cursor.clone(),
+                            None,
+                        )
+                        .await
+                })
+                .await
+            });
+            let page = into_anyhow(outcome)
+                .unwrap_or_else(|err| panic!("failed to list owned gas coins for {address}: {err}"))
+                .into_inner();
+            for object in &page.items {
+                if let Some(coin) = coin_from_object(object) {
+                    if coin.balance >= balance_threshold {
+                        coins.push(coin);
+                    }
                 }
             }
-            if page.has_next_page {
-                cursor = page.next_cursor;
-            } else {
-                break;
+            match page.next_page_token {
+                Some(token) => cursor = Some(token),
+                None => break,
             }
         }
         coins
@@ -81,10 +129,7 @@ impl IotaClient {
 
     /// Fetches aggregate statistics of all IOTA coins owned by the given address from the network.
     /// Returns (total_coin_count, total_balance) or an error if the network request fails.
-    pub async fn get_aggregate_coin_stats(
-        &self,
-        address: IotaAddress,
-    ) -> anyhow::Result<(u64, u64)> {
+    pub async fn get_aggregate_coin_stats(&self, address: Address) -> anyhow::Result<(u64, u64)> {
         debug!(
             "Querying aggregate coin stats for sponsor address {}",
             address
@@ -93,211 +138,387 @@ impl IotaClient {
         let mut total_count: u64 = 0;
         let mut total_balance: u64 = 0;
         loop {
-            let page = retry_with_max_attempts!(
+            let outcome = retry_with_max_attempts!(
                 async {
-                    self.iota_client
-                        .coin_read_api()
-                        .get_coins(address, None, cursor, None)
-                        .await
-                        .map_err(anyhow::Error::from)
-                        .tap_err(|err| debug!("Failed to get owned gas coins: {:?}", err))
+                    attempt(async {
+                        self.client
+                            .list_owned_objects(
+                                address,
+                                Some(StructTag::new_gas_coin()),
+                                Some(COIN_LIST_PAGE_SIZE),
+                                cursor.clone(),
+                                None,
+                            )
+                            .await
+                    })
+                    .await
                 },
                 3
-            )?;
-            for coin in page.data {
-                total_count += 1;
-                total_balance += coin.balance;
+            );
+            let page = into_anyhow(outcome)
+                .map_err(|err| anyhow::anyhow!("failed to get owned gas coins: {err}"))?
+                .into_inner();
+            for object in &page.items {
+                if let Some(coin) = coin_from_object(object) {
+                    total_count += 1;
+                    total_balance += coin.balance;
+                }
             }
-            if page.has_next_page {
-                cursor = page.next_cursor;
-            } else {
-                break;
+            match page.next_page_token {
+                Some(token) => cursor = Some(token),
+                None => break,
             }
         }
         Ok((total_count, total_balance))
     }
 
     pub async fn get_reference_gas_price(&self) -> u64 {
-        retry_forever!(async {
-            self.iota_client
-                .governance_api()
-                .get_reference_gas_price()
-                .await
-                .tap_err(|err| debug!("Failed to get reference gas price: {:?}", err))
-        })
-        .unwrap()
+        let outcome = retry_forever!(async {
+            attempt(async { self.client.get_reference_gas_price().await }).await
+        });
+        into_anyhow(outcome)
+            .unwrap_or_else(|err| panic!("failed to get reference gas price: {err}"))
+            .into_inner()
     }
 
     pub async fn get_latest_gas_objects(
         &self,
-        object_ids: impl IntoIterator<Item = ObjectID>,
-    ) -> HashMap<ObjectID, Option<GasCoin>> {
-        let tasks: FuturesUnordered<_> = object_ids
-            .into_iter()
-            .chunks(50)
-            .into_iter()
-            .map(|chunk| {
-                let chunk: Vec<_> = chunk.collect();
-                let iota_client = self.iota_client.clone();
-                tokio::spawn(async move {
-                    retry_forever!(async {
-                        let chunk = chunk.clone();
-                        let result = iota_client
-                            .clone()
-                            .read_api()
-                            .multi_get_object_with_options(
-                                chunk.clone(),
-                                IotaObjectDataOptions::default().with_bcs(),
-                            )
-                            .await
-                            .map_err(anyhow::Error::from)?;
-                        if result.len() != chunk.len() {
-                            anyhow::bail!(
-                                "Unable to get all gas coins, got {} out of {}",
-                                result.len(),
-                                chunk.len()
-                            );
-                        }
-                        Ok(chunk.into_iter().zip(result).collect::<Vec<_>>())
-                    })
-                    .unwrap()
-                })
-            })
-            .collect();
-        let objects: Vec<_> = tasks.collect().await;
-        let objects: Vec<_> = objects.into_iter().flat_map(|r| r.unwrap()).collect();
-        objects
-            .into_iter()
-            .map(|(id, response)| {
-                let object = match Self::try_get_iota_coin_balance(&response) {
-                    Some(coin) => {
-                        debug!("Got updated gas coin info: {:?}", coin);
-                        Some(coin)
-                    }
-                    None => {
-                        debug!("Object no longer exists: {:?}", id);
-                        None
-                    }
-                };
-                (id, object)
-            })
-            .collect()
+        object_ids: impl IntoIterator<Item = ObjectId>,
+    ) -> HashMap<ObjectId, Option<GasCoin>> {
+        let ids: Vec<ObjectId> = object_ids.into_iter().collect();
+        let mut result = HashMap::with_capacity(ids.len());
+        for chunk in ids.chunks(OBJECT_FETCH_CHUNK_SIZE) {
+            self.fetch_gas_object_chunk(chunk, &mut result).await;
+        }
+        result
     }
 
-    pub fn construct_coin_split_pt(
-        gas_coin: Argument,
-        split_count: u64,
-    ) -> ProgrammableTransaction {
-        let mut pt_builder = ProgrammableTransactionBuilder::new();
-        let pure_arg = pt_builder.pure(split_count).unwrap();
-        pt_builder.programmable_move_call(
-            IOTA_FRAMEWORK_PACKAGE_ID,
-            PAY_MODULE_NAME.into(),
-            PAY_SPLIT_N_FUNC_NAME.into(),
-            vec![GAS::type_tag()],
-            vec![gas_coin, pure_arg],
-        );
-        pt_builder.finish()
+    /// Fetches one chunk via a single batched `get_objects` call when possible.
+    ///
+    /// `get_objects` guarantees response order matches the request order
+    /// (`iota-sdk-grpc-client`'s `api/ledger/objects.rs`: "Server guarantees
+    /// results are returned in request order"), so no client-side
+    /// reordering is needed. It also, however, fails the *entire* batch as
+    /// soon as any single requested object comes back with a per-item error
+    /// -- including the common, expected case of "this object no longer
+    /// exists" (that same module's `get_objects` drains the response stream
+    /// via `collect_stream`, which propagates the first per-item error with
+    /// `?`, discarding every item collected so far). A missing gas coin is
+    /// routine here (coins get consumed/smashed during execution), so we
+    /// fall back to resolving the chunk one object at a time only when the
+    /// batch call fails, keeping the common (nothing missing) case batched.
+    async fn fetch_gas_object_chunk(
+        &self,
+        chunk: &[ObjectId],
+        result: &mut HashMap<ObjectId, Option<GasCoin>>,
+    ) {
+        let refs: Vec<(ObjectId, Option<Version>)> = chunk.iter().map(|id| (*id, None)).collect();
+        let outcome = retry_forever!(async {
+            attempt(async { self.client.get_objects(&refs, None).await }).await
+        });
+        match into_anyhow(outcome) {
+            Ok(envelope) => {
+                let objects = envelope.into_inner();
+                debug_assert_eq!(objects.len(), chunk.len());
+                for (id, object) in chunk.iter().zip(objects.iter()) {
+                    result.insert(*id, coin_from_object(object));
+                }
+            }
+            Err(_) => {
+                for id in chunk {
+                    result.insert(*id, self.fetch_gas_object_one(*id).await);
+                }
+            }
+        }
     }
 
+    /// Resolves a single object, treating "not found" as `None` (the object
+    /// no longer exists) rather than a failure.
+    async fn fetch_gas_object_one(&self, id: ObjectId) -> Option<GasCoin> {
+        let outcome = retry_forever!(async {
+            attempt(async { self.client.get_objects(&[(id, None)], None).await }).await
+        });
+        match outcome {
+            Ok(Ok(envelope)) => envelope.into_inner().first().and_then(coin_from_object),
+            Ok(Err(err)) if is_not_found(&err) => {
+                debug!("Object no longer exists: {:?}", id);
+                None
+            }
+            Ok(Err(err)) => panic!("failed to fetch gas object {id}: {err}"),
+            Err(err) => panic!("failed to fetch gas object {id}: exhausted retries: {err}"),
+        }
+    }
+
+    /// Calibrates the gas cost of a single `pay::divide_and_keep` object mutation by
+    /// simulating a real split of `gas_coin` and reading back the actual gas
+    /// used.
+    ///
+    /// This is deliberately simulated with an *empty* transaction gas
+    /// payment, not a fabricated one: with `skip_checks: true` and
+    /// `gas_payment.objects` empty, the authority fabricates its own mock
+    /// gas coin owned by `gas_payment.owner`, and with `gas_payment.budget ==
+    /// 0` under skipped checks the server rewrites the budget to the
+    /// protocol max and reports back the actual cost incurred (verified
+    /// against `crates/iota-grpc-server/src/**/simulate.rs` and
+    /// `crates/iota-core/src/authority.rs` on the `iotaledger/iota` monorepo
+    /// `develop` branch). `gas_coin` itself is a real, separate object: it's
+    /// the *input* being split by the move call, not the fee-paying gas
+    /// object, so its object reference must be real and correct.
     pub async fn calibrate_gas_cost_per_object(
         &self,
-        sponsor_address: IotaAddress,
+        sponsor_address: Address,
         gas_coin: &GasCoin,
+        reference_gas_price: u64,
     ) -> u64 {
         const SPLIT_COUNT: u64 = 500;
-        let mut pt_builder = ProgrammableTransactionBuilder::new();
-        let object_arg = pt_builder
-            .obj(ObjectArg::ImmOrOwnedObject(gas_coin.object_ref))
-            .unwrap();
-        let pure_arg = pt_builder.pure(SPLIT_COUNT).unwrap();
-        pt_builder.programmable_move_call(
-            IOTA_FRAMEWORK_PACKAGE_ID,
-            PAY_MODULE_NAME.into(),
-            PAY_SPLIT_N_FUNC_NAME.into(),
-            vec![GAS::type_tag()],
-            vec![object_arg, pure_arg],
-        );
-        let pt = pt_builder.finish();
-        let response = retry_forever!(async {
-            self.iota_client
-                .read_api()
-                .dev_inspect_transaction_block(
-                    sponsor_address,
-                    TransactionKind::ProgrammableTransaction(pt.clone()),
-                    None,
-                    None,
-                    None,
-                )
-                .await
-        })
-        .unwrap();
-        let gas_used = response.effects.gas_cost_summary().gas_used();
-        // Multiply by 2 to be conservative and resilient to precision loss.
-        gas_used / SPLIT_COUNT * 2
-    }
 
-    pub async fn execute_transaction(
-        &self,
-        tx: Transaction,
-        max_attempts: usize,
-        request_type: Option<ExecuteTransactionRequestType>,
-    ) -> anyhow::Result<IotaTransactionBlockEffects> {
-        let digest = *tx.digest();
-        debug!(?digest, "Executing transaction: {:?}", tx);
-        let request_type =
-            request_type.unwrap_or(ExecuteTransactionRequestType::WaitForEffectsCert);
-        let response = retry_with_max_attempts!(
-            async {
-                self.iota_client
-                    .quorum_driver_api()
-                    .execute_transaction_block(
+        let mut builder = TransactionBuilder::new(sponsor_address);
+        builder.sponsor(sponsor_address);
+        builder.gas_price(reference_gas_price);
+        builder.gas_budget(0);
+        let coin_arg = builder.input(Input::ImmutableOrOwned(gas_coin.object_ref));
+        let count_arg = builder.pure(SPLIT_COUNT);
+        builder
+            .move_call(ObjectId::FRAMEWORK, Identifier::PAY_MODULE.as_str(), "divide_and_keep")
+            .type_tags([TypeTag::from(StructTag::new_gas())])
+            .arguments((coin_arg, count_arg));
+        // Built entirely offline (no client, no gas objects) -- the only way
+        // `finish()` can fail is a missing gas price, which is always set above.
+        let tx = builder
+            .finish()
+            .expect("gas calibration transaction is built offline and always well-formed");
+
+        let outcome = retry_forever!(async {
+            attempt(async {
+                self.client
+                    .simulate_transaction(
                         tx.clone(),
-                        IotaTransactionBlockResponseOptions::new().with_effects(),
-                        request_type.clone(),
+                        true,
+                        Some(ReadMask::from(&["executed_transaction.effects"])),
                     )
                     .await
-                    .tap_err(|err| debug!(?digest, "execute_transaction error: {:?}", err))
-                    .map_err(anyhow::Error::from)
-                    .and_then(|r| r.effects.ok_or_else(|| anyhow::anyhow!("No effects")))
+            })
+            .await
+        });
+        let simulated = into_anyhow(outcome)
+            .unwrap_or_else(|err| panic!("failed to simulate gas calibration transaction: {err}"))
+            .into_inner();
+
+        let executed = simulated
+            .executed_transaction()
+            .expect("requested with an explicit `executed_transaction.effects` read mask");
+        let effects = executed
+            .effects()
+            .and_then(|effects| effects.effects())
+            .expect("requested with an explicit `executed_transaction.effects` read mask");
+
+        // Multiply by 2 to be conservative and resilient to precision loss.
+        gas_used_from_effects(&effects) / SPLIT_COUNT * 2
+    }
+
+    /// Executes a fully-signed transaction.
+    ///
+    /// `checkpoint_wait_ms` is only used when `request_type` is
+    /// `WaitForLocalExecution`; it maps to the gRPC call's
+    /// `checkpoint_inclusion_timeout_ms`, which asks the server to wait up to
+    /// that long for checkpoint inclusion before responding.
+    pub async fn execute_transaction(
+        &self,
+        tx: SignedTransaction,
+        max_attempts: usize,
+        request_type: Option<ExecuteTransactionRequestType>,
+        checkpoint_wait_ms: u64,
+    ) -> anyhow::Result<TransactionEffects> {
+        let digest = tx.transaction().digest();
+        debug!(?digest, "Executing transaction: {:?}", tx);
+        let checkpoint_inclusion_timeout_ms =
+            match request_type.unwrap_or(ExecuteTransactionRequestType::WaitForEffectsCert) {
+                ExecuteTransactionRequestType::WaitForEffectsCert => None,
+                ExecuteTransactionRequestType::WaitForLocalExecution => Some(checkpoint_wait_ms),
+            };
+        // Narrow read mask: this service only ever reads the digest (for
+        // logging) and the effects. The default mask also pulls
+        // events/input_objects/output_objects, which are never used here;
+        // balance_changes/object_changes aren't in any default mask and are
+        // deliberately not requested either way -- we could not
+        // independently verify (from the ground-truth source/docs available
+        // here) the claim that requesting them can turn a pruned-object
+        // lookup into a hard `FAILED_PRECONDITION`, but not requesting them
+        // is the safe default regardless, since this service never reads them.
+        let mask = ReadMask::from(&["transaction.digest", "effects"]);
+        let outcome = retry_with_max_attempts!(
+            async {
+                attempt(async {
+                    self.client
+                        .execute_transaction(
+                            tx.clone(),
+                            Some(mask.clone()),
+                            checkpoint_inclusion_timeout_ms,
+                        )
+                        .await
+                })
+                .await
             },
             max_attempts
         );
-        debug!(?digest, "Transaction execution response: {:?}", response);
-        response
+        let effects = match into_anyhow(outcome) {
+            Ok(envelope) => {
+                let executed = envelope.into_inner();
+                executed
+                    .effects()
+                    .and_then(|effects| effects.effects())
+                    .map_err(|err| {
+                        anyhow::anyhow!(
+                            "missing effects in execute_transaction response for {digest}: {err}"
+                        )
+                    })
+            }
+            Err(err) => Err(anyhow::anyhow!("execute_transaction error for {digest}: {err}")),
+        };
+        debug!(?digest, "Transaction execution response: {:?}", effects);
+        effects
     }
 
-    /// Wait for a known valid object version to be available on the fullnode.
-    pub async fn wait_for_object(&self, obj_ref: ObjectRef) {
+    /// Waits for a specific object version to become visible on the fullnode.
+    ///
+    /// Only reachable from `#[cfg(test)]` code (a post-execution consistency
+    /// assertion in `gas_station/gas_station_core.rs`) -- production never
+    /// needs to poll for object visibility, so this isn't compiled into
+    /// production builds.
+    #[cfg(test)]
+    pub async fn wait_for_object(&self, obj_ref: iota_sdk_types::ObjectReference) {
         loop {
-            let response = self
-                .iota_client
-                .read_api()
-                .get_object_with_options(obj_ref.0, IotaObjectDataOptions::default())
-                .await;
-            if let Ok(IotaObjectResponse {
-                data: Some(data), ..
-            }) = response
-            {
-                if data.version == obj_ref.1 {
-                    break;
-                }
+            let found = self
+                .client
+                .get_objects(&[(obj_ref.object_id, Some(obj_ref.version))], None)
+                .await
+                .is_ok();
+            if found {
+                break;
             }
             tokio::time::sleep(Duration::from_millis(200)).await;
         }
     }
+}
 
-    fn try_get_iota_coin_balance(object: &IotaObjectResponse) -> Option<GasCoin> {
-        let data = object.data.as_ref()?;
-        let object_ref = data.object_ref();
-        let move_obj = data.bcs.as_ref()?.try_as_move()?;
-        if move_obj.type_ != iota_types::gas_coin::GasCoin::type_() {
-            return None;
-        }
-        let gas_coin: iota_types::gas_coin::GasCoin = bcs::from_bytes(&move_obj.bcs_bytes).ok()?;
-        Some(GasCoin {
-            object_ref,
-            balance: gas_coin.value(),
-        })
+/// Builds a [`GasCoin`] from a `get_objects`/`list_owned_objects` result
+/// object, or `None` if it isn't a (recognizable) IOTA gas coin. Mirrors the
+/// old JSON-RPC client's `try_get_iota_coin_balance`.
+fn coin_from_object(object: &Object) -> Option<GasCoin> {
+    let object_ref = object.object_reference().ok()?;
+    let sdk_object = object.object().ok()?;
+    let coin = Coin::try_from_object(&sdk_object).ok()?;
+    Some(GasCoin {
+        object_ref,
+        balance: coin.balance(),
+    })
+}
+
+/// Extracts the total gas used from a transaction's effects. Split out from
+/// `calibrate_gas_cost_per_object` so it can be exercised by a unit test
+/// without a live network (see
+/// `tests::gas_used_from_effects_reads_gas_cost_summary`).
+fn gas_used_from_effects(effects: &TransactionEffects) -> u64 {
+    effects.as_v1().gas_cost_summary.gas_used()
+}
+
+/// Classifies a gRPC-client error as transient (worth another attempt) or
+/// permanent. Bad input, missing objects, and auth/permission failures will
+/// never succeed no matter how many times they're retried, so letting
+/// `retry_forever!` spin on them would just be a silent hang with extra
+/// network chatter; everything else (`Unavailable`, `DeadlineExceeded`,
+/// transport resets, ...) is assumed transient, matching the old JSON-RPC
+/// client's blanket-retry behavior.
+fn is_transient(err: &GrpcError) -> bool {
+    let code = match err {
+        GrpcError::Grpc(status) => status.code(),
+        GrpcError::Server(status) => tonic::Code::from_i32(status.code),
+        // Local/logic errors (proto conversion bugs, an empty id list, a
+        // signature that failed to encode, ...) and any future `Error`
+        // variant (the enum is `#[non_exhaustive]`) are bugs in this code or
+        // a version skew with the SDK, not transient server conditions --
+        // retrying can't fix either.
+        _ => return false,
+    };
+    !matches!(
+        code,
+        tonic::Code::InvalidArgument
+            | tonic::Code::NotFound
+            | tonic::Code::PermissionDenied
+            | tonic::Code::Unauthenticated
+            | tonic::Code::FailedPrecondition
+            | tonic::Code::Unimplemented
+    )
+}
+
+/// `err` is specifically "the requested object does not exist / this version
+/// does not exist", as opposed to any other server-side per-item error.
+fn is_not_found(err: &GrpcError) -> bool {
+    matches!(
+        err,
+        GrpcError::Server(status) if tonic::Code::from_i32(status.code) == tonic::Code::NotFound
+    )
+}
+
+/// Runs one gRPC attempt under [`GRPC_CALL_TIMEOUT`] and folds the outcome
+/// into the "double `Result`" shape this crate's retry macros need to
+/// distinguish "retry me" from "stop, this is final" *without* changing the
+/// unconditional-retry-on-`Err` macros themselves (`src/errors.rs`):
+/// transient failures come back as the outer `Err` (the macro retries
+/// again); permanent failures come back as `Ok(Err(_))` (the macro treats
+/// the attempt as done and hands the inner error back to the caller,
+/// unretried). Pair with [`into_anyhow`] to unwrap the result after it has
+/// passed through a retry macro.
+async fn attempt<T>(
+    fut: impl std::future::Future<Output = Result<T, GrpcError>>,
+) -> Result<Result<T, GrpcError>, GrpcError> {
+    match tokio::time::timeout(GRPC_CALL_TIMEOUT, fut).await {
+        Ok(Ok(value)) => Ok(Ok(value)),
+        Ok(Err(err)) if is_transient(&err) => Err(err),
+        Ok(Err(err)) => Ok(Err(err)),
+        Err(_elapsed) => Err(GrpcError::Grpc(Box::new(tonic::Status::deadline_exceeded(
+            "gas station: internal per-attempt gRPC timeout exceeded",
+        )))),
+    }
+}
+
+/// Flattens the `attempt()` double-`Result` after it has passed through a
+/// retry macro: "retries exhausted while still transient" (outer `Err`) and
+/// "classified permanent, never retried" (inner `Err`) both become the same
+/// `anyhow::Error`, since by this point neither is going to be retried again.
+fn into_anyhow<T>(outcome: Result<Result<T, GrpcError>, GrpcError>) -> anyhow::Result<T> {
+    match outcome {
+        Ok(Ok(value)) => Ok(value),
+        Ok(Err(err)) | Err(err) => Err(anyhow::Error::from(err)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use iota_sdk_types::{ExecutionStatus, GasCostSummary, TransactionDigest, TransactionEffectsV1};
+
+    #[test]
+    fn gas_used_from_effects_reads_gas_cost_summary() {
+        let v1 = TransactionEffectsV1 {
+            status: ExecutionStatus::Success,
+            epoch: 1,
+            gas_cost_summary: GasCostSummary::new(100, 10, 50, 20, 5),
+            transaction_digest: TransactionDigest::new([7; 32]),
+            gas_object_index: None,
+            events_digest: None,
+            dependencies: vec![],
+            lamport_version: Version::from_u64(1),
+            changed_objects: vec![],
+            unchanged_shared_objects: vec![],
+            auxiliary_data_digest: None,
+        };
+        let effects = TransactionEffects::V1(Box::new(v1));
+
+        // gas_used() = computation_cost + storage_cost = 100 + 50 = 150,
+        // independent of computation_cost_burned/storage_rebate/
+        // non_refundable_storage_fee -- pinning this catches an accidental
+        // switch to net_gas_usage() (which subtracts storage_rebate) instead.
+        assert_eq!(gas_used_from_effects(&effects), 150);
     }
 }

--- a/src/iota_client.rs
+++ b/src/iota_client.rs
@@ -380,11 +380,6 @@ impl IotaClient {
     }
 
     /// Waits for a specific object version to become visible on the fullnode.
-    ///
-    /// Only reachable from `#[cfg(test)]` code (a post-execution consistency
-    /// assertion in `gas_station/gas_station_core.rs`) -- production never
-    /// needs to poll for object visibility, so this isn't compiled into
-    /// production builds.
     #[cfg(test)]
     pub async fn wait_for_object(&self, obj_ref: iota_sdk_types::ObjectReference) {
         loop {

--- a/src/iota_client.rs
+++ b/src/iota_client.rs
@@ -18,7 +18,7 @@ use iota_sdk_types::{
 };
 use std::collections::HashMap;
 use std::time::Duration;
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 
 /// Per-attempt timeout for a single gRPC call. Without this, a stalled
 /// stream (e.g. a fullnode that accepted the connection but never responds)
@@ -49,8 +49,40 @@ pub struct IotaClient {
     client: Client,
 }
 
+/// The public networks' legacy JSON-RPC hosts and the gRPC endpoints that
+/// replace them, for [`rewrite_legacy_fullnode_url`].
+const LEGACY_JSON_RPC_HOST_TO_GRPC_URL: [(&str, &str); 3] = [
+    ("api.mainnet.iota.cafe", "https://grpc.mainnet.iota.cafe"),
+    ("api.testnet.iota.cafe", "https://grpc.testnet.iota.cafe"),
+    ("api.devnet.iota.cafe", "https://grpc.devnet.iota.cafe"),
+];
+
+/// Maps a `fullnode-url` that still points at one of the public networks'
+/// legacy JSON-RPC endpoints to the corresponding gRPC endpoint, or `None`
+/// if the URL is not a known legacy endpoint (including any self-hosted
+/// node, which we cannot guess a gRPC address for).
+///
+/// This is deliberately applied only here, at the last moment before the
+/// connection is created -- everything else in the process (most
+/// importantly the Redis storage namespace, which
+/// `storage::get_storage_namespace` derives from the *configured* URL)
+/// keeps seeing the original value, so a pre-migration config keeps its
+/// existing coin registry untouched.
+fn rewrite_legacy_fullnode_url(fullnode_url: &str) -> Option<&'static str> {
+    let url = url::Url::parse(fullnode_url).ok()?;
+    let host = url.host_str()?.to_ascii_lowercase();
+    LEGACY_JSON_RPC_HOST_TO_GRPC_URL
+        .iter()
+        .find(|(legacy_host, _)| *legacy_host == host)
+        .map(|(_, grpc_url)| *grpc_url)
+}
+
 impl IotaClient {
     /// Connects to the fullnode's gRPC endpoint.
+    ///
+    /// A `fullnode_url` still pointing at one of the public networks' legacy
+    /// JSON-RPC endpoints is transparently redirected to the matching gRPC
+    /// endpoint (with a warning) -- see [`rewrite_legacy_fullnode_url`].
     ///
     /// The underlying channel connects lazily (`Client::new` never touches
     /// the network, see `iota_sdk_grpc_client::Client::new`), so failure
@@ -62,6 +94,22 @@ impl IotaClient {
         fullnode_url: &str,
         basic_auth: Option<(String, String)>,
     ) -> anyhow::Result<Self> {
+        let fullnode_url = match rewrite_legacy_fullnode_url(fullnode_url) {
+            Some(grpc_url) => {
+                warn!(
+                    "fullnode-url {fullnode_url:?} is a legacy JSON-RPC endpoint, which the gas \
+                     station no longer speaks; connecting to the gRPC endpoint {grpc_url:?} \
+                     instead. Please update fullnode-url in your config. Note that changing the \
+                     configured URL also changes the Redis storage namespace: the coin registry \
+                     is re-initialized from scratch (in-flight reservations are dropped and the \
+                     daily gas usage counter resets), so update all instances together during a \
+                     full stop, not via a rolling deploy -- see the README section 'Upgrading \
+                     from JSON-RPC to gRPC'."
+                );
+                grpc_url
+            }
+            None => fullnode_url,
+        };
         let mut headers = HeadersInterceptor::new();
         if let Some((username, password)) = basic_auth {
             headers.basic_auth(username, Some(password));
@@ -474,5 +522,42 @@ mod tests {
         // non_refundable_storage_fee -- pinning this catches an accidental
         // switch to net_gas_usage() (which subtracts storage_rebate) instead.
         assert_eq!(gas_used_from_effects(&effects), 150);
+    }
+
+    #[test]
+    fn legacy_json_rpc_urls_are_rewritten_to_grpc() {
+        for (legacy, grpc) in [
+            (
+                "https://api.mainnet.iota.cafe",
+                "https://grpc.mainnet.iota.cafe",
+            ),
+            (
+                "https://api.testnet.iota.cafe",
+                "https://grpc.testnet.iota.cafe",
+            ),
+            (
+                "https://api.devnet.iota.cafe",
+                "https://grpc.devnet.iota.cafe",
+            ),
+        ] {
+            assert_eq!(rewrite_legacy_fullnode_url(legacy), Some(grpc));
+        }
+        // Host matching is scheme/port/path/case-insensitive.
+        assert_eq!(
+            rewrite_legacy_fullnode_url("https://API.TESTNET.IOTA.CAFE:443/"),
+            Some("https://grpc.testnet.iota.cafe")
+        );
+    }
+
+    #[test]
+    fn non_legacy_urls_are_left_untouched() {
+        for url in [
+            "https://grpc.testnet.iota.cafe",
+            "http://localhost:9000",
+            "https://fullnode.example.com:9000",
+            "not a url at all",
+        ] {
+            assert_eq!(rewrite_legacy_fullnode_url(url), None);
+        }
     }
 }

--- a/src/iota_client.rs
+++ b/src/iota_client.rs
@@ -314,14 +314,14 @@ impl IotaClient {
         tx: SignedTransaction,
         max_attempts: usize,
         request_type: Option<ExecuteTransactionRequestType>,
-        checkpoint_wait_ms: u64,
+        checkpoint_inclusion_timeout_ms: u64,
     ) -> anyhow::Result<TransactionEffects> {
         let digest = tx.transaction().digest();
         debug!(?digest, "Executing transaction: {:?}", tx);
         let checkpoint_inclusion_timeout_ms =
             match request_type.unwrap_or(ExecuteTransactionRequestType::WaitForEffectsCert) {
                 ExecuteTransactionRequestType::WaitForEffectsCert => None,
-                ExecuteTransactionRequestType::WaitForLocalExecution => Some(checkpoint_wait_ms),
+                ExecuteTransactionRequestType::WaitForLocalExecution => Some(checkpoint_inclusion_timeout_ms),
             };
         // Narrow read mask: this service only ever reads the digest (for
         // logging) and the effects.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod access_controller;
+pub mod base64;
 pub mod benchmarks;
 pub mod command;
 pub mod config;

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -3,7 +3,70 @@
 
 use std::fmt::{self, Display, Formatter};
 
+use once_cell::sync::OnceCell;
 use serde::Serialize;
+use tracing_subscriber::filter::Directive;
+use tracing_subscriber::EnvFilter;
+
+use crate::{TRANSACTION_LOGGING_ENV_NAME, TRANSACTION_LOGGING_TARGET_NAME};
+
+/// Filter directive used when `RUST_LOG` is not set (or fails to parse).
+///
+/// Mirrors the default that used to be passed to
+/// `telemetry_subscribers::TelemetryConfig::with_log_level`: everything is
+/// silenced except this crate, which logs at `debug`.
+const DEFAULT_LOG_DIRECTIVE: &str = "off,iota_gas_station=debug";
+
+/// Initialize the global `tracing` subscriber for the running binary.
+///
+/// `RUST_LOG` takes full precedence over the built-in default when it is set
+/// and parses successfully — this matches the previous
+/// `telemetry_subscribers` behavior, which built its `EnvFilter` via
+/// `EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(default_directives))`.
+/// When `RUST_LOG` is unset/invalid, [`DEFAULT_LOG_DIRECTIVE`] is used instead
+/// (note: this is a plain fallback, not a merge with `RUST_LOG`).
+///
+/// Also restores the old `telemetry_subscribers`-era behavior of the
+/// `TRANSACTIONS_LOGGING` env var: when set to `"true"`, it forces the
+/// `"transactions"` target (used by `rpc/server.rs` to emit full
+/// transaction-effects audit records) to `trace` level regardless of the
+/// base filter above — this target doesn't match `iota_gas_station=...`
+/// directives since it's a bare custom target, not a crate path, so without
+/// this it is silently swallowed by `DEFAULT_LOG_DIRECTIVE`'s `off` default.
+pub fn init() {
+    let mut env_filter =
+        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(DEFAULT_LOG_DIRECTIVE));
+    if std::env::var(TRANSACTION_LOGGING_ENV_NAME).as_deref() == Ok("true") {
+        let directive: Directive = format!("{TRANSACTION_LOGGING_TARGET_NAME}=trace")
+            .parse()
+            .expect("static directive string is always valid");
+        env_filter = env_filter.add_directive(directive);
+    }
+    tracing_subscriber::fmt().with_env_filter(env_filter).init();
+}
+
+static TEST_LOGGER: OnceCell<()> = OnceCell::new();
+
+/// Idempotent `tracing` subscriber setup for tests.
+///
+/// Safe to call from many tests/threads: only the first call installs the
+/// global subscriber, later calls are no-ops. This replaces
+/// `telemetry_subscribers::init_for_testing()`, which used the same
+/// once-only pattern (there via `once_cell::sync::Lazy`).
+pub fn init_for_testing() {
+    TEST_LOGGER.get_or_init(|| {
+        let _ = tracing_subscriber::fmt()
+            .with_env_filter(
+                EnvFilter::builder()
+                    .with_default_directive(tracing::level_filters::LevelFilter::INFO.into())
+                    .from_env_lossy(),
+            )
+            .with_file(true)
+            .with_line_number(true)
+            .with_test_writer()
+            .try_init();
+    });
+}
 
 #[derive(Debug, Serialize, Clone)]
 #[serde(rename_all = "camelCase")]

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -10,29 +10,22 @@ use tracing_subscriber::EnvFilter;
 
 use crate::{TRANSACTION_LOGGING_ENV_NAME, TRANSACTION_LOGGING_TARGET_NAME};
 
-/// Filter directive used when `RUST_LOG` is not set (or fails to parse).
-///
-/// Mirrors the default that used to be passed to
-/// `telemetry_subscribers::TelemetryConfig::with_log_level`: everything is
-/// silenced except this crate, which logs at `debug`.
+/// Filter directive used when `RUST_LOG` is not set (or fails to parse):
+/// everything is silenced except this crate, which logs at `debug`.
 const DEFAULT_LOG_DIRECTIVE: &str = "off,iota_gas_station=debug";
 
 /// Initialize the global `tracing` subscriber for the running binary.
 ///
-/// `RUST_LOG` takes full precedence over the built-in default when it is set
-/// and parses successfully — this matches the previous
-/// `telemetry_subscribers` behavior, which built its `EnvFilter` via
-/// `EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(default_directives))`.
-/// When `RUST_LOG` is unset/invalid, [`DEFAULT_LOG_DIRECTIVE`] is used instead
-/// (note: this is a plain fallback, not a merge with `RUST_LOG`).
+/// `RUST_LOG` takes full precedence when it is set and parses successfully;
+/// otherwise [`DEFAULT_LOG_DIRECTIVE`] is used (a plain fallback, not a merge
+/// with `RUST_LOG`).
 ///
-/// Also restores the old `telemetry_subscribers`-era behavior of the
-/// `TRANSACTIONS_LOGGING` env var: when set to `"true"`, it forces the
+/// When the `TRANSACTIONS_LOGGING` env var is set to `"true"`, the
 /// `"transactions"` target (used by `rpc/server.rs` to emit full
-/// transaction-effects audit records) to `trace` level regardless of the
-/// base filter above — this target doesn't match `iota_gas_station=...`
-/// directives since it's a bare custom target, not a crate path, so without
-/// this it is silently swallowed by `DEFAULT_LOG_DIRECTIVE`'s `off` default.
+/// transaction-effects audit records) is forced to `trace` level regardless
+/// of the base filter — it's a bare custom target, not a crate path, so it
+/// doesn't match `iota_gas_station=...` directives and would otherwise be
+/// swallowed by [`DEFAULT_LOG_DIRECTIVE`]'s `off` default.
 pub fn init() {
     let mut env_filter =
         EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(DEFAULT_LOG_DIRECTIVE));
@@ -50,9 +43,7 @@ static TEST_LOGGER: OnceCell<()> = OnceCell::new();
 /// Idempotent `tracing` subscriber setup for tests.
 ///
 /// Safe to call from many tests/threads: only the first call installs the
-/// global subscriber, later calls are no-ops. This replaces
-/// `telemetry_subscribers::init_for_testing()`, which used the same
-/// once-only pattern (there via `once_cell::sync::Lazy`).
+/// global subscriber, later calls are no-ops.
 pub fn init_for_testing() {
     TEST_LOGGER.get_or_init(|| {
         let _ = tracing_subscriber::fmt()

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -12,8 +12,7 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use tracing::error;
 
-/// HTTP path metrics are served on, matching the path previously used by
-/// `iota_metrics::start_prometheus_server`.
+/// HTTP path metrics are served on.
 pub const METRICS_ROUTE: &str = "/metrics";
 
 /// Millisecond-scale buckets for RPC/transaction latency histograms.

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -56,8 +56,7 @@ fn small_count_buckets() -> Vec<f64> {
 }
 
 /// Builds an axum [`Router`] that serves `registry`'s metrics as Prometheus
-/// text format at [`METRICS_ROUTE`], replacing the router that used to be set
-/// up internally by `iota_metrics::start_prometheus_server`.
+/// text format at [`METRICS_ROUTE`].
 pub fn metrics_router(registry: Registry) -> Router {
     Router::new()
         .route(METRICS_ROUTE, get(metrics_handler))
@@ -76,10 +75,8 @@ async fn metrics_handler(Extension(registry): Extension<Registry>) -> (StatusCod
 }
 
 /// Creates a fresh [`Registry`] and spawns an axum HTTP server bound to
-/// `addr` that serves it at [`METRICS_ROUTE`], mirroring the behavior of the
-/// now-removed `iota_metrics::start_prometheus_server`. Returns the
-/// [`Registry`] so callers can register metrics against it, exactly as they
-/// previously did with `RegistryService::default_registry()`.
+/// `addr` that serves it at [`METRICS_ROUTE`]. Returns the
+/// [`Registry`] so callers can register metrics against it.
 pub fn start_prometheus_server(addr: SocketAddr) -> Registry {
     let registry = Registry::new();
     let app = metrics_router(registry.clone());

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -2,13 +2,100 @@
 // Modifications Copyright (c) 2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use iota_metrics::histogram::Histogram;
+use axum::{http::StatusCode, routing::get, Extension, Router};
 use prometheus::{
-    register_int_counter_vec_with_registry, register_int_counter_with_registry,
-    register_int_gauge_vec_with_registry, IntCounter, IntCounterVec, IntGaugeVec, Registry,
+    register_histogram_with_registry, register_int_counter_vec_with_registry,
+    register_int_counter_with_registry, register_int_gauge_vec_with_registry, Histogram,
+    IntCounter, IntCounterVec, IntGaugeVec, Registry, TextEncoder,
 };
+use std::net::SocketAddr;
 use std::sync::Arc;
 use tracing::error;
+
+/// HTTP path metrics are served on, matching the path previously used by
+/// `iota_metrics::start_prometheus_server`.
+pub const METRICS_ROUTE: &str = "/metrics";
+
+/// Millisecond-scale buckets for RPC/transaction latency histograms.
+/// Covers sub-millisecond blips up to a 30s worst case (network retries,
+/// slow full nodes), which comfortably spans reserve/sign/execute latencies.
+fn latency_ms_buckets() -> Vec<f64> {
+    vec![
+        1.0, 5.0, 10.0, 25.0, 50.0, 100.0, 250.0, 500.0, 1_000.0, 2_500.0, 5_000.0, 10_000.0,
+        30_000.0,
+    ]
+}
+
+/// Buckets (in seconds) for the client-requested gas reservation duration.
+/// `reserve_duration_secs` is hard-capped at `RESERVE_GAS_MAX_DURATION_S`
+/// (600s / 10 minutes), so the buckets are chosen to resolve that whole range.
+fn reserve_duration_secs_buckets() -> Vec<f64> {
+    vec![1.0, 5.0, 10.0, 30.0, 60.0, 120.0, 300.0, 600.0]
+}
+
+/// Buckets for NANOS-denominated gas amounts (gas budgets, gas usage, and
+/// deltas thereof). 1 IOTA == 1_000_000_000 NANOS; this spans from a
+/// negligible 1_000 NANOS up to 10 IOTA to cover both small transactions and
+/// large, operator-configured gas budgets.
+fn nanos_buckets() -> Vec<f64> {
+    vec![
+        1_000.0,
+        10_000.0,
+        100_000.0,
+        1_000_000.0,
+        10_000_000.0,
+        100_000_000.0,
+        1_000_000_000.0,
+        10_000_000_000.0,
+    ]
+}
+
+/// Buckets for small non-negative integer counts, such as the number of gas
+/// coins involved in a single request.
+fn small_count_buckets() -> Vec<f64> {
+    vec![1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0, 128.0, 256.0]
+}
+
+/// Builds an axum [`Router`] that serves `registry`'s metrics as Prometheus
+/// text format at [`METRICS_ROUTE`], replacing the router that used to be set
+/// up internally by `iota_metrics::start_prometheus_server`.
+pub fn metrics_router(registry: Registry) -> Router {
+    Router::new()
+        .route(METRICS_ROUTE, get(metrics_handler))
+        .layer(Extension(registry))
+}
+
+async fn metrics_handler(Extension(registry): Extension<Registry>) -> (StatusCode, String) {
+    let metric_families = registry.gather();
+    match TextEncoder::new().encode_to_string(&metric_families) {
+        Ok(metrics) => (StatusCode::OK, metrics),
+        Err(err) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("unable to encode metrics: {err}"),
+        ),
+    }
+}
+
+/// Creates a fresh [`Registry`] and spawns an axum HTTP server bound to
+/// `addr` that serves it at [`METRICS_ROUTE`], mirroring the behavior of the
+/// now-removed `iota_metrics::start_prometheus_server`. Returns the
+/// [`Registry`] so callers can register metrics against it, exactly as they
+/// previously did with `RegistryService::default_registry()`.
+pub fn start_prometheus_server(addr: SocketAddr) -> Registry {
+    let registry = Registry::new();
+    let app = metrics_router(registry.clone());
+
+    tokio::spawn(async move {
+        if let Err(err) = axum::Server::bind(&addr)
+            .serve(app.into_make_service())
+            .await
+        {
+            error!("metrics server error: {err}");
+        }
+    });
+
+    registry
+}
 
 pub struct GasStationRpcMetrics {
     // === RPC Server Metrics ===
@@ -60,16 +147,22 @@ impl GasStationRpcMetrics {
                 registry,
             )
             .unwrap(),
-            target_gas_budget_per_request: Histogram::new_in_registry(
+            // NANOS-denominated gas budget requested by the caller.
+            target_gas_budget_per_request: register_histogram_with_registry!(
                 "target_gas_budget_per_request",
                 "Target gas budget value in the reserve_gas RPC request",
+                nanos_buckets(),
                 registry,
-            ),
-            reserve_duration_per_request: Histogram::new_in_registry(
+            )
+            .unwrap(),
+            // Caller-requested reservation duration, in seconds (capped at 600s).
+            reserve_duration_per_request: register_histogram_with_registry!(
                 "reserve_duration_per_request",
                 "Reserve duration value in the reserve_gas RPC request",
+                reserve_duration_secs_buckets(),
                 registry,
-            ),
+            )
+            .unwrap(),
             num_execute_tx_requests: register_int_counter_with_registry!(
                 "num_execute_tx_requests",
                 "Total number of execute_tx RPC requests received",
@@ -131,11 +224,14 @@ pub struct GasStationCoreMetrics {
 impl GasStationCoreMetrics {
     pub fn new(registry: &Registry) -> Arc<Self> {
         Arc::new(Self {
-            reserved_gas_coin_count_per_request: Histogram::new_in_registry(
+            // Count of gas coins reserved per request, not a NANOS/latency domain.
+            reserved_gas_coin_count_per_request: register_histogram_with_registry!(
                 "reserved_gas_coin_count_per_request",
                 "Number of gas coins reserved in each reserve_gas RPC request",
+                small_count_buckets(),
                 registry,
-            ),
+            )
+            .unwrap(),
             num_expired_gas_coins: register_int_counter_vec_with_registry!(
                 "num_expired_gas_coins",
                 "Total number of gas coins that are put back due to reservation expiration",
@@ -150,21 +246,27 @@ impl GasStationCoreMetrics {
                 registry,
             )
                 .unwrap(),
-            reserve_gas_latency_ms: Histogram::new_in_registry(
+            reserve_gas_latency_ms: register_histogram_with_registry!(
                 "reserve_gas_latency",
                 "Latency of gas reservation, in milliseconds",
+                latency_ms_buckets(),
                 registry,
-            ),
-            transaction_signing_latency_ms: Histogram::new_in_registry(
+            )
+            .unwrap(),
+            transaction_signing_latency_ms: register_histogram_with_registry!(
                 "transaction_signing_latency",
                 "Latency of transaction signing, in milliseconds",
+                latency_ms_buckets(),
                 registry,
-            ),
-            transaction_execution_latency_ms: Histogram::new_in_registry(
+            )
+            .unwrap(),
+            transaction_execution_latency_ms: register_histogram_with_registry!(
                 "transaction_execution_latency",
                 "Latency of transaction execution, in milliseconds",
+                latency_ms_buckets(),
                 registry,
-            ),
+            )
+            .unwrap(),
             num_gas_station_invariant_violations: register_int_counter_with_registry!(
                 "num_gas_station_invariant_violations",
                 "Total number of invariant violations in the Gas Station core",
@@ -185,16 +287,22 @@ impl GasStationCoreMetrics {
                 registry,
             )
                 .unwrap(),
-            gas_usage_per_transaction: Histogram::new_in_registry(
+            // Actual (post-execution) net gas usage, NANOS-denominated.
+            gas_usage_per_transaction: register_histogram_with_registry!(
                 "gas_usage_per_transaction",
                 "Gas usage per transaction",
+                nanos_buckets(),
                 registry,
-            ),
-            reserved_gas_real_gas_usage_delta: Histogram::new_in_registry(
+            )
+            .unwrap(),
+            // Delta between the coin balance reserved and the real gas usage, also NANOS.
+            reserved_gas_real_gas_usage_delta: register_histogram_with_registry!(
                 "reserved_gas_real_gas_usage_delta",
                 "Reserved gas vs real gas usage delta",
+                nanos_buckets(),
                 registry,
-            ),
+            )
+            .unwrap(),
         })
     }
 

--- a/src/rpc/client.rs
+++ b/src/rpc/client.rs
@@ -2,18 +2,16 @@
 // Modifications Copyright (c) 2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::base64::Base64;
 use crate::read_auth_env;
+use crate::rpc::effects::TransactionEffectsDto;
 use crate::rpc::rpc_types::{
     ExecuteTransactionRequestType, ExecuteTxRequest, ExecuteTxResponse, ReserveGasRequest,
     ReserveGasResponse,
 };
 use crate::types::ReservationID;
 use anyhow::bail;
-use fastcrypto::encoding::Base64;
-use iota_json_rpc_types::IotaTransactionBlockEffects;
-use iota_types::base_types::{IotaAddress, ObjectRef};
-use iota_types::signature::GenericSignature;
-use iota_types::transaction::TransactionData;
+use iota_sdk_types::{Address, ObjectReference, Transaction, UserSignature};
 use reqwest::header::{HeaderMap, AUTHORIZATION};
 use reqwest::Client;
 
@@ -84,7 +82,7 @@ impl GasStationRpcClient {
         &self,
         gas_budget: u64,
         reserve_duration_secs: u64,
-    ) -> anyhow::Result<(IotaAddress, ReservationID, Vec<ObjectRef>)> {
+    ) -> anyhow::Result<(Address, ReservationID, Vec<ObjectReference>)> {
         let request = ReserveGasRequest {
             gas_budget,
             reserve_duration_secs,
@@ -113,11 +111,7 @@ impl GasStationRpcClient {
                 (
                     result.sponsor_address,
                     result.reservation_id,
-                    result
-                        .gas_coins
-                        .into_iter()
-                        .map(|c| c.to_object_ref())
-                        .collect(),
+                    result.gas_coins.into_iter().map(Into::into).collect(),
                 )
             })
     }
@@ -125,19 +119,19 @@ impl GasStationRpcClient {
     pub async fn execute_tx(
         &self,
         reservation_id: ReservationID,
-        tx_data: &TransactionData,
-        user_sig: &GenericSignature,
+        tx: &Transaction,
+        user_sig: &UserSignature,
         request_type: Option<ExecuteTransactionRequestType>,
         headers: Option<HeaderMap>,
-    ) -> anyhow::Result<IotaTransactionBlockEffects> {
+    ) -> anyhow::Result<TransactionEffectsDto> {
         let mut headers = headers.unwrap_or_default();
         if let Some(auth) = read_auth_env() {
             headers.insert(AUTHORIZATION, format!("Bearer {}", auth).parse().unwrap());
         }
         let request = ExecuteTxRequest {
             reservation_id,
-            tx_bytes: Base64::from_bytes(&bcs::to_bytes(&tx_data).unwrap()),
-            user_sig: Base64::from_bytes(user_sig.as_ref()),
+            tx_bytes: Base64::from_bytes(&bcs::to_bytes(tx)?),
+            user_sig: Base64::from_bytes(&user_sig.to_bytes()),
             request_type,
         };
         let response = self

--- a/src/rpc/effects.rs
+++ b/src/rpc/effects.rs
@@ -1,0 +1,982 @@
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! JSON-RPC-shaped transaction effects DTOs.
+//!
+//! The SDK's own [`iota_sdk_types::TransactionEffects`] (and its `V1` payload,
+//! [`TransactionEffectsV1`]) use a *compact* representation: a single
+//! `changed_objects: Vec<ChangedObject>` list (each entry carrying its
+//! before/after state plus an [`IdOperation`]), rather than the flat
+//! `created`/`mutated`/`deleted`/... lists that this service's existing
+//! `/v1/execute_tx` clients (including this SDK's own [`super::client`]) have
+//! always received on the wire and depend on byte-for-byte.
+//!
+//! This module defines that flat, JSON-RPC-shaped wire type (mirroring
+//! `IotaTransactionBlockEffectsV1` from `iota-json-rpc-types` on the
+//! `iotaledger/iota` monorepo) and derives it from the SDK's compact
+//! `TransactionEffectsV1`. Both the *derivation* (the `created()`/`mutated()`/
+//! .../`gas_object()` logic below) and the *serde shape* (every
+//! `#[serde(...)]`/`#[schemars(...)]` annotation) are ported from the
+//! monorepo's `develop` branch, which has already done this exact migration
+//! for the node itself against the same pinned `iota-sdk-types` revision this
+//! crate uses:
+//!   - `crates/iota-types/src/effects/v1.rs`
+//!     (`impl TransactionEffectsAPI for TransactionEffectsV1`) for the
+//!     derivation logic.
+//!   - `crates/iota-json-rpc-types/src/iota_transaction.rs`
+//!     (`IotaTransactionBlockEffectsV1` and
+//!     `impl<T: TransactionEffectsAPI> From<T> for IotaTransactionBlockEffectsV1`)
+//!     for the wire shape and the flattening logic.
+//!   - `crates/iota-json-rpc-types/src/{iota_gas_cost_summary,iota_owner,iota_object,iota_primitives}.rs`
+//!     for the exact per-field serde/schemars adapters (`IotaGasCostSummary`,
+//!     `OwnerSchema`, `ObjectRefSchema`, `SequenceNumberU64`,
+//!     `SequenceNumberString`, ...) that this module's local DTOs replicate.
+//!
+//! Renames encountered while porting (monorepo `iota-types` re-exports the SDK
+//! types under old names in some places -- this module always uses the real
+//! `iota_sdk_types` names): `ObjectIn::NotExist` -> `Missing`,
+//! `ObjectOut::NotExist` -> `Missing`, `IDOperation` -> `IdOperation`.
+//!
+//! One design simplification versus the monorepo: `IotaTransactionBlockEffects`
+//! there is an enum (`V1(IotaTransactionBlockEffectsV1)`) internally tagged on
+//! `messageVersion`, so that on the wire the tag and the `V1` payload's fields
+//! are flattened into one JSON object. Since the SDK's `TransactionEffects`
+//! only ever has a single `V1` variant, [`TransactionEffectsDto`] below bakes
+//! that flattening in directly as a single struct with a `message_version`
+//! field fixed to `"v1"`, rather than modeling the enum -- this produces
+//! byte-identical JSON while being simpler to define and to test.
+
+use iota_sdk_types::{
+    Address, EpochId, ExecutionStatus, GasCostSummary, IdOperation, ObjectDigest, ObjectId,
+    ObjectIn, ObjectOut, ObjectReference, Owner, TransactionDigest, TransactionEffects,
+    TransactionEffectsV1, TransactionEventsDigest, UnchangedSharedKind, Version,
+};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use serde_with::{serde_as, DisplayFromStr};
+
+/// JSON-RPC-shaped object reference: `{"objectId": "0x..", "version": N, "digest": ".."}`.
+///
+/// This intentionally does *not* reuse `iota_sdk_types::ObjectReference`'s own
+/// `Serialize` impl (which is snake_case and not part of our wire contract);
+/// note also that `version` here is a plain JSON **number**, unlike
+/// [`ModifiedAtVersionDto::sequence_number`] below, which is a **string** --
+/// this mirrors the monorepo's `ObjectRefSchema` (numeric, via
+/// `SequenceNumberU64`) vs. `SequenceNumberString` distinction exactly; the
+/// two are not interchangeable despite both ultimately wrapping a `Version`.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ObjectRefDto {
+    #[schemars(with = "String")]
+    pub object_id: ObjectId,
+    pub version: u64,
+    #[schemars(with = "String")]
+    pub digest: ObjectDigest,
+}
+
+impl From<ObjectReference> for ObjectRefDto {
+    fn from(r: ObjectReference) -> Self {
+        Self {
+            object_id: r.object_id,
+            version: r.version.as_u64(),
+            digest: r.digest,
+        }
+    }
+}
+
+impl From<ObjectRefDto> for ObjectReference {
+    fn from(r: ObjectRefDto) -> Self {
+        ObjectReference::new(r.object_id, Version::from_u64(r.version), r.digest)
+    }
+}
+
+/// JSON-RPC-shaped owner, mirroring the monorepo's `OwnerSchema`/`IotaOwner`:
+/// `{"AddressOwner": "0x.."}` / `{"ObjectOwner": "0x.."}` /
+/// `{"Shared": {"initial_shared_version": N}}` / `"Immutable"`.
+///
+/// Deliberately *not* `#[serde(rename_all = "camelCase")]`: the monorepo's
+/// `OwnerSchema` has no `rename_all` either, so `Shared`'s inner field stays
+/// `initial_shared_version` verbatim on the wire (not `initialSharedVersion`).
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub enum OwnerDto {
+    AddressOwner(#[schemars(with = "String")] Address),
+    ObjectOwner(#[schemars(with = "String")] Address),
+    Shared { initial_shared_version: u64 },
+    Immutable,
+}
+
+impl From<Owner> for OwnerDto {
+    fn from(owner: Owner) -> Self {
+        match owner {
+            Owner::Address(address) => OwnerDto::AddressOwner(address),
+            Owner::Object(object_id) => OwnerDto::ObjectOwner(*object_id.as_address()),
+            Owner::Shared(initial_shared_version) => OwnerDto::Shared {
+                initial_shared_version: initial_shared_version.as_u64(),
+            },
+            Owner::Immutable => OwnerDto::Immutable,
+            // `Owner` is `#[non_exhaustive]` in iota-sdk-types; mirrors the monorepo's own
+            // defensive arm in `impl From<Owner> for OwnerSchema`.
+            _ => unimplemented!("a new Owner enum variant was added and needs to be handled"),
+        }
+    }
+}
+
+/// `{"owner": <OwnerDto>, "reference": <ObjectRefDto>}`, mirroring the
+/// monorepo's `OwnedObjectRef` (which has `#[serde(rename = "OwnedObjectRef")]`
+/// but *no* `rename_all`, so the field names stay `owner`/`reference` verbatim).
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct OwnedObjectRefDto {
+    pub owner: OwnerDto,
+    pub reference: ObjectRefDto,
+}
+
+/// Mirrors the monorepo's `IotaGasCostSummary`: every field is a JSON string
+/// (`DisplayFromStr`), camelCase.
+#[serde_as]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct GasCostSummaryDto {
+    #[schemars(with = "String")]
+    #[serde_as(as = "DisplayFromStr")]
+    pub computation_cost: u64,
+    #[schemars(with = "String")]
+    #[serde_as(as = "DisplayFromStr")]
+    pub computation_cost_burned: u64,
+    #[schemars(with = "String")]
+    #[serde_as(as = "DisplayFromStr")]
+    pub storage_cost: u64,
+    #[schemars(with = "String")]
+    #[serde_as(as = "DisplayFromStr")]
+    pub storage_rebate: u64,
+    #[schemars(with = "String")]
+    #[serde_as(as = "DisplayFromStr")]
+    pub non_refundable_storage_fee: u64,
+}
+
+impl From<GasCostSummary> for GasCostSummaryDto {
+    fn from(g: GasCostSummary) -> Self {
+        Self {
+            computation_cost: g.computation_cost,
+            computation_cost_burned: g.computation_cost_burned,
+            storage_cost: g.storage_cost,
+            storage_rebate: g.storage_rebate,
+            non_refundable_storage_fee: g.non_refundable_storage_fee,
+        }
+    }
+}
+
+/// Mirrors the monorepo's `IotaExecutionStatus`: internally tagged on
+/// `"status"`, camelCase tag values (`"success"` / `"failure"`), with the
+/// error rendered as its `Display` string -- *not* the clever-error /
+/// Move-package-resolved form (`IotaExecutionStatus::from_native_with_clever_error`),
+/// since that requires an online Move package resolver this service does not
+/// have; this mirrors the plain `From<ExecutionStatus> for IotaExecutionStatus`
+/// impl instead.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename = "ExecutionStatus", rename_all = "camelCase", tag = "status")]
+pub enum ExecutionStatusDto {
+    Success,
+    Failure { error: String },
+}
+
+impl From<ExecutionStatus> for ExecutionStatusDto {
+    fn from(status: ExecutionStatus) -> Self {
+        match status {
+            ExecutionStatus::Success => Self::Success,
+            ExecutionStatus::Failure {
+                error,
+                command: None,
+            } => Self::Failure {
+                error: error.to_string(),
+            },
+            ExecutionStatus::Failure {
+                error,
+                command: Some(idx),
+            } => Self::Failure {
+                error: format!("{error} in command {idx}"),
+            },
+            // `ExecutionStatus` is `#[non_exhaustive]`; mirrors the monorepo's own
+            // defensive arm in `impl From<ExecutionStatus> for IotaExecutionStatus`.
+            _ => unimplemented!(
+                "a new ExecutionStatus enum variant was added and needs to be handled"
+            ),
+        }
+    }
+}
+
+/// Mirrors the monorepo's `IotaTransactionBlockEffectsModifiedAtVersions`.
+///
+/// Note `sequence_number` here is a JSON **string** (`SequenceNumberString` in
+/// the monorepo) -- unlike [`ObjectRefDto::version`], which is a plain number.
+#[serde_as]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ModifiedAtVersionDto {
+    #[schemars(with = "String")]
+    pub object_id: ObjectId,
+    #[schemars(with = "String")]
+    #[serde_as(as = "DisplayFromStr")]
+    pub sequence_number: Version,
+}
+
+/// JSON-RPC-shaped transaction effects (`IotaTransactionBlockEffectsV1`'s wire
+/// shape, flattened -- see the module doc for why this isn't modeled as an
+/// enum). `#[serde(rename_all = "camelCase")]` applies to every field below.
+#[serde_as]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct TransactionEffectsDto {
+    /// Always `"v1"`: the SDK's `TransactionEffects` only has a `V1` payload today.
+    pub message_version: String,
+    pub status: ExecutionStatusDto,
+    #[schemars(with = "String")]
+    #[serde_as(as = "DisplayFromStr")]
+    pub executed_epoch: EpochId,
+    pub gas_used: GasCostSummaryDto,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub modified_at_versions: Vec<ModifiedAtVersionDto>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub shared_objects: Vec<ObjectRefDto>,
+    #[schemars(with = "String")]
+    pub transaction_digest: TransactionDigest,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub created: Vec<OwnedObjectRefDto>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub mutated: Vec<OwnedObjectRefDto>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub unwrapped: Vec<OwnedObjectRefDto>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub deleted: Vec<ObjectRefDto>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub unwrapped_then_deleted: Vec<ObjectRefDto>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub wrapped: Vec<ObjectRefDto>,
+    pub gas_object: OwnedObjectRefDto,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schemars(with = "Option<String>")]
+    pub events_digest: Option<TransactionEventsDigest>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[schemars(with = "Vec<String>")]
+    pub dependencies: Vec<TransactionDigest>,
+}
+
+// ---------------------------------------------------------------------------
+// Derivation from the SDK's compact `TransactionEffectsV1`, ported from
+// `crates/iota-types/src/effects/v1.rs` (`impl TransactionEffectsAPI for
+// TransactionEffectsV1`) on the `iotaledger/iota` monorepo `develop` branch.
+// ---------------------------------------------------------------------------
+
+fn modified_at_versions(v1: &TransactionEffectsV1) -> Vec<(ObjectId, Version)> {
+    v1.changed_objects
+        .iter()
+        .filter_map(|changed| {
+            if let ObjectIn::Data { version, .. } = &changed.input_state {
+                Some((changed.object_id, *version))
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+fn created(v1: &TransactionEffectsV1) -> Vec<(ObjectReference, Owner)> {
+    v1.changed_objects
+        .iter()
+        .filter_map(|changed| {
+            match (
+                &changed.input_state,
+                &changed.output_state,
+                &changed.id_operation,
+            ) {
+                (
+                    ObjectIn::Missing,
+                    ObjectOut::ObjectWrite { digest, owner },
+                    IdOperation::Created,
+                ) => Some((
+                    ObjectReference::new(changed.object_id, v1.lamport_version, *digest),
+                    *owner,
+                )),
+                // Asymmetry: package versions come from the write itself, never from
+                // `lamport_version` (packages don't use the lamport clock).
+                (
+                    ObjectIn::Missing,
+                    ObjectOut::PackageWrite { version, digest },
+                    IdOperation::Created,
+                ) => Some((
+                    ObjectReference::new(changed.object_id, *version, *digest),
+                    Owner::Immutable,
+                )),
+                _ => None,
+            }
+        })
+        .collect()
+}
+
+fn mutated(v1: &TransactionEffectsV1) -> Vec<(ObjectReference, Owner)> {
+    v1.changed_objects
+        .iter()
+        .filter_map(
+            |changed| match (&changed.input_state, &changed.output_state) {
+                (ObjectIn::Data { .. }, ObjectOut::ObjectWrite { digest, owner }) => Some((
+                    ObjectReference::new(changed.object_id, v1.lamport_version, *digest),
+                    *owner,
+                )),
+                // Same package-version asymmetry as in `created` above (system package upgrades).
+                (ObjectIn::Data { .. }, ObjectOut::PackageWrite { version, digest }) => Some((
+                    ObjectReference::new(changed.object_id, *version, *digest),
+                    Owner::Immutable,
+                )),
+                _ => None,
+            },
+        )
+        .collect()
+}
+
+fn unwrapped(v1: &TransactionEffectsV1) -> Vec<(ObjectReference, Owner)> {
+    v1.changed_objects
+        .iter()
+        .filter_map(|changed| {
+            match (
+                &changed.input_state,
+                &changed.output_state,
+                &changed.id_operation,
+            ) {
+                (
+                    ObjectIn::Missing,
+                    ObjectOut::ObjectWrite { digest, owner },
+                    IdOperation::None,
+                ) => Some((
+                    ObjectReference::new(changed.object_id, v1.lamport_version, *digest),
+                    *owner,
+                )),
+                _ => None,
+            }
+        })
+        .collect()
+}
+
+fn deleted(v1: &TransactionEffectsV1) -> Vec<ObjectReference> {
+    v1.changed_objects
+        .iter()
+        .filter_map(|changed| {
+            match (
+                &changed.input_state,
+                &changed.output_state,
+                &changed.id_operation,
+            ) {
+                (ObjectIn::Data { .. }, ObjectOut::Missing, IdOperation::Deleted) => {
+                    Some(ObjectReference::new(
+                        changed.object_id,
+                        v1.lamport_version,
+                        ObjectDigest::OBJECT_DELETED,
+                    ))
+                }
+                _ => None,
+            }
+        })
+        .collect()
+}
+
+fn unwrapped_then_deleted(v1: &TransactionEffectsV1) -> Vec<ObjectReference> {
+    v1.changed_objects
+        .iter()
+        .filter_map(|changed| {
+            match (
+                &changed.input_state,
+                &changed.output_state,
+                &changed.id_operation,
+            ) {
+                (ObjectIn::Missing, ObjectOut::Missing, IdOperation::Deleted) => {
+                    Some(ObjectReference::new(
+                        changed.object_id,
+                        v1.lamport_version,
+                        ObjectDigest::OBJECT_DELETED,
+                    ))
+                }
+                _ => None,
+            }
+        })
+        .collect()
+}
+
+fn wrapped(v1: &TransactionEffectsV1) -> Vec<ObjectReference> {
+    v1.changed_objects
+        .iter()
+        .filter_map(|changed| {
+            match (
+                &changed.input_state,
+                &changed.output_state,
+                &changed.id_operation,
+            ) {
+                (ObjectIn::Data { .. }, ObjectOut::Missing, IdOperation::None) => {
+                    Some(ObjectReference::new(
+                        changed.object_id,
+                        v1.lamport_version,
+                        ObjectDigest::OBJECT_WRAPPED,
+                    ))
+                }
+                _ => None,
+            }
+        })
+        .collect()
+}
+
+fn gas_object(v1: &TransactionEffectsV1) -> (ObjectReference, Owner) {
+    if let Some(gas_object_index) = v1.gas_object_index {
+        let changed = &v1.changed_objects[gas_object_index as usize];
+        match &changed.output_state {
+            ObjectOut::ObjectWrite { digest, owner } => (
+                ObjectReference::new(changed.object_id, v1.lamport_version, *digest),
+                *owner,
+            ),
+            _ => panic!("Gas object must be an ObjectWrite in changed_objects"),
+        }
+    } else {
+        // System transactions that don't require gas.
+        (
+            ObjectReference::new(ObjectId::ZERO, Version::default(), ObjectDigest::MIN),
+            Owner::Address(Address::ZERO),
+        )
+    }
+}
+
+/// Ported from `TransactionEffectsAPI::input_shared_objects` (which returns
+/// `Vec<InputSharedObject>`) fused with `InputSharedObject::object_ref()`,
+/// since the JSON-RPC DTO only ever needs the flattened `ObjectReference`
+/// list (`IotaTransactionBlockEffectsV1::shared_objects`), not the
+/// `InputSharedObject` enum itself.
+fn shared_object_refs(v1: &TransactionEffectsV1) -> Vec<ObjectReference> {
+    v1.changed_objects
+        .iter()
+        .filter_map(|changed| {
+            if let ObjectIn::Data {
+                version,
+                digest,
+                owner: Owner::Shared { .. },
+            } = &changed.input_state
+            {
+                Some(ObjectReference::new(changed.object_id, *version, *digest))
+            } else {
+                None
+            }
+        })
+        .chain(v1.unchanged_shared_objects.iter().filter_map(|unchanged| {
+            match &unchanged.kind {
+                UnchangedSharedKind::ReadOnlyRoot { version, digest } => {
+                    Some(ObjectReference::new(unchanged.object_id, *version, *digest))
+                }
+                UnchangedSharedKind::MutateDeleted { version } => Some(ObjectReference::new(
+                    unchanged.object_id,
+                    *version,
+                    ObjectDigest::OBJECT_DELETED,
+                )),
+                UnchangedSharedKind::ReadDeleted { version } => Some(ObjectReference::new(
+                    unchanged.object_id,
+                    *version,
+                    ObjectDigest::OBJECT_DELETED,
+                )),
+                UnchangedSharedKind::Cancelled { version } => Some(ObjectReference::new(
+                    unchanged.object_id,
+                    *version,
+                    ObjectDigest::OBJECT_CANCELLED,
+                )),
+                // Per-epoch config objects don't require sequencing and are excluded from
+                // the shared-objects view, matching `TransactionEffectsAPI::input_shared_objects`.
+                UnchangedSharedKind::PerEpochConfig => None,
+                // `UnchangedSharedKind` is `#[non_exhaustive]`; mirrors the monorepo's own
+                // defensive arm in `TransactionEffectsV1::input_shared_objects`.
+                _ => unimplemented!(
+                    "a new UnchangedSharedKind enum variant was added and needs to be handled"
+                ),
+            }
+        }))
+        .collect()
+}
+
+fn to_owned_refs(refs: Vec<(ObjectReference, Owner)>) -> Vec<OwnedObjectRefDto> {
+    refs.into_iter()
+        .map(|(reference, owner)| OwnedObjectRefDto {
+            owner: owner.into(),
+            reference: reference.into(),
+        })
+        .collect()
+}
+
+impl From<&TransactionEffectsV1> for TransactionEffectsDto {
+    fn from(v1: &TransactionEffectsV1) -> Self {
+        let (gas_reference, gas_owner) = gas_object(v1);
+        Self {
+            message_version: "v1".to_string(),
+            status: v1.status.clone().into(),
+            executed_epoch: v1.epoch,
+            gas_used: v1.gas_cost_summary.clone().into(),
+            modified_at_versions: modified_at_versions(v1)
+                .into_iter()
+                .map(|(object_id, sequence_number)| ModifiedAtVersionDto {
+                    object_id,
+                    sequence_number,
+                })
+                .collect(),
+            shared_objects: shared_object_refs(v1).into_iter().map(Into::into).collect(),
+            transaction_digest: v1.transaction_digest,
+            created: to_owned_refs(created(v1)),
+            mutated: to_owned_refs(mutated(v1)),
+            unwrapped: to_owned_refs(unwrapped(v1)),
+            deleted: deleted(v1).into_iter().map(Into::into).collect(),
+            unwrapped_then_deleted: unwrapped_then_deleted(v1)
+                .into_iter()
+                .map(Into::into)
+                .collect(),
+            wrapped: wrapped(v1).into_iter().map(Into::into).collect(),
+            gas_object: OwnedObjectRefDto {
+                owner: gas_owner.into(),
+                reference: gas_reference.into(),
+            },
+            events_digest: v1.events_digest,
+            dependencies: v1.dependencies.clone(),
+        }
+    }
+}
+
+impl From<TransactionEffectsV1> for TransactionEffectsDto {
+    fn from(v1: TransactionEffectsV1) -> Self {
+        Self::from(&v1)
+    }
+}
+
+impl From<TransactionEffects> for TransactionEffectsDto {
+    fn from(effects: TransactionEffects) -> Self {
+        // `TransactionEffects` only has a `V1` payload today; `into_v1()` is an
+        // inherent method on the SDK's own (non_exhaustive-to-us, but not to
+        // itself) enum, so no wildcard arm is needed here.
+        effects.into_v1().into()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use iota_sdk_types::{ChangedObject, ExecutionError, UnchangedSharedObject};
+    use serde_json::json;
+
+    fn oid(byte: u8) -> ObjectId {
+        ObjectId::new([byte; 32])
+    }
+
+    fn addr(byte: u8) -> Address {
+        Address::new([byte; 32])
+    }
+
+    fn odig(byte: u8) -> ObjectDigest {
+        ObjectDigest::new([byte; 32])
+    }
+
+    fn txdig(byte: u8) -> TransactionDigest {
+        TransactionDigest::new([byte; 32])
+    }
+
+    fn base_gas_cost_summary() -> GasCostSummary {
+        GasCostSummary::new(100, 10, 50, 20, 5)
+    }
+
+    fn expected_gas_used_json() -> serde_json::Value {
+        json!({
+            "computationCost": "100",
+            "computationCostBurned": "10",
+            "storageCost": "50",
+            "storageRebate": "20",
+            "nonRefundableStorageFee": "5",
+        })
+    }
+
+    /// (a) Simple success with exactly one mutated (gas) object.
+    #[test]
+    fn simple_success_mutated_gas_object() {
+        let gas_owner_addr = addr(0xA0);
+        let v1 = TransactionEffectsV1 {
+            status: ExecutionStatus::Success,
+            epoch: 42,
+            gas_cost_summary: base_gas_cost_summary(),
+            transaction_digest: txdig(1),
+            gas_object_index: Some(0),
+            events_digest: None,
+            dependencies: vec![],
+            lamport_version: Version::from_u64(6),
+            changed_objects: vec![ChangedObject {
+                object_id: oid(2),
+                input_state: ObjectIn::Data {
+                    version: Version::from_u64(5),
+                    digest: odig(3),
+                    owner: Owner::Address(gas_owner_addr),
+                },
+                output_state: ObjectOut::ObjectWrite {
+                    digest: odig(4),
+                    owner: Owner::Address(gas_owner_addr),
+                },
+                id_operation: IdOperation::None,
+            }],
+            unchanged_shared_objects: vec![],
+            auxiliary_data_digest: None,
+        };
+
+        let dto = TransactionEffectsDto::from(&v1);
+        let actual = serde_json::to_value(&dto).unwrap();
+
+        let expected = json!({
+            "messageVersion": "v1",
+            "status": { "status": "success" },
+            "executedEpoch": "42",
+            "gasUsed": expected_gas_used_json(),
+            "modifiedAtVersions": [
+                { "objectId": oid(2).to_string(), "sequenceNumber": "5" },
+            ],
+            "transactionDigest": txdig(1).to_string(),
+            "mutated": [
+                {
+                    "owner": { "AddressOwner": gas_owner_addr.to_string() },
+                    "reference": {
+                        "objectId": oid(2).to_string(),
+                        "version": 6,
+                        "digest": odig(4).to_string(),
+                    },
+                },
+            ],
+            "gasObject": {
+                "owner": { "AddressOwner": gas_owner_addr.to_string() },
+                "reference": {
+                    "objectId": oid(2).to_string(),
+                    "version": 6,
+                    "digest": odig(4).to_string(),
+                },
+            },
+        });
+
+        assert_eq!(actual, expected);
+    }
+
+    /// (b) Created + mutated + deleted objects together, plus a
+    /// `modifiedAtVersions` entry and a non-empty `dependencies` list.
+    #[test]
+    fn created_mutated_deleted_together() {
+        let owner_a = addr(0xA1);
+        let owner_b = addr(0xA2);
+
+        let created_obj = ChangedObject {
+            object_id: oid(10),
+            input_state: ObjectIn::Missing,
+            output_state: ObjectOut::ObjectWrite {
+                digest: odig(11),
+                owner: Owner::Address(owner_a),
+            },
+            id_operation: IdOperation::Created,
+        };
+        let mutated_obj = ChangedObject {
+            object_id: oid(20),
+            input_state: ObjectIn::Data {
+                version: Version::from_u64(3),
+                digest: odig(21),
+                owner: Owner::Address(owner_b),
+            },
+            output_state: ObjectOut::ObjectWrite {
+                digest: odig(22),
+                owner: Owner::Address(owner_b),
+            },
+            id_operation: IdOperation::None,
+        };
+        let deleted_obj = ChangedObject {
+            object_id: oid(30),
+            input_state: ObjectIn::Data {
+                version: Version::from_u64(7),
+                digest: odig(31),
+                owner: Owner::Address(owner_a),
+            },
+            output_state: ObjectOut::Missing,
+            id_operation: IdOperation::Deleted,
+        };
+        // Gas object, mutated, at index 1 (matches `changed_objects` ordering below).
+        let gas_obj = ChangedObject {
+            object_id: oid(40),
+            input_state: ObjectIn::Data {
+                version: Version::from_u64(1),
+                digest: odig(41),
+                owner: Owner::Address(owner_a),
+            },
+            output_state: ObjectOut::ObjectWrite {
+                digest: odig(42),
+                owner: Owner::Address(owner_a),
+            },
+            id_operation: IdOperation::None,
+        };
+
+        let v1 = TransactionEffectsV1 {
+            status: ExecutionStatus::Success,
+            epoch: 7,
+            gas_cost_summary: base_gas_cost_summary(),
+            transaction_digest: txdig(50),
+            gas_object_index: Some(3),
+            events_digest: Some(TransactionEventsDigest::new([60; 32])),
+            dependencies: vec![txdig(70), txdig(71)],
+            lamport_version: Version::from_u64(8),
+            changed_objects: vec![created_obj, mutated_obj, deleted_obj, gas_obj],
+            unchanged_shared_objects: vec![],
+            auxiliary_data_digest: None,
+        };
+
+        let dto = TransactionEffectsDto::from(&v1);
+        let actual = serde_json::to_value(&dto).unwrap();
+
+        let expected = json!({
+            "messageVersion": "v1",
+            "status": { "status": "success" },
+            "executedEpoch": "7",
+            "gasUsed": expected_gas_used_json(),
+            "modifiedAtVersions": [
+                { "objectId": oid(20).to_string(), "sequenceNumber": "3" },
+                { "objectId": oid(30).to_string(), "sequenceNumber": "7" },
+                { "objectId": oid(40).to_string(), "sequenceNumber": "1" },
+            ],
+            "transactionDigest": txdig(50).to_string(),
+            "created": [
+                {
+                    "owner": { "AddressOwner": owner_a.to_string() },
+                    "reference": { "objectId": oid(10).to_string(), "version": 8, "digest": odig(11).to_string() },
+                },
+            ],
+            "mutated": [
+                {
+                    "owner": { "AddressOwner": owner_b.to_string() },
+                    "reference": { "objectId": oid(20).to_string(), "version": 8, "digest": odig(22).to_string() },
+                },
+                {
+                    "owner": { "AddressOwner": owner_a.to_string() },
+                    "reference": { "objectId": oid(40).to_string(), "version": 8, "digest": odig(42).to_string() },
+                },
+            ],
+            "deleted": [
+                { "objectId": oid(30).to_string(), "version": 8, "digest": ObjectDigest::OBJECT_DELETED.to_string() },
+            ],
+            "gasObject": {
+                "owner": { "AddressOwner": owner_a.to_string() },
+                "reference": { "objectId": oid(40).to_string(), "version": 8, "digest": odig(42).to_string() },
+            },
+            "eventsDigest": TransactionEventsDigest::new([60; 32]).to_string(),
+            "dependencies": [txdig(70).to_string(), txdig(71).to_string()],
+        });
+
+        assert_eq!(actual, expected);
+    }
+
+    /// (c) A shared object appearing (read-only) in `unchanged_shared_objects`.
+    #[test]
+    fn shared_object_in_unchanged_shared_objects() {
+        let gas_owner_addr = addr(0xB0);
+        let shared_id = oid(80);
+        let shared_version = Version::from_u64(15);
+        let shared_digest = odig(81);
+
+        let v1 = TransactionEffectsV1 {
+            status: ExecutionStatus::Success,
+            epoch: 1,
+            gas_cost_summary: base_gas_cost_summary(),
+            transaction_digest: txdig(90),
+            gas_object_index: Some(0),
+            events_digest: None,
+            dependencies: vec![],
+            lamport_version: Version::from_u64(2),
+            changed_objects: vec![ChangedObject {
+                object_id: oid(91),
+                input_state: ObjectIn::Data {
+                    version: Version::from_u64(1),
+                    digest: odig(92),
+                    owner: Owner::Address(gas_owner_addr),
+                },
+                output_state: ObjectOut::ObjectWrite {
+                    digest: odig(93),
+                    owner: Owner::Address(gas_owner_addr),
+                },
+                id_operation: IdOperation::None,
+            }],
+            unchanged_shared_objects: vec![UnchangedSharedObject {
+                object_id: shared_id,
+                kind: UnchangedSharedKind::ReadOnlyRoot {
+                    version: shared_version,
+                    digest: shared_digest,
+                },
+            }],
+            auxiliary_data_digest: None,
+        };
+
+        let dto = TransactionEffectsDto::from(&v1);
+        let actual = serde_json::to_value(&dto).unwrap();
+
+        assert_eq!(
+            actual["sharedObjects"],
+            json!([
+                {
+                    "objectId": shared_id.to_string(),
+                    "version": 15,
+                    "digest": shared_digest.to_string(),
+                },
+            ])
+        );
+        // Sanity: the shared object must not leak into any of the other object lists.
+        assert_eq!(actual.get("created"), None);
+        assert_eq!(actual.get("deleted"), None);
+    }
+
+    /// (e) `PackageWrite`: the created package's `ObjectRefDto.version` must come
+    /// from `ObjectOut::PackageWrite`'s own `version` field, *not* `lamport_version`
+    /// -- this is the asymmetry called out explicitly in this stage's task.
+    #[test]
+    fn package_write_uses_its_own_version_not_lamport_version() {
+        let package_id = oid(100);
+        let package_version = Version::from_u64(3); // deliberately != lamport_version
+        let package_digest = odig(101);
+
+        let v1 = TransactionEffectsV1 {
+            status: ExecutionStatus::Success,
+            epoch: 1,
+            gas_cost_summary: base_gas_cost_summary(),
+            transaction_digest: txdig(110),
+            gas_object_index: None,
+            events_digest: None,
+            dependencies: vec![],
+            lamport_version: Version::from_u64(999), // must NOT show up on the package ref
+            changed_objects: vec![ChangedObject {
+                object_id: package_id,
+                input_state: ObjectIn::Missing,
+                output_state: ObjectOut::PackageWrite {
+                    version: package_version,
+                    digest: package_digest,
+                },
+                id_operation: IdOperation::Created,
+            }],
+            unchanged_shared_objects: vec![],
+            auxiliary_data_digest: None,
+        };
+
+        let dto = TransactionEffectsDto::from(&v1);
+        let actual = serde_json::to_value(&dto).unwrap();
+
+        assert_eq!(
+            actual["created"],
+            json!([
+                {
+                    "owner": "Immutable",
+                    "reference": {
+                        "objectId": package_id.to_string(),
+                        "version": 3,
+                        "digest": package_digest.to_string(),
+                    },
+                },
+            ])
+        );
+    }
+
+    /// (d) Failure status golden-JSON coverage for the four `ExecutionError`
+    /// variants that were permuted at the *old* (now-superseded) iota-sdk-types
+    /// revision this codebase used to pin -- proving these round-trip correctly
+    /// through `ExecutionStatusDto` is the most important regression check here.
+    fn failure_effects_with(error: ExecutionError) -> TransactionEffectsV1 {
+        TransactionEffectsV1 {
+            status: ExecutionStatus::new_failure(error, None),
+            epoch: 3,
+            gas_cost_summary: base_gas_cost_summary(),
+            transaction_digest: txdig(200),
+            gas_object_index: Some(0),
+            events_digest: None,
+            dependencies: vec![],
+            lamport_version: Version::from_u64(2),
+            changed_objects: vec![ChangedObject {
+                object_id: oid(201),
+                input_state: ObjectIn::Data {
+                    version: Version::from_u64(1),
+                    digest: odig(202),
+                    owner: Owner::Address(addr(0xC0)),
+                },
+                output_state: ObjectOut::ObjectWrite {
+                    digest: odig(203),
+                    owner: Owner::Address(addr(0xC0)),
+                },
+                id_operation: IdOperation::None,
+            }],
+            unchanged_shared_objects: vec![],
+            auxiliary_data_digest: None,
+        }
+    }
+
+    #[test]
+    fn failure_status_address_denied_for_coin() {
+        let error = ExecutionError::AddressDeniedForCoin {
+            address: addr(0xD0),
+            coin_type: "0x2::iota::IOTA".to_string(),
+        };
+        let expected_message = error.to_string();
+        let v1 = failure_effects_with(error);
+
+        let dto = TransactionEffectsDto::from(&v1);
+        let actual = serde_json::to_value(&dto).unwrap();
+        assert_eq!(
+            actual["status"],
+            json!({ "status": "failure", "error": expected_message })
+        );
+    }
+
+    #[test]
+    fn failure_status_coin_type_global_pause() {
+        let error = ExecutionError::CoinTypeGlobalPause {
+            coin_type: "0x2::iota::IOTA".to_string(),
+        };
+        let expected_message = error.to_string();
+        assert_eq!(
+            expected_message,
+            "Coin type is globally paused for use: 0x2::iota::IOTA"
+        );
+        let v1 = failure_effects_with(error);
+
+        let dto = TransactionEffectsDto::from(&v1);
+        let actual = serde_json::to_value(&dto).unwrap();
+        assert_eq!(
+            actual["status"],
+            json!({ "status": "failure", "error": expected_message })
+        );
+    }
+
+    #[test]
+    fn failure_status_randomness_unavailable() {
+        let error = ExecutionError::ExecutionCancelledDueToRandomnessUnavailable;
+        let expected_message = error.to_string();
+        assert_eq!(
+            expected_message,
+            "Certificate is cancelled because randomness could not be generated this epoch"
+        );
+        let v1 = failure_effects_with(error);
+
+        let dto = TransactionEffectsDto::from(&v1);
+        let actual = serde_json::to_value(&dto).unwrap();
+        assert_eq!(
+            actual["status"],
+            json!({ "status": "failure", "error": expected_message })
+        );
+    }
+
+    #[test]
+    fn failure_status_congestion_v2_with_command_index() {
+        let error = ExecutionError::ExecutionCancelledDueToSharedObjectCongestionV2 {
+            congested_objects: vec![oid(210), oid(211)],
+            suggested_gas_price: 12_345,
+        };
+        // Exercise the `command: Some(idx)` branch too (`"{error} in command {idx}"`).
+        let mut v1 = failure_effects_with(error.clone());
+        v1.status = ExecutionStatus::new_failure(error.clone(), Some(2));
+        let expected_message = format!("{error} in command 2");
+
+        let dto = TransactionEffectsDto::from(&v1);
+        let actual = serde_json::to_value(&dto).unwrap();
+        assert_eq!(
+            actual["status"],
+            json!({ "status": "failure", "error": expected_message })
+        );
+    }
+}

--- a/src/rpc/effects.rs
+++ b/src/rpc/effects.rs
@@ -4,48 +4,15 @@
 
 //! JSON-RPC-shaped transaction effects DTOs.
 //!
-//! The SDK's own [`iota_sdk_types::TransactionEffects`] (and its `V1` payload,
-//! [`TransactionEffectsV1`]) use a *compact* representation: a single
-//! `changed_objects: Vec<ChangedObject>` list (each entry carrying its
-//! before/after state plus an [`IdOperation`]), rather than the flat
-//! `created`/`mutated`/`deleted`/... lists that this service's existing
-//! `/v1/execute_tx` clients (including this SDK's own [`super::client`]) have
-//! always received on the wire and depend on byte-for-byte.
+//! The SDK's [`iota_sdk_types::TransactionEffects`] uses a compact
+//! representation (a single `changed_objects` list carrying before/after
+//! state), while this service's `/v1/execute_tx` clients depend byte-for-byte
+//! on the flat `created`/`mutated`/`deleted`/... JSON-RPC shape
+//! (`IotaTransactionBlockEffectsV1`). This module defines that flat wire type
+//! and derives it from the compact one.
 //!
-//! This module defines that flat, JSON-RPC-shaped wire type (mirroring
-//! `IotaTransactionBlockEffectsV1` from `iota-json-rpc-types` on the
-//! `iotaledger/iota` monorepo) and derives it from the SDK's compact
-//! `TransactionEffectsV1`. Both the *derivation* (the `created()`/`mutated()`/
-//! .../`gas_object()` logic below) and the *serde shape* (every
-//! `#[serde(...)]`/`#[schemars(...)]` annotation) are ported from the
-//! monorepo's `develop` branch, which has already done this exact migration
-//! for the node itself against the same pinned `iota-sdk-types` revision this
-//! crate uses:
-//!   - `crates/iota-types/src/effects/v1.rs`
-//!     (`impl TransactionEffectsAPI for TransactionEffectsV1`) for the
-//!     derivation logic.
-//!   - `crates/iota-json-rpc-types/src/iota_transaction.rs`
-//!     (`IotaTransactionBlockEffectsV1` and
-//!     `impl<T: TransactionEffectsAPI> From<T> for IotaTransactionBlockEffectsV1`)
-//!     for the wire shape and the flattening logic.
-//!   - `crates/iota-json-rpc-types/src/{iota_gas_cost_summary,iota_owner,iota_object,iota_primitives}.rs`
-//!     for the exact per-field serde/schemars adapters (`IotaGasCostSummary`,
-//!     `OwnerSchema`, `ObjectRefSchema`, `SequenceNumberU64`,
-//!     `SequenceNumberString`, ...) that this module's local DTOs replicate.
-//!
-//! Renames encountered while porting (monorepo `iota-types` re-exports the SDK
-//! types under old names in some places -- this module always uses the real
-//! `iota_sdk_types` names): `ObjectIn::NotExist` -> `Missing`,
-//! `ObjectOut::NotExist` -> `Missing`, `IDOperation` -> `IdOperation`.
-//!
-//! One design simplification versus the monorepo: `IotaTransactionBlockEffects`
-//! there is an enum (`V1(IotaTransactionBlockEffectsV1)`) internally tagged on
-//! `messageVersion`, so that on the wire the tag and the `V1` payload's fields
-//! are flattened into one JSON object. Since the SDK's `TransactionEffects`
-//! only ever has a single `V1` variant, [`TransactionEffectsDto`] below bakes
-//! that flattening in directly as a single struct with a `message_version`
-//! field fixed to `"v1"`, rather than modeling the enum -- this produces
-//! byte-identical JSON while being simpler to define and to test.
+//! The JSON shape is a wire contract: field names, casing, number-vs-string
+//! renderings, and empty-list omission must not change.
 
 use iota_sdk_types::{
     Address, EpochId, ExecutionStatus, GasCostSummary, IdOperation, ObjectDigest, ObjectId,
@@ -58,13 +25,9 @@ use serde_with::{serde_as, DisplayFromStr};
 
 /// JSON-RPC-shaped object reference: `{"objectId": "0x..", "version": N, "digest": ".."}`.
 ///
-/// This intentionally does *not* reuse `iota_sdk_types::ObjectReference`'s own
-/// `Serialize` impl (which is snake_case and not part of our wire contract);
-/// note also that `version` here is a plain JSON **number**, unlike
-/// [`ModifiedAtVersionDto::sequence_number`] below, which is a **string** --
-/// this mirrors the monorepo's `ObjectRefSchema` (numeric, via
-/// `SequenceNumberU64`) vs. `SequenceNumberString` distinction exactly; the
-/// two are not interchangeable despite both ultimately wrapping a `Version`.
+/// `version` here is a plain JSON **number**, unlike
+/// [`ModifiedAtVersionDto::sequence_number`], which is a **string** -- the two
+/// are not interchangeable despite both wrapping a `Version`.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct ObjectRefDto {
@@ -91,13 +54,11 @@ impl From<ObjectRefDto> for ObjectReference {
     }
 }
 
-/// JSON-RPC-shaped owner, mirroring the monorepo's `OwnerSchema`/`IotaOwner`:
-/// `{"AddressOwner": "0x.."}` / `{"ObjectOwner": "0x.."}` /
-/// `{"Shared": {"initial_shared_version": N}}` / `"Immutable"`.
+/// JSON-RPC-shaped owner: `{"AddressOwner": "0x.."}` / `{"ObjectOwner": "0x.."}`
+/// / `{"Shared": {"initial_shared_version": N}}` / `"Immutable"`.
 ///
-/// Deliberately *not* `#[serde(rename_all = "camelCase")]`: the monorepo's
-/// `OwnerSchema` has no `rename_all` either, so `Shared`'s inner field stays
-/// `initial_shared_version` verbatim on the wire (not `initialSharedVersion`).
+/// Deliberately *not* `#[serde(rename_all = "camelCase")]`: `Shared`'s inner
+/// field stays `initial_shared_version` verbatim on the wire.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
 pub enum OwnerDto {
     AddressOwner(#[schemars(with = "String")] Address),
@@ -115,24 +76,21 @@ impl From<Owner> for OwnerDto {
                 initial_shared_version: initial_shared_version.as_u64(),
             },
             Owner::Immutable => OwnerDto::Immutable,
-            // `Owner` is `#[non_exhaustive]` in iota-sdk-types; mirrors the monorepo's own
-            // defensive arm in `impl From<Owner> for OwnerSchema`.
+            // `Owner` is `#[non_exhaustive]` in iota-sdk-types.
             _ => unimplemented!("a new Owner enum variant was added and needs to be handled"),
         }
     }
 }
 
-/// `{"owner": <OwnerDto>, "reference": <ObjectRefDto>}`, mirroring the
-/// monorepo's `OwnedObjectRef` (which has `#[serde(rename = "OwnedObjectRef")]`
-/// but *no* `rename_all`, so the field names stay `owner`/`reference` verbatim).
+/// `{"owner": <OwnerDto>, "reference": <ObjectRefDto>}` (no `rename_all`; the
+/// field names stay `owner`/`reference` verbatim on the wire).
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
 pub struct OwnedObjectRefDto {
     pub owner: OwnerDto,
     pub reference: ObjectRefDto,
 }
 
-/// Mirrors the monorepo's `IotaGasCostSummary`: every field is a JSON string
-/// (`DisplayFromStr`), camelCase.
+/// Gas cost summary; every field is a JSON string (`DisplayFromStr`), camelCase.
 #[serde_as]
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
@@ -166,13 +124,9 @@ impl From<GasCostSummary> for GasCostSummaryDto {
     }
 }
 
-/// Mirrors the monorepo's `IotaExecutionStatus`: internally tagged on
-/// `"status"`, camelCase tag values (`"success"` / `"failure"`), with the
-/// error rendered as its `Display` string -- *not* the clever-error /
-/// Move-package-resolved form (`IotaExecutionStatus::from_native_with_clever_error`),
-/// since that requires an online Move package resolver this service does not
-/// have; this mirrors the plain `From<ExecutionStatus> for IotaExecutionStatus`
-/// impl instead.
+/// Execution status: internally tagged on `"status"`, camelCase tag values
+/// (`"success"` / `"failure"`), with the error rendered as its `Display`
+/// string.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename = "ExecutionStatus", rename_all = "camelCase", tag = "status")]
 pub enum ExecutionStatusDto {
@@ -203,8 +157,7 @@ impl From<ExecutionStatus> for ExecutionStatusDto {
             } => Self::Failure {
                 error: format!("{error} in command {idx}"),
             },
-            // `ExecutionStatus` is `#[non_exhaustive]`; mirrors the monorepo's own
-            // defensive arm in `impl From<ExecutionStatus> for IotaExecutionStatus`.
+            // `ExecutionStatus` is `#[non_exhaustive]` in iota-sdk-types.
             _ => unimplemented!(
                 "a new ExecutionStatus enum variant was added and needs to be handled"
             ),
@@ -212,10 +165,8 @@ impl From<ExecutionStatus> for ExecutionStatusDto {
     }
 }
 
-/// Mirrors the monorepo's `IotaTransactionBlockEffectsModifiedAtVersions`.
-///
-/// Note `sequence_number` here is a JSON **string** (`SequenceNumberString` in
-/// the monorepo) -- unlike [`ObjectRefDto::version`], which is a plain number.
+/// Note `sequence_number` here is a JSON **string** -- unlike
+/// [`ObjectRefDto::version`], which is a plain number.
 #[serde_as]
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
@@ -227,9 +178,8 @@ pub struct ModifiedAtVersionDto {
     pub sequence_number: Version,
 }
 
-/// JSON-RPC-shaped transaction effects (`IotaTransactionBlockEffectsV1`'s wire
-/// shape, flattened -- see the module doc for why this isn't modeled as an
-/// enum). `#[serde(rename_all = "camelCase")]` applies to every field below.
+/// JSON-RPC-shaped transaction effects. `#[serde(rename_all = "camelCase")]`
+/// applies to every field below.
 #[serde_as]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
@@ -269,9 +219,7 @@ pub struct TransactionEffectsDto {
 }
 
 // ---------------------------------------------------------------------------
-// Derivation from the SDK's compact `TransactionEffectsV1`, ported from
-// `crates/iota-types/src/effects/v1.rs` (`impl TransactionEffectsAPI for
-// TransactionEffectsV1`) on the `iotaledger/iota` monorepo `develop` branch.
+// Derivation of the flat lists from the SDK's compact `TransactionEffectsV1`.
 // ---------------------------------------------------------------------------
 
 fn modified_at_versions(v1: &TransactionEffectsV1) -> Vec<(ObjectId, Version)> {
@@ -448,11 +396,6 @@ fn gas_object(v1: &TransactionEffectsV1) -> (ObjectReference, Owner) {
     }
 }
 
-/// Ported from `TransactionEffectsAPI::input_shared_objects` (which returns
-/// `Vec<InputSharedObject>`) fused with `InputSharedObject::object_ref()`,
-/// since the JSON-RPC DTO only ever needs the flattened `ObjectReference`
-/// list (`IotaTransactionBlockEffectsV1::shared_objects`), not the
-/// `InputSharedObject` enum itself.
 fn shared_object_refs(v1: &TransactionEffectsV1) -> Vec<ObjectReference> {
     v1.changed_objects
         .iter()
@@ -488,11 +431,10 @@ fn shared_object_refs(v1: &TransactionEffectsV1) -> Vec<ObjectReference> {
                     *version,
                     ObjectDigest::OBJECT_CANCELLED,
                 )),
-                // Per-epoch config objects don't require sequencing and are excluded from
-                // the shared-objects view, matching `TransactionEffectsAPI::input_shared_objects`.
+                // Per-epoch config objects don't require sequencing and are
+                // excluded from the shared-objects view.
                 UnchangedSharedKind::PerEpochConfig => None,
-                // `UnchangedSharedKind` is `#[non_exhaustive]`; mirrors the monorepo's own
-                // defensive arm in `TransactionEffectsV1::input_shared_objects`.
+                // `UnchangedSharedKind` is `#[non_exhaustive]` in iota-sdk-types.
                 _ => unimplemented!(
                     "a new UnchangedSharedKind enum variant was added and needs to be handled"
                 ),
@@ -554,9 +496,6 @@ impl From<TransactionEffectsV1> for TransactionEffectsDto {
 
 impl From<TransactionEffects> for TransactionEffectsDto {
     fn from(effects: TransactionEffects) -> Self {
-        // `TransactionEffects` only has a `V1` payload today; `into_v1()` is an
-        // inherent method on the SDK's own (non_exhaustive-to-us, but not to
-        // itself) enum, so no wildcard arm is needed here.
         effects.into_v1().into()
     }
 }
@@ -833,8 +772,7 @@ mod tests {
     }
 
     /// (e) `PackageWrite`: the created package's `ObjectRefDto.version` must come
-    /// from `ObjectOut::PackageWrite`'s own `version` field, *not* `lamport_version`
-    /// -- this is the asymmetry called out explicitly in this stage's task.
+    /// from `ObjectOut::PackageWrite`'s own `version` field, *not* `lamport_version`.
     #[test]
     fn package_write_uses_its_own_version_not_lamport_version() {
         let package_id = oid(100);
@@ -881,10 +819,7 @@ mod tests {
         );
     }
 
-    /// (d) Failure status golden-JSON coverage for the four `ExecutionError`
-    /// variants that were permuted at the *old* (now-superseded) iota-sdk-types
-    /// revision this codebase used to pin -- proving these round-trip correctly
-    /// through `ExecutionStatusDto` is the most important regression check here.
+    /// (d) Failure status golden-JSON coverage for four `ExecutionError` variants.
     fn failure_effects_with(error: ExecutionError) -> TransactionEffectsV1 {
         TransactionEffectsV1 {
             status: ExecutionStatus::new_failure(error, None),

--- a/src/rpc/effects.rs
+++ b/src/rpc/effects.rs
@@ -180,6 +180,13 @@ pub enum ExecutionStatusDto {
     Failure { error: String },
 }
 
+impl ExecutionStatusDto {
+    /// Returns `true` if the transaction executed successfully.
+    pub fn is_success(&self) -> bool {
+        matches!(self, Self::Success)
+    }
+}
+
 impl From<ExecutionStatus> for ExecutionStatusDto {
     fn from(status: ExecutionStatus) -> Self {
         match status {

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -3,9 +3,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod client;
+pub(crate) mod effects;
 pub(crate) mod rpc_types;
 mod server;
 
+pub use effects::TransactionEffectsDto;
 pub use rpc_types::ExecuteTransactionRequestType;
 pub use server::GasStationServer;
 
@@ -17,7 +19,7 @@ mod tests {
     use crate::access_controller::predicates::{ValueAggregate, ValueNumber};
     use crate::access_controller::rule::{predicate_names, AccessRuleBuilder};
     use crate::access_controller::AccessController;
-    use crate::config::GasStationConfig;
+    use crate::config::{Config, GasStationConfig};
     use crate::rpc::ExecuteTransactionRequestType;
     use crate::test_env::{
         create_test_transaction, fetch_redis_val, remove_redis_key, start_rpc_server_for_testing,
@@ -26,10 +28,9 @@ mod tests {
     };
     use crate::tracker::stats_tracker_storage::redis::get_redis_aggr_key;
     use crate::tracker::stats_tracker_storage::AggregateType;
+    use crate::gas_station::gas_station_core::NANOS_PER_IOTA;
+    use crate::rpc::effects::ExecutionStatusDto;
     use crate::AUTH_ENV_NAME;
-    use iota_config::Config;
-    use iota_json_rpc_types::IotaTransactionBlockEffectsAPI;
-    use iota_types::gas_coin::NANOS_PER_IOTA;
 
     #[tokio::test]
     async fn test_basic_rpc_flow() {
@@ -50,7 +51,7 @@ mod tests {
             .execute_tx(reservation_id, &tx_data, &user_sig, None, None)
             .await
             .unwrap();
-        assert!(effects.status().is_ok());
+        assert!(matches!(effects.status, ExecutionStatusDto::Success));
     }
 
     #[tokio::test]
@@ -287,7 +288,7 @@ mod tests {
             )
             .await
             .unwrap();
-        assert!(effects.status().is_ok());
+        assert!(matches!(effects.status, ExecutionStatusDto::Success));
     }
 
     #[tokio::test]
@@ -315,6 +316,6 @@ mod tests {
             )
             .await
             .unwrap();
-        assert!(effects.status().is_ok());
+        assert!(matches!(effects.status, ExecutionStatusDto::Success));
     }
 }

--- a/src/rpc/rpc_types.rs
+++ b/src/rpc/rpc_types.rs
@@ -2,13 +2,10 @@
 // Modifications Copyright (c) 2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::base64::Base64;
+use crate::rpc::effects::{ObjectRefDto, TransactionEffectsDto};
 use crate::types::ReservationID;
-use fastcrypto::encoding::Base64;
-use iota_json_rpc_types::{IotaObjectRef, IotaTransactionBlockEffects};
-use iota_types::{
-    base_types::{IotaAddress, ObjectRef},
-    quorum_driver_types::ExecuteTransactionRequestType as IotaExecuteTransactionRequestType,
-};
+use iota_sdk_types::{Address, ObjectReference};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -26,16 +23,17 @@ pub struct ReserveGasResponse {
 
 #[derive(Debug, JsonSchema, Serialize, Deserialize)]
 pub struct ReserveGasResult {
-    pub sponsor_address: IotaAddress,
+    #[schemars(with = "String")]
+    pub sponsor_address: Address,
     pub reservation_id: ReservationID,
-    pub gas_coins: Vec<IotaObjectRef>,
+    pub gas_coins: Vec<ObjectRefDto>,
 }
 
 impl ReserveGasResponse {
     pub fn new_ok(
-        sponsor_address: IotaAddress,
+        sponsor_address: Address,
         reservation_id: ReservationID,
-        gas_coins: Vec<ObjectRef>,
+        gas_coins: Vec<ObjectReference>,
     ) -> Self {
         Self {
             result: Some(ReserveGasResult {
@@ -70,27 +68,14 @@ pub enum ExecuteTransactionRequestType {
     WaitForLocalExecution,
 }
 
-impl Into<Option<IotaExecuteTransactionRequestType>> for ExecuteTransactionRequestType {
-    fn into(self) -> Option<IotaExecuteTransactionRequestType> {
-        match self {
-            ExecuteTransactionRequestType::WaitForEffectsCert => {
-                Some(IotaExecuteTransactionRequestType::WaitForEffectsCert)
-            }
-            ExecuteTransactionRequestType::WaitForLocalExecution => {
-                Some(IotaExecuteTransactionRequestType::WaitForLocalExecution)
-            }
-        }
-    }
-}
-
 #[derive(Debug, JsonSchema, Serialize, Deserialize)]
 pub struct ExecuteTxResponse {
-    pub effects: Option<IotaTransactionBlockEffects>,
+    pub effects: Option<TransactionEffectsDto>,
     pub error: Option<String>,
 }
 
 impl ExecuteTxResponse {
-    pub fn new_ok(effects: IotaTransactionBlockEffects) -> Self {
+    pub fn new_ok(effects: TransactionEffectsDto) -> Self {
         Self {
             effects: Some(effects),
             error: None,

--- a/src/rpc/server.rs
+++ b/src/rpc/server.rs
@@ -5,12 +5,14 @@
 use crate::access_controller::decision::Decision;
 use crate::access_controller::rule::TransactionContext;
 use crate::access_controller::{AccessController, TransactionExecutionResult};
-use crate::config::GasStationConfig;
+use crate::base64::Base64;
+use crate::config::{Config, GasStationConfig};
 use crate::errors::generate_event_id;
 use crate::gas_station::gas_station_core::GasStation;
 use crate::logging::TxLogMessage;
 use crate::metrics::GasStationRpcMetrics;
 use crate::rpc::client::GasStationRpcClient;
+use crate::rpc::effects::TransactionEffectsDto;
 use crate::rpc::rpc_types::{
     ExecuteTxRequest, ExecuteTxResponse, GasStationResponse, ReserveGasRequest, ReserveGasResponse,
 };
@@ -24,12 +26,7 @@ use axum::http::{HeaderMap, StatusCode};
 use axum::response::IntoResponse;
 use axum::routing::{get, post};
 use axum::{Extension, Json, Router, TypedHeader};
-use fastcrypto::encoding::Base64;
-use iota_config::Config;
-use iota_json_rpc_types::IotaTransactionBlockEffectsAPI;
-use iota_types::crypto::ToFromBytes;
-use iota_types::signature::GenericSignature;
-use iota_types::transaction::TransactionData;
+use iota_sdk_types::{Transaction, UserSignature};
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -186,11 +183,11 @@ async fn reserve_gas(
     server
         .metrics
         .target_gas_budget_per_request
-        .observe(gas_budget);
+        .observe(gas_budget as f64);
     server
         .metrics
         .reserve_duration_per_request
-        .observe(reserve_duration_secs);
+        .observe(reserve_duration_secs as f64);
     // Spawn a thread to process the request so that it will finish even when client drops the connection.
     tokio::task::spawn(reserve_gas_impl(
         server.gas_station.clone(),
@@ -276,11 +273,11 @@ async fn execute_tx(
         user_sig: user_sig_raw,
         request_type,
     } = payload;
-    let Ok((tx_data, user_sig)) = convert_tx_and_sig(tx_bytes.clone(), user_sig_raw.clone()) else {
+    let Ok((tx, user_sig)) = convert_tx_and_sig(tx_bytes.clone(), user_sig_raw.clone()) else {
         return (
             StatusCode::BAD_REQUEST,
             Json(ExecuteTxResponse::new_err(anyhow::anyhow!(
-                "Invalid bcs bytes for TransactionData"
+                "Invalid bcs bytes for Transaction"
             ))),
         );
     };
@@ -288,7 +285,7 @@ async fn execute_tx(
     // collect information about request and transaction
     let ctx = TransactionContext::new(
         &user_sig,
-        &tx_data,
+        &tx,
         server.stats_tracker.clone(),
         reservation_id,
         tx_bytes,
@@ -301,7 +298,7 @@ async fn execute_tx(
     tokio::task::spawn(execute_tx_impl(
         server.gas_station.clone(),
         server.metrics.clone(),
-        tx_data,
+        tx,
         user_sig,
         server.access_controller.clone(),
         ctx,
@@ -321,12 +318,12 @@ async fn execute_tx(
 async fn execute_tx_impl(
     gas_station: Arc<GasStation>,
     metrics: Arc<GasStationRpcMetrics>,
-    tx_data: TransactionData,
-    user_sig: GenericSignature,
+    tx: Transaction,
+    user_sig: UserSignature,
     access_controller: Arc<ArcSwap<AccessController>>,
     ctx: TransactionContext,
 ) -> (StatusCode, Json<ExecuteTxResponse>) {
-    let transaction_digest = tx_data.digest();
+    let transaction_digest = tx.digest();
 
     let is_rejected = match access_controller.load().check_access(&ctx).await {
         Ok(Decision::Allow) => {
@@ -373,23 +370,23 @@ async fn execute_tx_impl(
     }
 
     match gas_station
-        .execute_transaction(ctx.reservation_id, tx_data, user_sig, ctx.request_type)
+        .execute_transaction(ctx.reservation_id, tx, user_sig, ctx.request_type)
         .await
     {
         Ok(effects) => {
             info!(
                 ?ctx.reservation_id,
                 "Successfully executed transaction {:?} with status: {:?}",
-                effects.transaction_digest(),
-                effects.status()
+                transaction_digest,
+                effects.as_v1().status
             );
             trace!(target: "transactions", "{}", TxLogMessage::new(&effects));
 
+            let gas_used = effects.as_v1().gas_cost_summary.gas_used();
             let confirmation_result = access_controller
                 .load()
                 .confirm_transaction(
-                    TransactionExecutionResult::new(transaction_digest)
-                        .with_gas_usage(effects.gas_cost_summary().gas_used()),
+                    TransactionExecutionResult::new(transaction_digest).with_gas_usage(gas_used),
                     &ctx.stats_tracker.clone(),
                 )
                 .await;
@@ -399,7 +396,12 @@ async fn execute_tx_impl(
                 error!("Error while confirming transaction in AC: {:?}", err);
             }
             metrics.num_successful_execute_tx_requests.inc();
-            (StatusCode::OK, Json(ExecuteTxResponse::new_ok(effects)))
+            (
+                StatusCode::OK,
+                Json(ExecuteTxResponse::new_ok(TransactionEffectsDto::from(
+                    effects,
+                ))),
+            )
         }
         Err(err) => {
             error!("Failed to execute transaction: {:?}", err);
@@ -470,14 +472,14 @@ async fn reload_access_controller(
 fn convert_tx_and_sig(
     tx_bytes: Base64,
     user_sig: Base64,
-) -> anyhow::Result<(TransactionData, GenericSignature)> {
+) -> anyhow::Result<(Transaction, UserSignature)> {
     let tx = bcs::from_bytes(
         &tx_bytes
             .to_vec()
             .map_err(|_| anyhow::anyhow!("Failed to convert tx_bytes to vector"))?,
     )?;
-    let user_sig = GenericSignature::from_bytes(
-        &user_sig
+    let user_sig = UserSignature::from_bytes(
+        user_sig
             .to_vec()
             .map_err(|_| anyhow::anyhow!("Failed to convert user_sig to vector"))?,
     )?;

--- a/src/rpc/server.rs
+++ b/src/rpc/server.rs
@@ -153,6 +153,7 @@ async fn reserve_gas(
     Extension(server): Extension<ServerState>,
     Json(payload): Json<ReserveGasRequest>,
 ) -> impl IntoResponse {
+    server.metrics.num_reserve_gas_requests.inc();
     if let Some(secret) = server.secret.as_ref() {
         let token = authorization.as_ref().map(|auth| auth.token());
         if token != Some(secret.as_str()) {

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -6,7 +6,7 @@ use crate::config::GasStationStorageConfig;
 use crate::metrics::StorageMetrics;
 use crate::storage::redis::RedisStorage;
 use crate::types::{GasCoin, ReservationID};
-use iota_types::base_types::{IotaAddress, ObjectID};
+use iota_sdk_types::{Address, ObjectId};
 use std::sync::Arc;
 use url::Url;
 
@@ -38,7 +38,7 @@ pub trait Storage: SetGetStorage + Sync + Send {
 
     async fn add_new_coins(&self, new_coins: Vec<GasCoin>) -> anyhow::Result<()>;
 
-    async fn expire_coins(&self) -> anyhow::Result<Vec<ObjectID>>;
+    async fn expire_coins(&self) -> anyhow::Result<Vec<ObjectId>>;
 
     /// Initialize some of the Gas Station statistics at the startup.
     /// Such as the total number of gas coins and the total balance.
@@ -104,7 +104,7 @@ pub trait SetGetStorage: Sync + Send {
 
 pub async fn connect_storage(
     config: &GasStationStorageConfig,
-    sponsor_address: IotaAddress,
+    sponsor_address: Address,
     namespace_prefix: &str,
     metrics: Arc<StorageMetrics>,
 ) -> Arc<dyn Storage> {
@@ -122,7 +122,7 @@ pub async fn connect_storage(
 }
 
 /// Generate the namespace for the storage based on the network URL and the sponsor address.
-pub fn get_storage_namespace(network_url: &str, sponsor_address: &IotaAddress) -> String {
+pub fn get_storage_namespace(network_url: &str, sponsor_address: &Address) -> String {
     let url = Url::parse(network_url).unwrap();
     let scheme = url.scheme();
     let host = url.host_str().unwrap();
@@ -143,7 +143,7 @@ pub fn get_storage_namespace(network_url: &str, sponsor_address: &IotaAddress) -
 pub async fn connect_storage_for_testing_with_config(
     config: &GasStationStorageConfig,
     network_url: &str,
-    sponsor_address: IotaAddress,
+    sponsor_address: Address,
 ) -> Arc<dyn Storage> {
     use std::sync::atomic::{AtomicBool, Ordering};
 
@@ -167,7 +167,7 @@ pub async fn connect_storage_for_testing_with_config(
 }
 
 #[cfg(test)]
-pub async fn connect_storage_for_testing(sponsor_address: IotaAddress) -> Arc<dyn Storage> {
+pub async fn connect_storage_for_testing(sponsor_address: Address) -> Arc<dyn Storage> {
     connect_storage_for_testing_with_config(
         &GasStationStorageConfig::default(),
         "http://localhost:9000",
@@ -179,9 +179,8 @@ pub async fn connect_storage_for_testing(sponsor_address: IotaAddress) -> Arc<dy
 #[cfg(test)]
 mod tests {
     use crate::storage::{connect_storage_for_testing, Storage, MAX_GAS_PER_QUERY};
-    use crate::types::GasCoin;
-    use iota_types::base_types::{random_object_ref, IotaAddress, ObjectID, SequenceNumber};
-    use iota_types::digests::ObjectDigest;
+    use crate::types::{random_object_ref, GasCoin};
+    use iota_sdk_types::{Address, ObjectDigest, ObjectId, ObjectReference, Version};
     use rand::random;
     use std::collections::BTreeSet;
     use std::sync::Arc;
@@ -192,14 +191,14 @@ mod tests {
         assert_eq!(storage.get_reserved_coin_count().await, reserved);
     }
 
-    async fn setup(sponsor: IotaAddress, init_balances: Vec<u64>) -> Arc<dyn Storage> {
+    async fn setup(sponsor: Address, init_balances: Vec<u64>) -> Arc<dyn Storage> {
         let storage = connect_storage_for_testing(sponsor).await;
         let gas_coins = init_balances
             .into_iter()
             .map(|balance| GasCoin {
-                object_ref: (
-                    ObjectID::random(),
-                    SequenceNumber::from_u64(random()),
+                object_ref: ObjectReference::new(
+                    ObjectId::random(),
+                    Version::from_u64(random()),
                     ObjectDigest::random(),
                 ),
                 balance,
@@ -213,7 +212,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_gas_station_init() {
-        let sponsor = IotaAddress::random_for_testing_only();
+        let sponsor = Address::random();
         let storage = connect_storage_for_testing(sponsor).await;
         assert!(!storage.is_initialized().await.unwrap());
         storage.add_new_coins(vec![]).await.unwrap();
@@ -232,7 +231,7 @@ mod tests {
     #[tokio::test]
     async fn test_successful_reservation() {
         // Create a Gas Station of 100000 coins, each with balance of 1.
-        let sponsor = IotaAddress::random_for_testing_only();
+        let sponsor = Address::random();
         let storage = setup(sponsor, vec![1; 100000]).await;
         assert_coin_count(&storage, 100000, 0).await;
         let mut cur_available = 100000;
@@ -250,7 +249,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_max_gas_coin_per_query() {
-        let sponsor = IotaAddress::random_for_testing_only();
+        let sponsor = Address::random();
         let storage = setup(sponsor, vec![1; MAX_GAS_PER_QUERY + 1]).await;
         assert!(storage
             .reserve_gas_coins((MAX_GAS_PER_QUERY + 1) as u64, 1000)
@@ -261,7 +260,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_insufficient_pool_budget() {
-        let sponsor = IotaAddress::random_for_testing_only();
+        let sponsor = Address::random();
         let storage = setup(sponsor, vec![1; 100]).await;
         assert!(storage.reserve_gas_coins(101, 1000).await.is_err());
         assert_coin_count(&storage, 100, 0).await;
@@ -269,7 +268,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_coin_release() {
-        let sponsor = IotaAddress::random_for_testing_only();
+        let sponsor = Address::random();
         let storage = setup(sponsor, vec![1; 100]).await;
         for _ in 0..100 {
             // Keep reserving and putting them back.
@@ -285,7 +284,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_coin_release_with_updated_balance() {
-        let sponsor = IotaAddress::random_for_testing_only();
+        let sponsor = Address::random();
         let storage = setup(sponsor, vec![1; 100]).await;
         for _ in 0..10 {
             let (res_id, mut reserved_gas_coins) =
@@ -309,7 +308,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_deleted_objects() {
-        let sponsor = IotaAddress::random_for_testing_only();
+        let sponsor = Address::random();
         let storage = setup(sponsor, vec![1; 100]).await;
         let (res_id, mut reserved_gas_coins) = storage.reserve_gas_coins(100, 1000).await.unwrap();
         assert_eq!(reserved_gas_coins.len(), 100);
@@ -323,7 +322,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_coin_expiration() {
-        let sponsor = IotaAddress::random_for_testing_only();
+        let sponsor = Address::random();
         let storage = setup(sponsor, vec![1; 100]).await;
         let (_res_id1, reserved_gas_coins1) = storage.reserve_gas_coins(10, 900).await.unwrap();
         assert_eq!(reserved_gas_coins1.len(), 10);
@@ -344,7 +343,7 @@ mod tests {
             expired1.iter().cloned().collect::<BTreeSet<_>>(),
             reserved_gas_coins1
                 .iter()
-                .map(|coin| coin.object_ref.0)
+                .map(|coin| coin.object_ref.object_id)
                 .collect::<BTreeSet<_>>()
         );
         assert_coin_count(&storage, 10, 80).await;
@@ -360,7 +359,7 @@ mod tests {
             reserved_gas_coins2
                 .iter()
                 .chain(&reserved_gas_coins3)
-                .map(|coin| coin.object_ref.0)
+                .map(|coin| coin.object_ref.object_id)
                 .collect::<BTreeSet<_>>()
         );
         assert_coin_count(&storage, 10, 0).await;
@@ -368,9 +367,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_multiple_sponsors() {
-        let sponsors = (0..10)
-            .map(|_| IotaAddress::random_for_testing_only())
-            .collect::<Vec<_>>();
+        let sponsors = (0..10).map(|_| Address::random()).collect::<Vec<_>>();
         let mut storages = vec![];
         for sponsor in sponsors {
             storages.push(setup(sponsor, vec![1; 100]).await);
@@ -384,7 +381,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_concurrent_reservation() {
-        let sponsor = IotaAddress::random_for_testing_only();
+        let sponsor = Address::random();
         let storage = setup(sponsor, vec![1; 100000]).await;
         let mut handles = vec![];
         for _ in 0..10 {
@@ -404,15 +401,15 @@ mod tests {
         }
         let count = reserved_gas_coins.len();
         // Check that all object IDs are unique in all reservations.
-        reserved_gas_coins.sort_by_key(|c| c.object_ref.0);
-        reserved_gas_coins.dedup_by_key(|c| c.object_ref.0);
+        reserved_gas_coins.sort_by_key(|c| c.object_ref.object_id);
+        reserved_gas_coins.dedup_by_key(|c| c.object_ref.object_id);
         assert_eq!(reserved_gas_coins.len(), count);
         assert_coin_count(&storage, 100000 - count, count).await;
     }
 
     #[tokio::test]
     async fn test_acquire_init_lock() {
-        let sponsor = IotaAddress::random_for_testing_only();
+        let sponsor = Address::random();
         let storage = setup(sponsor, vec![1; 100]).await;
         assert!(storage.acquire_init_lock(5).await.unwrap());
         assert!(!storage.acquire_init_lock(1).await.unwrap());
@@ -422,7 +419,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_init_coin_stats_idempotent() {
-        let sponsor = IotaAddress::random_for_testing_only();
+        let sponsor = Address::random();
         let storage = setup(sponsor, vec![1; 100]).await;
         // init_coin_stats_at_startup has already been called in setup.
         // Calling it again should not change anything.

--- a/src/storage/redis/mod.rs
+++ b/src/storage/redis/mod.rs
@@ -11,7 +11,7 @@ use crate::storage::{SetGetStorage, Storage, MAINTENANCE_MODE_ERROR_MESSAGE};
 use crate::types::{GasCoin, ReservationID};
 use anyhow::bail;
 use chrono::Utc;
-use iota_types::base_types::{IotaAddress, ObjectDigest, ObjectID, SequenceNumber};
+use iota_sdk_types::{Address, ObjectDigest, ObjectId, ObjectReference, Version};
 use redis::aio::ConnectionManager;
 use redis::AsyncCommands;
 use std::ops::Add;
@@ -30,7 +30,7 @@ pub struct RedisStorage {
 impl RedisStorage {
     pub async fn new(
         redis_url: &str,
-        sponsor_address: IotaAddress,
+        sponsor_address: Address,
         namespace_prefix: &str,
         metrics: Arc<StorageMetrics>,
     ) -> Self {
@@ -79,6 +79,43 @@ impl RedisStorage {
 
 fn generate_namespace(namespace_prefix: &str) -> String {
     format!("{}:registry", namespace_prefix)
+}
+
+/// Encodes a single gas coin into the CSV-ish format used by the coin registry:
+/// `balance,object_id,version,digest`.
+///
+/// This exact format is embedded, byte-for-byte, in existing production Redis
+/// registries (written by earlier, pre-migration versions of this service) and is
+/// independently re-implemented in `reserve_gas_coins.lua`'s parsing logic. Any
+/// change here MUST stay compatible with what's already stored, which is why the
+/// object id and digest are formatted via `Display` (verified to produce the exact
+/// same strings as the pre-migration `iota_types` `ObjectID`/`ObjectDigest` Display
+/// impls -- see `src/types.rs`) and the version via `.as_u64()` rather than via
+/// `Version`'s own `Display` (mirroring the pre-migration code, which likewise
+/// called `SequenceNumber::value()` explicitly instead of relying on
+/// `SequenceNumber`'s own -- differently formatted -- `Display` impl).
+fn encode_gas_coin(coin: &GasCoin) -> String {
+    format!(
+        "{},{},{},{}",
+        coin.balance,
+        coin.object_ref.object_id,
+        coin.object_ref.version.as_u64(),
+        coin.object_ref.digest
+    )
+}
+
+/// Decodes a single gas coin from the format produced by [`encode_gas_coin`].
+fn decode_gas_coin(s: &str) -> GasCoin {
+    // Each coin is in the form of: balance,object_id,version,digest
+    let mut splits = s.split(',');
+    let balance = splits.next().unwrap().parse::<u64>().unwrap();
+    let object_id = ObjectId::from_str(splits.next().unwrap()).unwrap();
+    let version = Version::from_u64(splits.next().unwrap().parse::<u64>().unwrap());
+    let digest = ObjectDigest::from_str(splits.next().unwrap()).unwrap();
+    GasCoin {
+        balance,
+        object_ref: ObjectReference::new(object_id, version, digest),
+    }
 }
 
 #[async_trait::async_trait]
@@ -133,21 +170,7 @@ impl Storage for RedisStorage {
         if coins.is_empty() {
             bail!("Unable to reserve gas coins for the given budget.");
         }
-        let gas_coins: Vec<_> = coins
-            .into_iter()
-            .map(|s| {
-                // Each coin is in the form of: balance,object_id,version,digest
-                let mut splits = s.split(',');
-                let balance = splits.next().unwrap().parse::<u64>().unwrap();
-                let object_id = ObjectID::from_str(splits.next().unwrap()).unwrap();
-                let version = SequenceNumber::from(splits.next().unwrap().parse::<u64>().unwrap());
-                let digest = ObjectDigest::from_str(splits.next().unwrap()).unwrap();
-                GasCoin {
-                    balance,
-                    object_ref: (object_id, version, digest),
-                }
-            })
-            .collect();
+        let gas_coins: Vec<_> = coins.into_iter().map(|s| decode_gas_coin(&s)).collect();
 
         self.metrics
             .gas_station_available_gas_coin_count
@@ -179,20 +202,11 @@ impl Storage for RedisStorage {
 
     async fn add_new_coins(&self, new_coins: Vec<GasCoin>) -> anyhow::Result<()> {
         self.metrics.num_add_new_coins_requests.inc();
+        // The way we turn coins into strings must be consistent with the way we parse them in
+        // reserve_gas_coins_script (via decode_gas_coin).
         let formatted_coins = new_coins
             .iter()
-            .map(|c| {
-                // The format is: balance,object_id,version,digest
-                // The way we turn them into strings must be consistent with the way we parse them in
-                // reserve_gas_coins_script.
-                format!(
-                    "{},{},{},{}",
-                    c.balance,
-                    c.object_ref.0,
-                    c.object_ref.1.value(),
-                    c.object_ref.2
-                )
-            })
+            .map(encode_gas_coin)
             .collect::<Vec<String>>();
 
         let mut conn = self.conn_manager.clone();
@@ -218,7 +232,7 @@ impl Storage for RedisStorage {
         Ok(())
     }
 
-    async fn expire_coins(&self) -> anyhow::Result<Vec<ObjectID>> {
+    async fn expire_coins(&self) -> anyhow::Result<Vec<ObjectId>> {
         self.metrics.num_expire_coins_requests.inc();
 
         let now = Utc::now().timestamp_millis() as u64;
@@ -231,7 +245,7 @@ impl Storage for RedisStorage {
         // The script returns a list of comma separated coin ids.
         let expired_coin_ids = expired_coin_strings
             .iter()
-            .flat_map(|s| s.split(',').map(|id| ObjectID::from_str(id).unwrap()))
+            .flat_map(|s| s.split(',').map(|id| ObjectId::from_str(id).unwrap()))
             .collect();
 
         self.metrics.num_successful_expire_coins_requests.inc();
@@ -398,13 +412,13 @@ impl Storage for RedisStorage {
 }
 #[cfg(test)]
 mod tests {
-    use iota_types::base_types::{random_object_ref, IotaAddress};
+    use iota_sdk_types::Address;
     use serde::{Deserialize, Serialize};
 
     use crate::{
         metrics::StorageMetrics,
         storage::{redis::RedisStorage, SetGetStorage, Storage},
-        types::GasCoin,
+        types::{random_object_ref, GasCoin},
     };
 
     #[tokio::test]
@@ -611,7 +625,7 @@ mod tests {
     }
 
     async fn setup_storage() -> RedisStorage {
-        let sponsor = IotaAddress::ZERO;
+        let sponsor = Address::ZERO;
         let namespace_prefix = "test";
         let redis_url = "redis://127.0.0.1:6379";
         let storage = RedisStorage::new(
@@ -688,5 +702,64 @@ mod tests {
 
         // Should be able to acquire lock again
         assert!(storage.acquire_maintenance_lock(60).await.unwrap());
+    }
+
+    /// Regression test pinning the coin registry's CSV encoding (`encode_gas_coin`
+    /// / `decode_gas_coin`, i.e. `balance,object_id,version,digest`) for a known
+    /// `GasCoin` to the exact string the *pre-migration* implementation -- which
+    /// used `iota_types::base_types::{ObjectID, SequenceNumber}` and
+    /// `iota_types::digests::ObjectDigest` instead of the new SDK's
+    /// `iota_sdk_types::{ObjectId, Version, ObjectDigest}` -- would have produced
+    /// for the same triple.
+    ///
+    /// If this ever stops matching, every gas coin already sitting in a
+    /// production Redis registry becomes unparseable (silently "losing" coins,
+    /// since `decode_gas_coin`/the Lua scripts would then choke on or misread
+    /// live data), so this pin exists as a tripwire independent of whatever the
+    /// current code happens to compute.
+    ///
+    /// The expected literal below was derived from first principles (not by
+    /// calling this file's own `encode_gas_coin`), then cross-checked two more
+    /// ways before being hardcoded here:
+    ///   - the object id is `0x` followed by `hex::encode([0u8, 1, 2, .., 31])`
+    ///     (plain lowercase hex -- both old `ObjectID` and new `ObjectId`
+    ///     `Display` produce this, see `src/types.rs` for the verification);
+    ///   - the version is the plain decimal `42`;
+    ///   - the digest is the Base58 (Bitcoin alphabet, as used by both the old
+    ///     `fastcrypto::encoding::Base58` and the new `bs58` crate) encoding of
+    ///     `[255u8, 254, .., 224]`, computed by hand and cross-checked against
+    ///     both Python's `base58` package and `bs58`'s own documented test
+    ///     vector (`bs58::encode(b"Hello world!") == "2NEpo7TZRhna7vSvL"`);
+    ///   - finally, this exact literal was independently reproduced by two
+    ///     standalone scratch binaries built outside this crate: one against
+    ///     the real, unmodified `iota_sdk_types` (rev b77fcd5, this migration's
+    ///     target) and one against the real, unmodified pre-migration
+    ///     `iota_types` (tag v1.20.1), each formatting the same
+    ///     (object_id, version, digest) triple the same way `encode_gas_coin`
+    ///     / the old `add_new_coins` code did/does.
+    #[test]
+    fn test_encode_decode_gas_coin_pinned_format() {
+        let object_id_bytes: [u8; 32] = std::array::from_fn(|i| i as u8);
+        let digest_bytes: [u8; 32] = std::array::from_fn(|i| (255 - i) as u8);
+        let coin = GasCoin {
+            balance: 12345,
+            object_ref: iota_sdk_types::ObjectReference::new(
+                iota_sdk_types::ObjectId::new(object_id_bytes),
+                iota_sdk_types::Version::from_u64(42),
+                iota_sdk_types::ObjectDigest::new(digest_bytes),
+            ),
+        };
+
+        let encoded = super::encode_gas_coin(&coin);
+        assert_eq!(
+            encoded,
+            "12345,0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f,42,\
+             JEJUoGfGEPTZ1XTwN39dYdFxYxDiDaSKVNy5qYWJmZt3"
+        );
+
+        // And the round trip back through decode_gas_coin must reproduce the
+        // original coin exactly.
+        let decoded = super::decode_gas_coin(&encoded);
+        assert_eq!(decoded, coin);
     }
 }

--- a/src/storage/redis/mod.rs
+++ b/src/storage/redis/mod.rs
@@ -84,16 +84,8 @@ fn generate_namespace(namespace_prefix: &str) -> String {
 /// Encodes a single gas coin into the CSV-ish format used by the coin registry:
 /// `balance,object_id,version,digest`.
 ///
-/// This exact format is embedded, byte-for-byte, in existing production Redis
-/// registries (written by earlier, pre-migration versions of this service) and is
-/// independently re-implemented in `reserve_gas_coins.lua`'s parsing logic. Any
-/// change here MUST stay compatible with what's already stored, which is why the
-/// object id and digest are formatted via `Display` (verified to produce the exact
-/// same strings as the pre-migration `iota_types` `ObjectID`/`ObjectDigest` Display
-/// impls -- see `src/types.rs`) and the version via `.as_u64()` rather than via
-/// `Version`'s own `Display` (mirroring the pre-migration code, which likewise
-/// called `SequenceNumber::value()` explicitly instead of relying on
-/// `SequenceNumber`'s own -- differently formatted -- `Display` impl).
+/// This is how coins are encoded in `reserve_gas_coins.lua` and in existing
+/// registries, so it has to stay like this.
 fn encode_gas_coin(coin: &GasCoin) -> String {
     format!(
         "{},{},{},{}",

--- a/src/storage/redis/mod.rs
+++ b/src/storage/redis/mod.rs
@@ -696,39 +696,11 @@ mod tests {
         assert!(storage.acquire_maintenance_lock(60).await.unwrap());
     }
 
-    /// Regression test pinning the coin registry's CSV encoding (`encode_gas_coin`
-    /// / `decode_gas_coin`, i.e. `balance,object_id,version,digest`) for a known
-    /// `GasCoin` to the exact string the *pre-migration* implementation -- which
-    /// used `iota_types::base_types::{ObjectID, SequenceNumber}` and
-    /// `iota_types::digests::ObjectDigest` instead of the new SDK's
-    /// `iota_sdk_types::{ObjectId, Version, ObjectDigest}` -- would have produced
-    /// for the same triple.
-    ///
-    /// If this ever stops matching, every gas coin already sitting in a
-    /// production Redis registry becomes unparseable (silently "losing" coins,
-    /// since `decode_gas_coin`/the Lua scripts would then choke on or misread
-    /// live data), so this pin exists as a tripwire independent of whatever the
-    /// current code happens to compute.
-    ///
-    /// The expected literal below was derived from first principles (not by
-    /// calling this file's own `encode_gas_coin`), then cross-checked two more
-    /// ways before being hardcoded here:
-    ///   - the object id is `0x` followed by `hex::encode([0u8, 1, 2, .., 31])`
-    ///     (plain lowercase hex -- both old `ObjectID` and new `ObjectId`
-    ///     `Display` produce this, see `src/types.rs` for the verification);
-    ///   - the version is the plain decimal `42`;
-    ///   - the digest is the Base58 (Bitcoin alphabet, as used by both the old
-    ///     `fastcrypto::encoding::Base58` and the new `bs58` crate) encoding of
-    ///     `[255u8, 254, .., 224]`, computed by hand and cross-checked against
-    ///     both Python's `base58` package and `bs58`'s own documented test
-    ///     vector (`bs58::encode(b"Hello world!") == "2NEpo7TZRhna7vSvL"`);
-    ///   - finally, this exact literal was independently reproduced by two
-    ///     standalone scratch binaries built outside this crate: one against
-    ///     the real, unmodified `iota_sdk_types` (rev b77fcd5, this migration's
-    ///     target) and one against the real, unmodified pre-migration
-    ///     `iota_types` (tag v1.20.1), each formatting the same
-    ///     (object_id, version, digest) triple the same way `encode_gas_coin`
-    ///     / the old `add_new_coins` code did/does.
+    /// Regression test pinning the coin registry's CSV encoding to the exact
+    /// string the pre-migration implementation produced for the same
+    /// (object_id, version, digest) triple. If this ever stops matching,
+    /// gas coins already stored in production Redis registries become
+    /// unparseable.
     #[test]
     fn test_encode_decode_gas_coin_pinned_format() {
         let object_id_bytes: [u8; 32] = std::array::from_fn(|i| i as u8);

--- a/src/test_env.rs
+++ b/src/test_env.rs
@@ -4,9 +4,10 @@
 
 use crate::access_controller::AccessController;
 use crate::config::{
-    CoinInitConfig, GasStationStorageConfig, DEFAULT_DAILY_GAS_USAGE_CAP, DEFAULT_MAX_GAS_BUDGET,
+    CoinInitConfig, GasStationStorageConfig, DEFAULT_CHECKPOINT_WAIT_MS,
+    DEFAULT_DAILY_GAS_USAGE_CAP, DEFAULT_MAX_GAS_BUDGET,
 };
-use crate::gas_station::gas_station_core::GasStationContainer;
+use crate::gas_station::gas_station_core::{GasStationContainer, NANOS_PER_IOTA};
 use crate::gas_station::rescan_trigger::RescanGasObjectsTrigger;
 use crate::gas_station_initializer::GasStationInitializer;
 use crate::iota_client::IotaClient;
@@ -20,15 +21,14 @@ use crate::tx_signer::{TestTxSigner, TxSigner};
 use crate::AUTH_ENV_NAME;
 use arc_swap::ArcSwap;
 use async_trait::async_trait;
-use iota_config::local_ip_utils::{get_available_port, localhost_for_testing};
+use iota_sdk_crypto::ed25519::Ed25519PrivateKey;
+use iota_sdk_crypto::simple::SimpleKeypair;
+use iota_sdk_transaction_builder::TransactionBuilderClient;
+use iota_sdk_types::{Address, ObjectReference, Transaction, UserSignature};
 use iota_swarm_config::genesis_config::AccountConfig;
-use iota_types::base_types::{IotaAddress, ObjectRef};
-use iota_types::crypto::get_account_key_pair;
-use iota_types::gas_coin::NANOS_PER_IOTA;
-use iota_types::signature::GenericSignature;
-use iota_types::transaction::{TransactionData, TransactionDataAPI};
 use redis::{Commands, FromRedisValue};
 use serde_json::Value;
+use std::net::TcpListener;
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -37,8 +37,34 @@ use tracing::debug;
 
 pub const DEFAULT_TEST_CONFIG_PATH: &str = "./test-env-config.yaml";
 
+/// Loopback address the gas-station server's own test-only HTTP listener
+/// binds to. There is no SDK equivalent of the old
+/// `iota_config::local_ip_utils::localhost_for_testing` -- this is purely
+/// this crate's own test infrastructure, not part of any wire format --
+/// so it is just a plain constant now.
+fn localhost_for_testing() -> String {
+    "127.0.0.1".to_string()
+}
+
+/// Binds an OS-assigned ephemeral TCP port on `host` and immediately drops
+/// the listener, returning the port number that was assigned. Same
+/// bind-then-release approach (and the same TOCTOU race against another
+/// caller grabbing the port before the caller of this function does) as the
+/// old `iota_config::local_ip_utils::get_available_port` it replaces; that
+/// crate is gone from our dependency tree, and the SDK has no equivalent
+/// (it's not part of any wire format either), so this is a small local
+/// helper instead.
+fn get_available_port(host: &str) -> u16 {
+    TcpListener::bind((host, 0))
+        .expect("failed to bind to an OS-assigned port")
+        .local_addr()
+        .expect("failed to read the local address of a just-bound listener")
+        .port()
+}
+
 pub async fn start_iota_cluster(init_gas_amounts: Vec<u64>) -> (TestCluster, Arc<dyn TxSigner>) {
-    let (sponsor, keypair) = get_account_key_pair();
+    let keypair = SimpleKeypair::from(Ed25519PrivateKey::generate(rand::rngs::OsRng));
+    let sponsor = keypair.public_key().derive_address();
     let cluster = TestClusterBuilder::new()
         .with_accounts(vec![
             AccountConfig {
@@ -53,7 +79,7 @@ pub async fn start_iota_cluster(init_gas_amounts: Vec<u64>) -> (TestCluster, Arc
         ])
         .build()
         .await;
-    (cluster, TestTxSigner::new(keypair.into()))
+    (cluster, TestTxSigner::new(keypair))
 }
 
 pub async fn start_gas_station(
@@ -63,11 +89,20 @@ pub async fn start_gas_station(
 ) -> (TestCluster, GasStationContainer) {
     debug!("Starting Iota cluster..");
     let (test_cluster, signer) = start_iota_cluster(init_gas_amounts).await;
-    let fullnode_url = test_cluster.fullnode_handle.rpc_url.clone();
+    // On develop, `TestCluster` starts its fullnode's gRPC API by default and
+    // self-allocates the port (see `TestClusterBuilder`'s
+    // `fullnode_enable_grpc_api: true` default and
+    // `node_config_builder.rs`'s `local_ip_utils::get_available_port` use) --
+    // `grpc_url()` (on `TestCluster` itself, not `FullNodeHandle`) is all
+    // that's needed to reach it, replacing the old JSON-RPC
+    // `fullnode_handle.rpc_url`, since our own `IotaClient` now speaks gRPC.
+    let grpc_url = test_cluster.grpc_url();
     let sponsor_address = signer.get_address();
     debug!("Starting storage. Sponsor address: {:?}", sponsor_address);
     let storage = connect_storage_for_testing(sponsor_address).await;
-    let iota_client = IotaClient::new(&fullnode_url, None).await;
+    let iota_client = IotaClient::new(&grpc_url, None)
+        .await
+        .expect("failed to connect to the test cluster's gRPC endpoint");
     let mut rescan_config = RescanGasObjectsTrigger::new(target_init_coin_balance);
     let rescan_trigger_receiver = rescan_config.create_receiver();
     GasStationInitializer::start(
@@ -89,6 +124,7 @@ pub async fn start_gas_station(
         iota_client,
         DEFAULT_DAILY_GAS_USAGE_CAP,
         max_gas_budget.unwrap_or(DEFAULT_MAX_GAS_BUDGET),
+        DEFAULT_CHECKPOINT_WAIT_MS,
         GasStationCoreMetrics::new_for_testing(),
         rescan_config,
     )
@@ -188,40 +224,86 @@ pub async fn start_rpc_server_for_testing_with_access_controller(
     (test_cluster, container, server)
 }
 
+/// Builds a user-signed, sponsored transaction: `user` (any cluster address
+/// other than `sponsor`) transfers one of their own objects to themselves --
+/// the PTB itself doesn't need to do anything meaningful, it just needs to be
+/// a valid transaction for the gas station to execute -- while `sponsor`
+/// pays with `gas_coins`.
+///
+/// Unlike the pre-migration version of this helper, which built a plain
+/// (unsponsored) transaction via the old `TestTransactionBuilder` and then
+/// hand-patched `gas_data_mut().payment`/`.owner` onto it afterwards (see the
+/// removed `TODO: Add proper sponsored transaction support to test tx
+/// builder` comment that used to sit here), this uses the new SDK
+/// transaction builder's first-class sponsor support
+/// (`TransactionBuilder::sponsor`/`::gas`) directly -- no post-hoc patching
+/// needed.
 pub async fn create_test_transaction(
     test_cluster: &TestCluster,
-    sponsor: IotaAddress,
-    gas_coins: Vec<ObjectRef>,
-) -> (TransactionData, GenericSignature) {
+    sponsor: Address,
+    gas_coins: Vec<ObjectReference>,
+) -> (Transaction, UserSignature) {
     let user = test_cluster
         .get_addresses()
         .into_iter()
-        .find(|a| *a != sponsor)
-        .unwrap();
-    let object = test_cluster
-        .wallet
-        .get_one_gas_object_owned_by_address(user)
+        .find(|address| *address != sponsor)
+        .expect("test cluster should have an address other than the sponsor");
+
+    // Any object owned by `user` works as the PTB's payload; genesis funds
+    // `user` with exactly one coin (see `start_iota_cluster`'s second
+    // `AccountConfig`), so this always finds one.
+    let object_id = test_cluster
+        .grpc_client()
+        .objects(None, user, None, Some(1))
         .await
-        .unwrap()
-        .unwrap();
-    let mut tx_data = test_cluster
-        .test_transaction_builder_with_gas_object(user, gas_coins[0])
+        .expect("failed to list user's owned objects")
+        .data
+        .into_iter()
+        .next()
+        .expect("`user` should own at least one object from genesis")
+        .id();
+
+    // `TransactionBuilder::gas` is overloaded on whether a client is
+    // attached: the *offline* (`C = ()`) overload takes full `ObjectReference`s,
+    // but the client-attached one -- which is what `grpc_transaction_builder`
+    // returns, and what's needed below for the `object_id` input to resolve --
+    // only takes bare `ObjectId`s and re-resolves each one's current
+    // version/digest from the network itself. So only the id is passed
+    // through here; the resolved (version, digest) is intentionally read
+    // live rather than trusted from the reservation.
+    let mut builder = test_cluster.grpc_transaction_builder(user);
+    builder
+        .transfer_objects(user, [object_id])
+        .sponsor(sponsor)
+        .gas(gas_coins.into_iter().map(|coin| coin.object_id));
+
+    // Gas price is left unset on purpose: with a client attached, `finish`
+    // resolves it from the network's current reference gas price, which is
+    // more accurate than hand-picking a constant here.
+    builder.gas_budget(10_000_000);
+    let tx = builder
+        .finish()
         .await
-        .transfer(object, user)
-        .build();
-    // TODO: Add proper sponsored transaction support to test tx builder.
-    tx_data.gas_data_mut().payment = gas_coins;
-    tx_data.gas_data_mut().owner = sponsor;
+        .expect("failed to resolve test transaction");
+
+    // `TestCluster::sign_transaction` accepts our `Transaction` directly
+    // (`TransactionData` is a re-export of it on develop) but returns the
+    // monorepo's own signed-transaction envelope type, not
+    // `iota_sdk_types::UserSignature` -- so the single user signature is
+    // pulled back out of it here, mirroring what the pre-migration version
+    // did with `tx_signatures_mut_for_testing().pop()`.
     let user_sig = test_cluster
-        .sign_transaction(&tx_data)
+        .sign_transaction(&tx)
         .into_data()
-        .tx_signatures_mut_for_testing()
-        .pop()
-        .unwrap();
-    (tx_data, user_sig)
+        .signatures()
+        .first()
+        .cloned()
+        .expect("wallet should have produced exactly one signature");
+
+    (tx, user_sig)
 }
 
-pub async fn new_stats_tracker_for_testing(sponsor_address: IotaAddress) -> StatsTracker {
+pub async fn new_stats_tracker_for_testing(sponsor_address: Address) -> StatsTracker {
     StatsTracker::new(Arc::new(
         connect_stats_storage(
             &GasStationStorageConfig::default(),
@@ -231,8 +313,17 @@ pub async fn new_stats_tracker_for_testing(sponsor_address: IotaAddress) -> Stat
     ))
 }
 
-pub fn random_address() -> IotaAddress {
-    IotaAddress::random_for_testing_only()
+/// Constructs an arbitrary `iota_sdk_types::Address` for use in tests.
+///
+/// This used to be generic over a `RandomTestAddress` trait so it could also
+/// produce the old `iota_types::base_types::IotaAddress` (once needed by the
+/// access-controller's `TransactionContext`, before that was retyped onto the
+/// new SDK's `Address` -- see `access_controller/rule.rs`). Now that nothing
+/// in this crate needs the old address type anymore, the indirection is gone
+/// too; every existing `random_address()` call site already inferred `Address`
+/// here, so this is a behavior-preserving simplification.
+pub fn random_address() -> Address {
+    Address::random()
 }
 
 struct MockedStatsTrackerStorage;

--- a/src/test_env.rs
+++ b/src/test_env.rs
@@ -38,10 +38,7 @@ use tracing::debug;
 pub const DEFAULT_TEST_CONFIG_PATH: &str = "./test-env-config.yaml";
 
 /// Loopback address the gas-station server's own test-only HTTP listener
-/// binds to. There is no SDK equivalent of the old
-/// `iota_config::local_ip_utils::localhost_for_testing` -- this is purely
-/// this crate's own test infrastructure, not part of any wire format --
-/// so it is just a plain constant now.
+/// binds to.
 fn localhost_for_testing() -> String {
     "127.0.0.1".to_string()
 }

--- a/src/test_env.rs
+++ b/src/test_env.rs
@@ -44,13 +44,9 @@ fn localhost_for_testing() -> String {
 }
 
 /// Binds an OS-assigned ephemeral TCP port on `host` and immediately drops
-/// the listener, returning the port number that was assigned. Same
-/// bind-then-release approach (and the same TOCTOU race against another
-/// caller grabbing the port before the caller of this function does) as the
-/// old `iota_config::local_ip_utils::get_available_port` it replaces; that
-/// crate is gone from our dependency tree, and the SDK has no equivalent
-/// (it's not part of any wire format either), so this is a small local
-/// helper instead.
+/// the listener, returning the port number that was assigned.
+/// (Warning: TOCTOU race against another caller grabbing the port before the
+/// caller of this function does)
 fn get_available_port(host: &str) -> u16 {
     TcpListener::bind((host, 0))
         .expect("failed to bind to an OS-assigned port")

--- a/src/test_env.rs
+++ b/src/test_env.rs
@@ -82,13 +82,12 @@ pub async fn start_gas_station(
 ) -> (TestCluster, GasStationContainer) {
     debug!("Starting Iota cluster..");
     let (test_cluster, signer) = start_iota_cluster(init_gas_amounts).await;
-    // On develop, `TestCluster` starts its fullnode's gRPC API by default and
+    // `TestCluster` starts its fullnode's gRPC API by default and
     // self-allocates the port (see `TestClusterBuilder`'s
     // `fullnode_enable_grpc_api: true` default and
     // `node_config_builder.rs`'s `local_ip_utils::get_available_port` use) --
     // `grpc_url()` (on `TestCluster` itself, not `FullNodeHandle`) is all
-    // that's needed to reach it, replacing the old JSON-RPC
-    // `fullnode_handle.rpc_url`, since our own `IotaClient` now speaks gRPC.
+    // that's needed to reach it.
     let grpc_url = test_cluster.grpc_url();
     let sponsor_address = signer.get_address();
     debug!("Starting storage. Sponsor address: {:?}", sponsor_address);

--- a/src/test_env.rs
+++ b/src/test_env.rs
@@ -269,12 +269,6 @@ pub async fn create_test_transaction(
         .await
         .expect("failed to resolve test transaction");
 
-    // `TestCluster::sign_transaction` accepts our `Transaction` directly
-    // (`TransactionData` is a re-export of it on develop) but returns the
-    // monorepo's own signed-transaction envelope type, not
-    // `iota_sdk_types::UserSignature` -- so the single user signature is
-    // pulled back out of it here, mirroring what the pre-migration version
-    // did with `tx_signatures_mut_for_testing().pop()`.
     let user_sig = test_cluster
         .sign_transaction(&tx)
         .into_data()

--- a/src/test_env.rs
+++ b/src/test_env.rs
@@ -314,14 +314,6 @@ pub async fn new_stats_tracker_for_testing(sponsor_address: Address) -> StatsTra
 }
 
 /// Constructs an arbitrary `iota_sdk_types::Address` for use in tests.
-///
-/// This used to be generic over a `RandomTestAddress` trait so it could also
-/// produce the old `iota_types::base_types::IotaAddress` (once needed by the
-/// access-controller's `TransactionContext`, before that was retyped onto the
-/// new SDK's `Address` -- see `access_controller/rule.rs`). Now that nothing
-/// in this crate needs the old address type anymore, the indirection is gone
-/// too; every existing `random_address()` call site already inferred `Address`
-/// here, so this is a behavior-preserving simplification.
 pub fn random_address() -> Address {
     Address::random()
 }

--- a/src/test_env.rs
+++ b/src/test_env.rs
@@ -221,15 +221,6 @@ pub async fn start_rpc_server_for_testing_with_access_controller(
 /// the PTB itself doesn't need to do anything meaningful, it just needs to be
 /// a valid transaction for the gas station to execute -- while `sponsor`
 /// pays with `gas_coins`.
-///
-/// Unlike the pre-migration version of this helper, which built a plain
-/// (unsponsored) transaction via the old `TestTransactionBuilder` and then
-/// hand-patched `gas_data_mut().payment`/`.owner` onto it afterwards (see the
-/// removed `TODO: Add proper sponsored transaction support to test tx
-/// builder` comment that used to sit here), this uses the new SDK
-/// transaction builder's first-class sponsor support
-/// (`TransactionBuilder::sponsor`/`::gas`) directly -- no post-hoc patching
-/// needed.
 pub async fn create_test_transaction(
     test_cluster: &TestCluster,
     sponsor: Address,

--- a/src/test_env.rs
+++ b/src/test_env.rs
@@ -4,7 +4,7 @@
 
 use crate::access_controller::AccessController;
 use crate::config::{
-    CoinInitConfig, GasStationStorageConfig, DEFAULT_CHECKPOINT_WAIT_MS,
+    CoinInitConfig, GasStationStorageConfig, DEFAULT_CHECKPOINT_INCLUSION_TIMEOUT_MS,
     DEFAULT_DAILY_GAS_USAGE_CAP, DEFAULT_MAX_GAS_BUDGET,
 };
 use crate::gas_station::gas_station_core::{GasStationContainer, NANOS_PER_IOTA};
@@ -124,7 +124,7 @@ pub async fn start_gas_station(
         iota_client,
         DEFAULT_DAILY_GAS_USAGE_CAP,
         max_gas_budget.unwrap_or(DEFAULT_MAX_GAS_BUDGET),
-        DEFAULT_CHECKPOINT_WAIT_MS,
+        DEFAULT_CHECKPOINT_INCLUSION_TIMEOUT_MS,
         GasStationCoreMetrics::new_for_testing(),
         rescan_config,
     )

--- a/src/tracker/stats_tracker_storage/redis/mod.rs
+++ b/src/tracker/stats_tracker_storage/redis/mod.rs
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use async_trait::async_trait;
-use fastcrypto::hash::*;
+use base64ct::Encoding as _;
+use sha2::{Digest, Sha256};
 
 use anyhow::Result;
 use itertools::Itertools;
@@ -89,9 +90,13 @@ fn generate_hash_from_key<'a>(key: &[(String, Value)]) -> String {
         hash_key.push_str(&to_string(&v).unwrap());
     }
 
-    let mut hasher = Sha256::default();
+    // NOTE: fastcrypto's `Digest` `Display` impl base64-encodes the raw hash bytes (NOT hex),
+    // so to keep producing byte-identical Redis keys for existing data we must reproduce that
+    // exact "SHA-256 then base64 (standard alphabet, padded)" encoding here, rather than the
+    // more obvious sha2 + hex::encode combination.
+    let mut hasher = Sha256::new();
     hasher.update(hash_key.as_bytes());
-    hasher.finalize().to_string()
+    base64ct::Base64::encode_string(&hasher.finalize())
 }
 
 pub async fn connect_stats_storage(
@@ -185,5 +190,37 @@ mod test {
         let hash_key_reversed = generate_hash_from_key(&key_map_rev);
 
         assert_eq!(hash_key, hash_key_reversed);
+    }
+
+    /// Regression test pinning `generate_hash_from_key`'s output for a known input to the
+    /// value the *old* `fastcrypto::hash::Sha256` + `Digest::to_string()` implementation
+    /// produced for the exact same input.
+    ///
+    /// `fastcrypto`'s `Digest` `Display` impl base64-encodes the raw hash bytes (not hex), so
+    /// the sha2+base64ct replacement must keep producing this exact string, otherwise every
+    /// Redis key this service has ever written for daily-gas-cap counters would be orphaned
+    /// (silently resetting existing customers' counters to zero).
+    ///
+    /// The expected value below was obtained empirically by running fastcrypto's old
+    /// `Sha256::default().update(input).finalize().to_string()` against the identical input
+    /// this test uses (a throwaway scratch binary depending on the still-present `fastcrypto`
+    /// crate), then hardcoded here as a permanent pin.
+    #[test]
+    fn test_generate_hash_from_key_pinned_digest() {
+        let key_meta = json!({
+            "sender_address": "0x1234567890abcdef",
+        })
+        .as_object()
+        .unwrap()
+        .to_owned()
+        .into_iter()
+        .collect::<Vec<_>>();
+
+        let hash = generate_hash_from_key(&key_meta);
+
+        // Empirically derived from fastcrypto's Sha256 + Base64 Digest::Display for the input
+        // "sender_address\"0x1234567890abcdef\"" (i.e. key "sender_address" concatenated with
+        // the canonical JSON string form of its value, per `generate_hash_from_key`).
+        assert_eq!(hash, "ppIC+GjLAl03pJy3GK0aFwo9XtX1Vl/i12ek/NaYIpw=");
     }
 }

--- a/src/tx_signer.rs
+++ b/src/tx_signer.rs
@@ -63,16 +63,6 @@ impl SidecarTxSigner {
 
 #[async_trait::async_trait]
 impl TxSigner for SidecarTxSigner {
-    // Wire-unchanged from the pre-migration implementation: still
-    // base64(bcs(tx)) posted as `{"txBytes": ...}` to `/sign-transaction`,
-    // with the response's `signature` field parsed via `UserSignature::from_str`
-    // (confirmed in ground truth at `iota-sdk-types/src/crypto/signature.rs`:
-    // `impl FromStr for UserSignature` delegates to `from_base64`, which
-    // base64-decodes then dispatches on the leading scheme-flag byte -- the
-    // same `flag || signature || pubkey` wire shape the old `GenericSignature`
-    // used). Only the type names (and the `fastcrypto::encoding::Base64` ->
-    // `crate::base64::Base64` swap, itself also just a thin wrapper over the
-    // same standard/padded base64 alphabet) changed here.
     async fn sign_transaction(&self, tx: &Transaction) -> anyhow::Result<UserSignature> {
         let bytes = Base64::encode(bcs::to_bytes(tx)?);
         let resp = self

--- a/src/tx_signer.rs
+++ b/src/tx_signer.rs
@@ -2,14 +2,11 @@
 // Modifications Copyright (c) 2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::base64::Base64;
 use anyhow::anyhow;
-use fastcrypto::encoding::{Base64, Encoding};
-use iota_sdk_types::Intent;
-use iota_sdk_types::IntentMessage;
-use iota_types::base_types::IotaAddress;
-use iota_types::crypto::{IotaKeyPair, Signature};
-use iota_types::signature::GenericSignature;
-use iota_types::transaction::TransactionData;
+use iota_sdk_crypto::simple::SimpleKeypair;
+use iota_sdk_crypto::IotaSigner;
+use iota_sdk_types::{Address, Transaction, UserSignature};
 use reqwest::Client;
 use serde::Deserialize;
 use serde_json::json;
@@ -18,10 +15,9 @@ use std::sync::Arc;
 
 #[async_trait::async_trait]
 pub trait TxSigner: Send + Sync {
-    async fn sign_transaction(&self, tx_data: &TransactionData)
-        -> anyhow::Result<GenericSignature>;
-    fn get_address(&self) -> IotaAddress;
-    fn is_valid_address(&self, address: &IotaAddress) -> bool {
+    async fn sign_transaction(&self, tx: &Transaction) -> anyhow::Result<UserSignature>;
+    fn get_address(&self) -> Address;
+    fn is_valid_address(&self, address: &Address) -> bool {
         self.get_address() == *address
     }
 }
@@ -35,13 +31,13 @@ struct SignatureResponse {
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct IotaAddressResponse {
-    iota_pubkey_address: IotaAddress,
+    iota_pubkey_address: Address,
 }
 
 pub struct SidecarTxSigner {
     sidecar_url: String,
     client: Client,
-    iota_address: IotaAddress,
+    iota_address: Address,
 }
 
 impl SidecarTxSigner {
@@ -67,11 +63,18 @@ impl SidecarTxSigner {
 
 #[async_trait::async_trait]
 impl TxSigner for SidecarTxSigner {
-    async fn sign_transaction(
-        &self,
-        tx_data: &TransactionData,
-    ) -> anyhow::Result<GenericSignature> {
-        let bytes = Base64::encode(bcs::to_bytes(&tx_data)?);
+    // Wire-unchanged from the pre-migration implementation: still
+    // base64(bcs(tx)) posted as `{"txBytes": ...}` to `/sign-transaction`,
+    // with the response's `signature` field parsed via `UserSignature::from_str`
+    // (confirmed in ground truth at `iota-sdk-types/src/crypto/signature.rs`:
+    // `impl FromStr for UserSignature` delegates to `from_base64`, which
+    // base64-decodes then dispatches on the leading scheme-flag byte -- the
+    // same `flag || signature || pubkey` wire shape the old `GenericSignature`
+    // used). Only the type names (and the `fastcrypto::encoding::Base64` ->
+    // `crate::base64::Base64` swap, itself also just a thin wrapper over the
+    // same standard/padded base64 alphabet) changed here.
+    async fn sign_transaction(&self, tx: &Transaction) -> anyhow::Result<UserSignature> {
+        let bytes = Base64::encode(bcs::to_bytes(tx)?);
         let resp = self
             .client
             .post(format!("{}/{}", self.sidecar_url, "sign-transaction"))
@@ -80,38 +83,44 @@ impl TxSigner for SidecarTxSigner {
             .send()
             .await?;
         let sig_bytes = resp.json::<SignatureResponse>().await?;
-        let sig = GenericSignature::from_str(&sig_bytes.signature)
+        let sig = UserSignature::from_str(&sig_bytes.signature)
             .map_err(|err| anyhow!(err.to_string()))?;
         Ok(sig)
     }
 
-    fn get_address(&self) -> IotaAddress {
+    fn get_address(&self) -> Address {
         self.iota_address
     }
 }
 
 pub struct TestTxSigner {
-    keypair: IotaKeyPair,
+    keypair: SimpleKeypair,
 }
 
 impl TestTxSigner {
-    pub fn new(keypair: IotaKeyPair) -> Arc<Self> {
+    pub fn new(keypair: SimpleKeypair) -> Arc<Self> {
         Arc::new(Self { keypair })
     }
 }
 
 #[async_trait::async_trait]
 impl TxSigner for TestTxSigner {
-    async fn sign_transaction(
-        &self,
-        tx_data: &TransactionData,
-    ) -> anyhow::Result<GenericSignature> {
-        let intent_msg = IntentMessage::new(Intent::iota_transaction(), tx_data);
-        let sponsor_sig = Signature::new_secure(&intent_msg, &self.keypair).into();
-        Ok(sponsor_sig)
+    async fn sign_transaction(&self, tx: &Transaction) -> anyhow::Result<UserSignature> {
+        // `IotaSigner::sign_transaction` is blanket-implemented (in
+        // `iota-sdk-crypto`) for any `T: Signer<UserSignature>`, which
+        // `SimpleKeypair` is. It computes the signing digest internally as
+        // `blake2b(Intent::iota_transaction().to_bytes() || bcs(tx))` --
+        // see `iota_sdk_types::Transaction::signing_digest` in ground truth
+        // (`iota-sdk-types/src/hash.rs`) -- so the old manual two-step
+        // (`IntentMessage::new(Intent::iota_transaction(), tx_data)` +
+        // `Signature::new_secure(&intent_msg, &keypair)`) collapses into this
+        // single call.
+        self.keypair
+            .sign_transaction(tx)
+            .map_err(|err| anyhow!(err.to_string()))
     }
 
-    fn get_address(&self) -> IotaAddress {
-        (&self.keypair.public()).into()
+    fn get_address(&self) -> Address {
+        self.keypair.public_key().derive_address()
     }
 }

--- a/src/tx_signer.rs
+++ b/src/tx_signer.rs
@@ -96,15 +96,6 @@ impl TestTxSigner {
 #[async_trait::async_trait]
 impl TxSigner for TestTxSigner {
     async fn sign_transaction(&self, tx: &Transaction) -> anyhow::Result<UserSignature> {
-        // `IotaSigner::sign_transaction` is blanket-implemented (in
-        // `iota-sdk-crypto`) for any `T: Signer<UserSignature>`, which
-        // `SimpleKeypair` is. It computes the signing digest internally as
-        // `blake2b(Intent::iota_transaction().to_bytes() || bcs(tx))` --
-        // see `iota_sdk_types::Transaction::signing_digest` in ground truth
-        // (`iota-sdk-types/src/hash.rs`) -- so the old manual two-step
-        // (`IntentMessage::new(Intent::iota_transaction(), tx_data)` +
-        // `Signature::new_secure(&intent_msg, &keypair)`) collapses into this
-        // single call.
         self.keypair
             .sign_transaction(tx)
             .map_err(|err| anyhow!(err.to_string()))

--- a/src/types.rs
+++ b/src/types.rs
@@ -2,25 +2,35 @@
 // Modifications Copyright (c) 2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::rpc::effects::ObjectRefDto;
 use anyhow::bail;
-use iota_json_rpc_types::IotaObjectRef;
-use iota_types::base_types::{ObjectID, ObjectRef};
+#[cfg(test)]
+use iota_sdk_types::{ObjectDigest, Version};
+use iota_sdk_types::{ObjectId, ObjectReference};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct GasCoin {
-    pub object_ref: ObjectRef,
+    pub object_ref: ObjectReference,
     pub balance: u64,
 }
 
 #[derive(Debug, JsonSchema, Serialize, Deserialize)]
 pub struct IotaGasCoin {
-    pub object_ref: IotaObjectRef,
+    pub object_ref: ObjectRefDto,
     pub balance: u64,
 }
 
+// `IotaGasCoin` is the JSON-RPC-facing (camelCase `{objectId, version, digest}`) wire
+// shape for a gas coin's object reference; see `crate::rpc::effects::ObjectRefDto` for
+// the exact serde contract. `GasCoin.object_ref` is the SDK's own `ObjectReference`
+// (snake_case, not wire-facing). Both `ObjectRefDto` and `ObjectReference` are native
+// `iota_sdk_types`-backed types now, so this is a direct field-for-field conversion --
+// no string round-tripping needed (that was only ever a stopgap bridge to the old,
+// now-removed `iota_json_rpc_types::IotaObjectRef`, from before `rpc/rpc_types.rs` was
+// migrated).
 impl From<GasCoin> for IotaGasCoin {
     fn from(gas_coin: GasCoin) -> Self {
         Self {
@@ -33,7 +43,7 @@ impl From<GasCoin> for IotaGasCoin {
 impl From<IotaGasCoin> for GasCoin {
     fn from(gas_coin: IotaGasCoin) -> Self {
         Self {
-            object_ref: gas_coin.object_ref.to_object_ref(),
+            object_ref: gas_coin.object_ref.into(),
             balance: gas_coin.balance,
         }
     }
@@ -41,16 +51,16 @@ impl From<IotaGasCoin> for GasCoin {
 
 pub type ReservationID = u64;
 pub type ExpirationTimeMs = u64;
-pub type GasGroupKey = ObjectID;
+pub type GasGroupKey = ObjectId;
 
 #[derive(Clone, Default, Debug)]
 pub struct UpdatedGasGroup {
     pub updated_gas_coins: Vec<GasCoin>,
-    pub deleted_gas_coins: Vec<ObjectID>,
+    pub deleted_gas_coins: Vec<ObjectId>,
 }
 
 impl UpdatedGasGroup {
-    pub fn new(updated_gas_coins: Vec<GasCoin>, deleted_gas_coins: Vec<ObjectID>) -> Self {
+    pub fn new(updated_gas_coins: Vec<GasCoin>, deleted_gas_coins: Vec<ObjectId>) -> Self {
         Self {
             updated_gas_coins,
             deleted_gas_coins,
@@ -60,7 +70,7 @@ impl UpdatedGasGroup {
         let all_ids: BTreeSet<_> = self
             .updated_gas_coins
             .iter()
-            .map(|coin| &coin.object_ref.0)
+            .map(|coin| &coin.object_ref.object_id)
             .chain(&self.deleted_gas_coins)
             .collect();
         if all_ids.is_empty() {
@@ -76,7 +86,7 @@ impl UpdatedGasGroup {
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ReservedGasGroup {
-    pub objects: BTreeSet<ObjectID>,
+    pub objects: BTreeSet<ObjectId>,
     pub expiration_time: ExpirationTimeMs,
 }
 
@@ -84,4 +94,16 @@ impl ReservedGasGroup {
     pub fn get_key(&self) -> GasGroupKey {
         *self.objects.iter().next().unwrap()
     }
+}
+
+/// Test-only helper equivalent to the old `iota_types::base_types::random_object_ref()`:
+/// a random object id paired with version 0 and the all-zero digest (the new SDK has no
+/// direct equivalent, so we reconstruct it here for use by `storage`'s test modules).
+#[cfg(test)]
+pub fn random_object_ref() -> ObjectReference {
+    ObjectReference::new(
+        ObjectId::random(),
+        Version::from_u64(0),
+        ObjectDigest::new([0; 32]),
+    )
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -23,14 +23,6 @@ pub struct IotaGasCoin {
     pub balance: u64,
 }
 
-// `IotaGasCoin` is the JSON-RPC-facing (camelCase `{objectId, version, digest}`) wire
-// shape for a gas coin's object reference; see `crate::rpc::effects::ObjectRefDto` for
-// the exact serde contract. `GasCoin.object_ref` is the SDK's own `ObjectReference`
-// (snake_case, not wire-facing). Both `ObjectRefDto` and `ObjectReference` are native
-// `iota_sdk_types`-backed types now, so this is a direct field-for-field conversion --
-// no string round-tripping needed (that was only ever a stopgap bridge to the old,
-// now-removed `iota_json_rpc_types::IotaObjectRef`, from before `rpc/rpc_types.rs` was
-// migrated).
 impl From<GasCoin> for IotaGasCoin {
     fn from(gas_coin: GasCoin) -> Self {
         Self {

--- a/src/types.rs
+++ b/src/types.rs
@@ -88,9 +88,6 @@ impl ReservedGasGroup {
     }
 }
 
-/// Test-only helper equivalent to the old `iota_types::base_types::random_object_ref()`:
-/// a random object id paired with version 0 and the all-zero digest (the new SDK has no
-/// direct equivalent, so we reconstruct it here for use by `storage`'s test modules).
 #[cfg(test)]
 pub fn random_object_ref() -> ObjectReference {
     ObjectReference::new(


### PR DESCRIPTION
# Migrate fullnode communication to gRPC via `iota-rust-sdk`

## Summary

This PR replaces the Gas Station's entire fullnode integration: instead of talking JSON-RPC through the IOTA monorepo crates (`iota-sdk`, `iota-types`, `iota-json-rpc-types`, …), it now talks **gRPC** through the standalone [iota-rust-sdk](https://github.com/iotaledger/iota-rust-sdk) (`iota-sdk-types`, `iota-sdk-crypto`, `iota-sdk-grpc-client`, `iota-sdk-transaction-builder`). JSON-RPC is being retired upstream in favor of gRPC as the fullnode transport, so this moves the Gas Station off the deprecated path ahead of time.

The guiding principle of the migration: **the transport and internal types change, but every externally observable contract is preserved** — the HTTP API wire format, the on-disk config format, the Redis schema, and the Rego policy input shape. Where the new SDK types diverge from the old wire shapes, explicit compatibility layers were written (and pinned with golden tests) rather than letting the new shapes leak out.

## Main changes (domain view)

### New gRPC fullnode client (`src/iota_client.rs`)

The JSON-RPC `iota_sdk::IotaClient` wrapper is rewritten on top of `iota-sdk-grpc-client`:

- **Error handling is now classification-based**: gRPC status codes are split into *transient* (retried — `Unavailable`, `DeadlineExceeded`, transport resets) and *permanent* (fail fast — `InvalidArgument`, `NotFound`, auth errors, `Unimplemented`). Every call runs under a 30 s per-attempt timeout so a stalled stream can't block the retry loop forever.
- **Coin listing** uses `list_owned_objects` with the server's max page size (1000, vs the old JSON-RPC default of 50).
- **Object refresh** uses batched `get_objects` (1000-object chunks) with a temporary one-by-one fallback for batches containing deleted coins (the pinned SDK rev fails a whole batch on any per-item error; TODO to drop once iotaledger/iota-rust-sdk#1292 lands).
- **Gas-cost calibration** uses gRPC `simulate_transaction` with a server-fabricated mock gas coin instead of the old dev-inspect flow.
- **Legacy URL auto-redirect**: a `fullnode-url` still pointing at one of the public JSON-RPC endpoints (`api.{mainnet,testnet,devnet}.iota.cafe`) is transparently redirected to the matching `grpc.*` endpoint at connection time, with a startup warning. This is deliberately done at the last moment ("last mile") so the Redis storage namespace — which is derived from the *configured* URL — stays unchanged and existing coin registries keep working (see Breaking changes).

### Transaction & signature types

All internal types moved to `iota-sdk-types`: `TransactionData` → `Transaction`, `GenericSignature` → `UserSignature`, `IotaAddress` → `Address`, `ObjectID` → `ObjectId`, etc. This is invisible on the wire: the SDK's `Transaction` BCS layout is identical to the old `TransactionData` (versioned enum), and `UserSignature` parses the same flagged signature bytes (including multisig), so **existing client SDKs keep working unmodified**.

### Effects response compatibility layer (`src/rpc/effects.rs`)

The SDK's `TransactionEffects` uses a compact representation (a single `changed_objects` list), while `/v1/execute_tx` clients have always received the flat JSON-RPC shape (`created` / `mutated` / `deleted` / `gasObject` / …, i.e. `IotaTransactionBlockEffectsV1`). This module defines JSON-RPC-shaped DTOs, ports the flattening logic from the monorepo's own migration, and pins the exact wire format with golden-JSON regression tests. The `/v1/execute_tx` response is **byte-identical** to before.

### Rego policy input compatibility layer (`src/access_controller/rego_input.rs`)

Rego policies are customer-deployed configuration, so the JSON shape of `input.transaction_data` is a wire contract. The new SDK types' native JSON diverges from the old `iota_types` shape in 8 documented ways (base64 vs byte-array `Pure` inputs, `gas_payment` vs `gas_data`, string vs numeric versions/budgets, renamed enum variants like `Programmable` vs `ProgrammableTransaction`, restructured `Command` variants, …). This module defines serialize-only "shadow" types reproducing the **pre-migration JSON shape exactly**, so existing Rego policies (including `bcs.decode_typed` usage) keep evaluating unchanged.

### Config & key handling (`src/config/mod.rs`, `src/tx_signer.rs`)

- The local signer keypair is now `iota_sdk_crypto::SimpleKeypair`, with a custom serde adapter that keeps the **on-disk base64 format byte-identical** to the old `IotaKeyPair` (pinned by a regression test loading a real pre-migration fixture and re-serializing it).
- A small local `Config` load/save trait replaces the monorepo's `iota-config` dependency.
- New optional config key **`checkpoint-inclusion-timeout-ms`** (default `10000`) — see Breaking changes.
- Sidecar (KMS) signing is unchanged; local signing goes through `iota-sdk-crypto`.

### Coin initialization & transaction building

Coin splitting and the hook/example transactions are built with `iota-sdk-transaction-builder`'s `TransactionBuilder` instead of the monorepo's `ProgrammableTransactionBuilder`. Behavior (split targets, budgets, init locking) is unchanged.

### Metrics & logging

- `iota-metrics` is dropped: the Prometheus server is now a small local axum router, and the eight latency/usage histograms moved from the monorepo's percentile-gauge style `Histogram` to **native Prometheus histograms** (metric *names* unchanged, exported *series shape* changed — see Breaking changes).
- `telemetry-subscribers` is dropped in favor of plain `tracing-subscriber`. `RUST_LOG` and the `TRANSACTIONS_LOGGING=true` transaction-audit target keep working.

### Tooling, examples, dependencies

- `scripts/sync-sdk-rev.sh` pins/bumps the `iota-rust-sdk` revision (and keeps the `fastcrypto` patch in sync with the monorepo).
- The CLI `tool`, Rust examples (sponsored transaction, hook examples), and the hook example server were ported to the new SDK/gRPC endpoints.
- The dependency tree no longer pulls the IOTA monorepo at all for the main binary (only `test-cluster`/`iota-swarm-config` remain, as dev-dependencies for integration tests), which drastically shrinks the build.

## ⚠️ Breaking changes / operator notes

### 1. `fullnode-url` must now be a gRPC endpoint

The Gas Station no longer speaks JSON-RPC to the fullnode. For the public networks: `https://api.<net>.iota.cafe` → `https://grpc.<net>.iota.cafe`. Self-hosted nodes need `enable-grpc-api: true` in the node config.

**Mitigation:** the three well-known public JSON-RPC URLs are auto-redirected to their gRPC counterparts at connection time, with a warning log — an existing deployment keeps running unmodified. Unknown (self-hosted) JSON-RPC URLs cannot be guessed: they pass config load (the gRPC channel connects lazily) and fail at the first RPC call — either a fast panic (endpoint returns 404 → `Unimplemented`, classified permanent) or, if the endpoint's failure mode maps to a transient code, a retry loop. There is no config-load-time validation.

### 2. Changing `fullnode-url` changes the Redis storage namespace

All Redis state (coin registry, reservations, daily gas-usage counter) is namespaced by `<fullnode-host>_<port>:<sponsor>`. Repointing the URL therefore starts a **fresh, empty namespace**: the coin pool re-initializes from on-chain coins, in-flight reservations are dropped, and the daily-cap counter resets; old-namespace keys linger in Redis until cleaned manually.

Consequences for the upgrade:
- Update the URL on **all instances at once during a full stop**. A rolling deploy would run old and new namespaces concurrently over the *same on-chain coins* and could hand out the same coin twice (equivocation).
- The auto-redirect (point 1) deliberately does **not** change the namespace, so operators can defer the config edit to a maintenance window.

### 3. `WaitForLocalExecution` semantics changed

The old JSON-RPC request type waited for local execution on the fullnode. It now maps to the gRPC `execute_transaction` call's `checkpoint_inclusion_timeout_ms` (waiting for checkpoint inclusion), configurable via the new `checkpoint-inclusion-timeout-ms` key (default 10 s). Latency characteristics differ; values above ~30 s are effectively capped by the client's per-attempt timeout. The HTTP API field itself is unchanged and both request types are still accepted.

### 4. Prometheus histogram series shape changed

The eight histogram metrics (e.g. `reserve_gas_latency_ms`, `transaction_execution_latency_ms`, `gas_usage_per_transaction`) keep their names but now export native Prometheus histograms (`_bucket`/`le` + `_sum`/`_count`) instead of the old percentile-gauge series. **Dashboards and alerts built on the old shape need updating.** The `iota-metrics` default registry extras (e.g. uptime) are gone.

### 5. Log line format changed

`telemetry-subscribers` → `tracing-subscriber` changes the emitted line format; log-shipping parsers may need adjustment. `RUST_LOG` now fully replaces the default filter instead of merging with it.

### 6. Error message strings changed

E.g. `"Invalid bcs bytes for TransactionData"` → `"Invalid bcs bytes for Transaction"`. Only relevant to clients matching on error text (which they shouldn't).

## Explicitly preserved compatibility (verified with tests)

| Surface | Status |
| --- | --- |
| `/v1/reserve_gas` and `/v1/execute_tx` request/response JSON (incl. effects) | unchanged, pinned by golden tests |
| `tx_bytes` BCS payloads from existing client SDKs | unchanged (same BCS layout) |
| User signatures (ed25519, secp256k1/r1, multisig) | unchanged |
| Config file format, incl. local `keypair` base64 encoding | unchanged, regression-tested against a pre-migration fixture |
| Redis key schema and namespaces | unchanged (as long as `fullnode-url` isn't edited — see above) |
| Rego policy `input.transaction_data` shape | unchanged via shadow types, tested against documented examples |
| Hook API payloads | unchanged |
| `fullnode-basic-auth` | unchanged (sent as gRPC headers) |
| `TRANSACTIONS_LOGGING` audit logging | unchanged |
