### PR TITLE
fix: prevent a successful transaction from permanently losing its gas coin

### DIFF
--- a/src/gas_station/gas_station_core.rs
+++ b/src/gas_station/gas_station_core.rs
@@ -221,33 +221,36 @@ impl GasStation {
                     .collect()
             }
         };
-        let smashed_coin_count = payment_count - updated_coins.len();
-        // Before returning the coins to the pool, verify if any coin exceeds
-        // NEW_COIN_BALANCE_FACTOR_THRESHOLD times the target initial balance.
-        let oversized_coins_count = updated_coins
-            .iter()
-            .filter(|coin| {
-                coin.balance
-                    > NEW_COIN_BALANCE_FACTOR_THRESHOLD * self.rescan_config.target_init_balance
-            })
-            .count();
-        if oversized_coins_count > 0 {
+        // Saturating: `updated_coins` exceeding `payment_count` would be a node
+        // bug, and wrapping would corrupt the metric.
+        let smashed_coin_count = payment_count.saturating_sub(updated_coins.len());
+
+        // Withhold only the coins actually above the threshold. Branching on
+        // "any oversized" used to skip release for the whole execution, which is
+        // what lost the coins.
+        let threshold = NEW_COIN_BALANCE_FACTOR_THRESHOLD * self.rescan_config.target_init_balance;
+        let (oversized_coins, coins_to_release): (Vec<GasCoin>, Vec<GasCoin>) = updated_coins
+            .into_iter()
+            .partition(|coin| coin.balance > threshold);
+
+        if !oversized_coins.is_empty() {
             warn!("Oversized coins found during transaction execution. Initiating rescan to split these coins. If this occurs frequently, consider adjusting target_init_balance or the maximum transaction budget.");
             self.rescan_config.trigger_rescan().await;
             self.metrics
                 .oversized_gas_coins_count
                 .with_label_values(&[&sponsor.to_string()])
-                .inc_by(oversized_coins_count as u64);
-        } else {
+                .inc_by(oversized_coins.len() as u64);
+        }
+        if !coins_to_release.is_empty() {
             // Regardless of whether the transaction succeeded, we need to release the coins.
             // Otherwise, we lose track of them. This is because `ready_for_execution` already takes
             // the coins out of the pool and will not be covered by the auto-release mechanism.
             info!(
                 ?reservation_id,
                 "Releasing {} coins back to the pool",
-                updated_coins.len()
+                coins_to_release.len()
             );
-            self.release_gas_coins(updated_coins).await;
+            self.release_gas_coins(coins_to_release).await;
         }
         if smashed_coin_count > 0 {
             info!(

--- a/src/gas_station/gas_station_core.rs
+++ b/src/gas_station/gas_station_core.rs
@@ -27,6 +27,11 @@ use tracing::{debug, error, info, warn};
 
 use super::gas_usage_cap::GasUsageCap;
 
+/// Bounded retry for a gas coin the fullnode cannot resolve yet. Tuning, not
+/// protocol: sized above a 500-650 ms read lag measured on a localnet.
+const GAS_COIN_RESOLVE_ATTEMPTS: u32 = 20;
+const GAS_COIN_RESOLVE_INTERVAL: Duration = Duration::from_millis(100);
+
 pub const NANOS_PER_IOTA: u64 = 1_000_000_000;
 
 const EXPIRATION_JOB_INTERVAL: Duration = Duration::from_secs(1);
@@ -137,7 +142,7 @@ impl GasStation {
         let total_gas_coin_balance = self.get_total_gas_coin_balance(payment.clone()).await;
         debug!(
             ?reservation_id,
-            "Total gas coin balance prior to execution: {}", total_gas_coin_balance,
+            "Total gas coin balance prior to execution: {:?}", total_gas_coin_balance,
         );
         let response = self
             .execute_transaction_impl(reservation_id, tx, user_sig, request_type)
@@ -146,58 +151,58 @@ impl GasStation {
             Ok(effects) => {
                 let new_gas_coin = gas_object_reference(effects);
                 let net_gas_usage = effects.as_v1().gas_cost_summary.net_gas_usage();
-                // Computed in i128 because neither operand's range fits the
-                // result: `total_gas_coin_balance` is a u64 (so values above
-                // i64::MAX are misread as negative by `as i64`), and
-                // `net_gas_usage` is a signed i64 that is *legitimately*
-                // negative whenever gas smashing refunds more storage than the
-                // transaction spent. i128 holds every (u64, i64) pair exactly,
-                // so the single conversion below is the only place either
-                // direction can be rejected.
-                let new_balance: i128 =
-                    total_gas_coin_balance as i128 - net_gas_usage as i128;
+                // i128: neither a u64 total nor a signed i64 gas usage fits the
+                // result. `None` means the pre-execution read never resolved.
+                let new_balance: Option<i128> = total_gas_coin_balance
+                    .map(|total| total as i128 - net_gas_usage as i128);
                 debug!(
                     ?reservation_id,
-                    "New gas coin balance after execution: {}", new_balance,
+                    "New gas coin balance after execution: {:?}", new_balance,
                 );
                 #[cfg(test)]
                 {
                     self.iota_client.wait_for_object(new_gas_coin).await;
                     assert_eq!(
-                        i128::from(self.get_total_gas_coin_balance(payment).await),
+                        self.get_total_gas_coin_balance(payment)
+                            .await
+                            .map(i128::from),
                         new_balance
                     );
                 }
                 self.metrics
                     .gas_usage_per_transaction
                     .observe(net_gas_usage as f64);
-                self.metrics
-                    .reserved_gas_real_gas_usage_delta
-                    // If a refund occurs, ensure that the delta does not exceed the original total balance of the gas coins
-                    .observe(min(new_balance, total_gas_coin_balance as i128) as f64);
+                if let (Some(derived), Some(total)) = (new_balance, total_gas_coin_balance) {
+                    self.metrics
+                        .reserved_gas_real_gas_usage_delta
+                        // If a refund occurs, ensure that the delta does not exceed the original total balance of the gas coins
+                        .observe(min(derived, total as i128) as f64);
+                }
 
-                // A successful transaction cannot leave its own gas coin with a
-                // negative balance: the validators debited this very coin and a
-                // `Coin<IOTA>` cannot go below zero. So a value that does not
-                // fit a u64 is not a gas-accounting outcome, it is proof that
-                // `total_gas_coin_balance` was wrong — in practice because the
-                // pre-execution read could not resolve the coin and reported 0.
-                //
-                // Record it and release the coin at a balance of zero rather
-                // than storing the wrapped value. `ready_for_execution` has
-                // already removed this coin from the pool and `expire_coins`
-                // cannot surface it again, so withholding it here would lose it
-                // permanently; an understated balance is recoverable and
-                // self-heals on the coin's next successful use.
-                let balance = u64::try_from(new_balance).unwrap_or_else(|_| {
-                    self.metrics.invariant_violation(format!(
-                        "derived balance {new_balance} is not a valid u64 for gas coin {} \
-                         (pre-execution total {total_gas_coin_balance}, net gas usage \
-                         {net_gas_usage}); releasing the coin with a recorded balance of 0",
-                        new_gas_coin.object_id
-                    ));
-                    0
-                });
+                // Release with 0 rather than withhold: the coin has already left
+                // the pool and nothing can surface it again, so withholding loses
+                // it for good. An understated balance self-heals on next use.
+                let balance = match new_balance.map(u64::try_from) {
+                    Some(Ok(balance)) => balance,
+                    Some(Err(_)) => {
+                        self.metrics.invariant_violation(format!(
+                            "derived balance {new_balance:?} is not a valid u64 for gas coin {} \
+                             (pre-execution total {total_gas_coin_balance:?}, net gas usage \
+                             {net_gas_usage}); releasing the coin with a recorded balance of 0",
+                            new_gas_coin.object_id
+                        ));
+                        0
+                    }
+                    None => {
+                        self.metrics.invariant_violation(format!(
+                            "could not determine the pre-execution balance of gas coin {} after \
+                             {GAS_COIN_RESOLVE_ATTEMPTS} attempts; releasing it with a recorded \
+                             balance of 0 rather than losing it",
+                            new_gas_coin.object_id
+                        ));
+                        0
+                    }
+                };
                 vec![GasCoin {
                     object_ref: new_gas_coin,
                     balance,
@@ -311,13 +316,41 @@ impl GasStation {
         Ok(effects)
     }
 
-    async fn get_total_gas_coin_balance(&self, gas_coins: Vec<ObjectId>) -> u64 {
-        let latest = self.iota_client.get_latest_gas_objects(gas_coins).await;
-        latest
-            .into_values()
-            .flatten()
-            .map(|coin| coin.balance)
-            .sum()
+    /// Sums the current balances of `gas_coins`, retrying a coin the fullnode
+    /// cannot resolve yet, or returns `None` if any never resolves.
+    ///
+    /// `None` is not a decision to fail the request: the coin has already left
+    /// the pool and must still be released. It only says the balance is unknown.
+    async fn get_total_gas_coin_balance(&self, gas_coins: Vec<ObjectId>) -> Option<u64> {
+        for attempt in 1..=GAS_COIN_RESOLVE_ATTEMPTS {
+            let latest = self
+                .iota_client
+                .get_latest_gas_objects(gas_coins.clone())
+                .await;
+
+            let unresolved: Vec<ObjectId> = latest
+                .iter()
+                .filter(|(_, coin)| coin.is_none())
+                .map(|(id, _)| *id)
+                .collect();
+
+            if unresolved.is_empty() {
+                // `checked_add`: a decoded-garbage balance must not wrap the sum.
+                return latest
+                    .into_values()
+                    .flatten()
+                    .try_fold(0u64, |acc, coin| acc.checked_add(coin.balance));
+            }
+
+            warn!(
+                ?unresolved,
+                attempt,
+                max_attempts = GAS_COIN_RESOLVE_ATTEMPTS,
+                "fullnode could not resolve gas coins; retrying"
+            );
+            tokio::time::sleep(GAS_COIN_RESOLVE_INTERVAL).await;
+        }
+        None
     }
 
     /// Checks gas reservation request validity.

--- a/src/gas_station/gas_station_core.rs
+++ b/src/gas_station/gas_station_core.rs
@@ -145,8 +145,17 @@ impl GasStation {
         let updated_coins = match &response {
             Ok(effects) => {
                 let new_gas_coin = gas_object_reference(effects);
-                let new_balance = total_gas_coin_balance as i64
-                    - effects.as_v1().gas_cost_summary.net_gas_usage();
+                let net_gas_usage = effects.as_v1().gas_cost_summary.net_gas_usage();
+                // Computed in i128 because neither operand's range fits the
+                // result: `total_gas_coin_balance` is a u64 (so values above
+                // i64::MAX are misread as negative by `as i64`), and
+                // `net_gas_usage` is a signed i64 that is *legitimately*
+                // negative whenever gas smashing refunds more storage than the
+                // transaction spent. i128 holds every (u64, i64) pair exactly,
+                // so the single conversion below is the only place either
+                // direction can be rejected.
+                let new_balance: i128 =
+                    total_gas_coin_balance as i128 - net_gas_usage as i128;
                 debug!(
                     ?reservation_id,
                     "New gas coin balance after execution: {}", new_balance,
@@ -155,20 +164,43 @@ impl GasStation {
                 {
                     self.iota_client.wait_for_object(new_gas_coin).await;
                     assert_eq!(
-                        self.get_total_gas_coin_balance(payment).await,
-                        new_balance as u64
+                        i128::from(self.get_total_gas_coin_balance(payment).await),
+                        new_balance
                     );
                 }
                 self.metrics
                     .gas_usage_per_transaction
-                    .observe(effects.as_v1().gas_cost_summary.net_gas_usage() as f64);
+                    .observe(net_gas_usage as f64);
                 self.metrics
                     .reserved_gas_real_gas_usage_delta
                     // If a refund occurs, ensure that the delta does not exceed the original total balance of the gas coins
-                    .observe(min(new_balance, total_gas_coin_balance as i64) as f64);
+                    .observe(min(new_balance, total_gas_coin_balance as i128) as f64);
+
+                // A successful transaction cannot leave its own gas coin with a
+                // negative balance: the validators debited this very coin and a
+                // `Coin<IOTA>` cannot go below zero. So a value that does not
+                // fit a u64 is not a gas-accounting outcome, it is proof that
+                // `total_gas_coin_balance` was wrong — in practice because the
+                // pre-execution read could not resolve the coin and reported 0.
+                //
+                // Record it and release the coin at a balance of zero rather
+                // than storing the wrapped value. `ready_for_execution` has
+                // already removed this coin from the pool and `expire_coins`
+                // cannot surface it again, so withholding it here would lose it
+                // permanently; an understated balance is recoverable and
+                // self-heals on the coin's next successful use.
+                let balance = u64::try_from(new_balance).unwrap_or_else(|_| {
+                    self.metrics.invariant_violation(format!(
+                        "derived balance {new_balance} is not a valid u64 for gas coin {} \
+                         (pre-execution total {total_gas_coin_balance}, net gas usage \
+                         {net_gas_usage}); releasing the coin with a recorded balance of 0",
+                        new_gas_coin.object_id
+                    ));
+                    0
+                });
                 vec![GasCoin {
                     object_ref: new_gas_coin,
-                    balance: new_balance as u64,
+                    balance,
                 }]
             }
             Err(_) => {

--- a/src/gas_station/gas_station_core.rs
+++ b/src/gas_station/gas_station_core.rs
@@ -5,7 +5,7 @@
 use crate::gas_station::effects_util::gas_object_reference;
 use crate::gas_station::rescan_trigger::RescanGasObjectsTrigger;
 use crate::gas_station_initializer::NEW_COIN_BALANCE_FACTOR_THRESHOLD;
-use crate::iota_client::IotaClient;
+use crate::iota_client::{IotaClient, GAS_COIN_RESOLVE_ATTEMPTS};
 use crate::metrics::GasStationCoreMetrics;
 use crate::rpc::rpc_types::{ExecuteTransactionRequestType, ReserveGasRequest};
 use crate::storage::Storage;
@@ -26,11 +26,6 @@ use tokio::task::JoinHandle;
 use tracing::{debug, error, info, warn};
 
 use super::gas_usage_cap::GasUsageCap;
-
-/// Bounded retry for a gas coin the fullnode cannot resolve yet. Tuning, not
-/// protocol: sized above a 500-650 ms read lag measured on a localnet.
-const GAS_COIN_RESOLVE_ATTEMPTS: u32 = 20;
-const GAS_COIN_RESOLVE_INTERVAL: Duration = Duration::from_millis(100);
 
 pub const NANOS_PER_IOTA: u64 = 1_000_000_000;
 
@@ -68,6 +63,13 @@ impl GasStation {
         checkpoint_inclusion_timeout_ms: u64,
         rescan_config: RescanGasObjectsTrigger,
     ) -> Arc<Self> {
+        // Export the series at zero so it exists from startup: an absent metric
+        // reads as "no data" rather than "nothing was lost".
+        metrics
+            .num_unreleased_gas_coins
+            .with_label_values(&[&signer.get_address().to_string()])
+            .inc_by(0);
+
         let pool = Self {
             signer,
             gas_station_store,
@@ -151,10 +153,20 @@ impl GasStation {
             Ok(effects) => {
                 let new_gas_coin = gas_object_reference(effects);
                 let net_gas_usage = effects.as_v1().gas_cost_summary.net_gas_usage();
-                // i128: neither a u64 total nor a signed i64 gas usage fits the
-                // result. `None` means the pre-execution read never resolved.
-                let new_balance: Option<i128> = total_gas_coin_balance
-                    .map(|total| total as i128 - net_gas_usage as i128);
+                // Computed in i128 because neither operand's range fits the
+                // result: `total_gas_coin_balance` is a u64 (so values above
+                // i64::MAX are misread as negative by `as i64`), and
+                // `net_gas_usage` is a signed i64 that is *legitimately*
+                // negative whenever gas smashing refunds more storage than the
+                // transaction spent. i128 holds every (u64, i64) pair exactly,
+                // so the single conversion below is the only place either
+                // direction can be rejected.
+                // Only derivable when the pre-execution balance is actually
+                // known. `None` here means the fullnode could not resolve the
+                // coin even after retrying, so any number we computed would be
+                // fabricated.
+                let new_balance: Option<i128> =
+                    total_gas_coin_balance.map(|total| total as i128 - net_gas_usage as i128);
                 debug!(
                     ?reservation_id,
                     "New gas coin balance after execution: {:?}", new_balance,
@@ -213,17 +225,41 @@ impl GasStation {
                     ?reservation_id,
                     "Querying latest gas state since transaction failed"
                 );
-                self.iota_client
-                    .get_latest_gas_objects(payment)
-                    .await
-                    .into_values()
-                    .flatten()
-                    .collect()
+                // The dangerous read: whether the coins are live or were smashed
+                // depends on whether the transaction landed, which is not known
+                // here.
+                let (resolved, unresolved) = self.iota_client.resolve_gas_coins(payment).await;
+
+                if !unresolved.is_empty() {
+                    // Deliberately NOT counted as unreleased and NOT an invariant:
+                    // these ids may have been smashed legitimately, so an alert
+                    // would prescribe a rescan for coins that may not exist.
+                    warn!(
+                        ?reservation_id,
+                        ?unresolved,
+                        attempts = GAS_COIN_RESOLVE_ATTEMPTS,
+                        "the fullnode did not resolve {} gas coin(s) after a failed execution. If \
+                         the transaction landed despite the error these were smashed and are gone \
+                         legitimately; if it did not land they are still owned on chain and the \
+                         registry has lost them. This branch cannot tell which.",
+                        unresolved.len()
+                    );
+                }
+                resolved
             }
         };
-        // Saturating: `updated_coins` exceeding `payment_count` would be a node
-        // bug, and wrapping would corrupt the metric.
-        let smashed_coin_count = payment_count.saturating_sub(updated_coins.len());
+        // Only a transaction that actually executed smashes anything, and when
+        // one does the success arm above yields exactly the single surviving
+        // coin. Deriving this from `updated_coins.len()` instead used to count
+        // every coin the node failed to resolve as one the validators
+        // legitimately consumed -- so a real loss was reported as a routine
+        // smash, and the one signal pointing at the problem argued against it.
+        // On success exactly one coin survives. On failure the retry makes this
+        // derivable too: unresolved ids are the ones smashing deleted.
+        let smashed_coin_count = match &response {
+            Ok(_) => payment_count.saturating_sub(1),
+            Err(_) => payment_count.saturating_sub(updated_coins.len()),
+        };
 
         // Withhold only the coins actually above the threshold. Branching on
         // "any oversized" used to skip release for the whole execution, which is
@@ -325,35 +361,15 @@ impl GasStation {
     /// `None` is not a decision to fail the request: the coin has already left
     /// the pool and must still be released. It only says the balance is unknown.
     async fn get_total_gas_coin_balance(&self, gas_coins: Vec<ObjectId>) -> Option<u64> {
-        for attempt in 1..=GAS_COIN_RESOLVE_ATTEMPTS {
-            let latest = self
-                .iota_client
-                .get_latest_gas_objects(gas_coins.clone())
-                .await;
-
-            let unresolved: Vec<ObjectId> = latest
-                .iter()
-                .filter(|(_, coin)| coin.is_none())
-                .map(|(id, _)| *id)
-                .collect();
-
-            if unresolved.is_empty() {
-                // `checked_add`: a decoded-garbage balance must not wrap the sum.
-                return latest
-                    .into_values()
-                    .flatten()
-                    .try_fold(0u64, |acc, coin| acc.checked_add(coin.balance));
-            }
-
-            warn!(
-                ?unresolved,
-                attempt,
-                max_attempts = GAS_COIN_RESOLVE_ATTEMPTS,
-                "fullnode could not resolve gas coins; retrying"
-            );
-            tokio::time::sleep(GAS_COIN_RESOLVE_INTERVAL).await;
+        let (resolved, unresolved) = self.iota_client.resolve_gas_coins(gas_coins).await;
+        if !unresolved.is_empty() {
+            // A partial sum looks like a balance and is silently too low.
+            return None;
         }
-        None
+        // `checked_add`: a decoded-garbage balance must not wrap the sum.
+        resolved
+            .into_iter()
+            .try_fold(0u64, |acc, coin| acc.checked_add(coin.balance))
     }
 
     /// Checks gas reservation request validity.
@@ -505,16 +521,41 @@ impl GasStation {
                 });
                 if !unlocked_coins.is_empty() {
                     debug!("Coins that are expired: {:?}", unlocked_coins);
-                    let latest_coins: Vec<_> = self
-                        .iota_client
-                        .get_latest_gas_objects(unlocked_coins.clone())
-                        .await
-                        .into_values()
-                        .flatten()
-                        .collect();
-                    let count = latest_coins.len();
+                    let expired = unlocked_coins.len();
+
+                    // These coins were never executed, so a `None` here is a read
+                    // failure and nothing else. Dropping one loses it for good:
+                    // `expire_coins` has already taken the reservation off the
+                    // queue.
+                    let (latest_coins, unresolved) =
+                        self.iota_client.resolve_gas_coins(unlocked_coins).await;
+
+                    if !unresolved.is_empty() {
+                        self.metrics
+                            .num_unreleased_gas_coins
+                            .with_label_values(&[&self.signer.get_address().to_string()])
+                            .inc_by(unresolved.len() as u64);
+                        // NOT `invariant_violation`: a caller can poison the
+                        // registry with an id that can never resolve until the
+                        // payment binding lands. Upgrade it then, not before.
+                        warn!(
+                            ?unresolved,
+                            attempts = GAS_COIN_RESOLVE_ATTEMPTS,
+                            "the fullnode did not resolve {} of {expired} expired gas coins, so \
+                             they were not released back into the pool",
+                            unresolved.len()
+                        );
+                    }
+
+                    let released = latest_coins.len();
                     self.release_gas_coins(latest_coins).await;
-                    info!("Released {:?} coins after expiration", count);
+                    self.metrics
+                        .num_expired_gas_coins
+                        .with_label_values(&[&self.signer.get_address().to_string()])
+                        .inc_by(released as u64);
+                    // Both numbers: `released` alone used to be computed after the
+                    // drop, so it always agreed with itself.
+                    info!("Released {released} of {expired} coins after expiration");
                 }
                 tokio::select! {
                     _ = tokio::time::sleep(EXPIRATION_JOB_INTERVAL) => {}

--- a/src/gas_station_initializer.rs
+++ b/src/gas_station_initializer.rs
@@ -149,20 +149,38 @@ impl CoinSplitEnv {
             }
         };
         let mut result = vec![];
-        let new_coin_balance = (coin.balance - budget) / split_count;
+        // Saturating: a future change to how `budget` is derived degrades into a
+        // zero-balance coin instead of a ~1.8e19 one.
+        let new_coin_balance = coin.balance.saturating_sub(budget) / split_count;
         for object_ref in created_object_refs(&effects) {
             result.extend(self.enqueue_task(GasCoin {
                 object_ref,
                 balance: new_coin_balance,
             }));
         }
-        let remaining_coin_balance = (coin.balance - new_coin_balance * (split_count - 1)) as i64
-            - effects.as_v1().gas_cost_summary.net_gas_usage();
+        // Same i128 hazard as the execution path, and this site writes straight
+        // into the registry.
+        let remaining_coin_balance: i128 = (coin.balance as i128
+            - new_coin_balance as i128 * (split_count - 1) as i128)
+            - effects.as_v1().gas_cost_summary.net_gas_usage() as i128;
+        let remaining_coin_balance = u64::try_from(remaining_coin_balance).unwrap_or_else(|_| {
+            error!(
+                "Split residual balance {remaining_coin_balance} is not a valid u64 for coin {} \
+                 (parent balance {}, per-child {new_coin_balance}, split count {split_count}); \
+                 registering it with a balance of 0 rather than a wrapped value",
+                gas_object_reference(&effects).object_id,
+                coin.balance,
+            );
+            0
+        });
         result.extend(self.enqueue_task(GasCoin {
             object_ref: gas_object_reference(&effects),
-            balance: remaining_coin_balance as u64,
+            balance: remaining_coin_balance,
         }));
-        self.increment_total_coin_count_by(result.len() - 1);
+        // `result` is empty when every child was re-enqueued for further
+        // splitting, which a large enough parent reaches. Saturating avoids a
+        // usize underflow into the coin counter.
+        self.increment_total_coin_count_by(result.len().saturating_sub(1));
         result
     }
 }

--- a/src/gas_station_initializer.rs
+++ b/src/gas_station_initializer.rs
@@ -411,11 +411,27 @@ impl GasStationInitializer {
         // cycle. Re-resolve every candidate to its live state with a point read
         // and re-apply the threshold, so calibration and splitting never
         // operate on stale object refs.
-        let coins: Vec<GasCoin> = iota_client
-            .get_latest_gas_objects(coins.iter().map(|coin| coin.object_ref.object_id))
-            .await
-            .into_values()
-            .flatten()
+        //
+        // Retried rather than flattened: this is the path an operator runs to
+        // *recover* lost coins, and in `RunMode::Init` the threshold is 0, so a
+        // coin dropped here is dropped from the initial pool.
+        let listed = coins.len();
+        let (resolved, unresolved) = iota_client
+            .resolve_gas_coins(coins.iter().map(|coin| coin.object_ref.object_id))
+            .await;
+        if !unresolved.is_empty() {
+            // No metrics reachable from `run_once`, so this has to be loud in the
+            // log instead.
+            error!(
+                ?unresolved,
+                "the fullnode listed {listed} owned gas coins but never resolved {} of them, so \
+                 they are excluded from this scan and stay outside the pool. Re-run the scan once \
+                 the node has caught up.",
+                unresolved.len()
+            );
+        }
+        let coins: Vec<GasCoin> = resolved
+            .into_iter()
             .filter(|coin| coin.balance >= balance_threshold)
             .collect();
         if coins.is_empty() {

--- a/src/iota_client.rs
+++ b/src/iota_client.rs
@@ -44,6 +44,11 @@ const COIN_LIST_PAGE_SIZE: u32 = 1000;
 /// objects (and how much BCS) go into one request/response pair.
 const OBJECT_FETCH_CHUNK_SIZE: usize = 1000;
 
+/// Bounded retry for a gas coin the fullnode cannot resolve yet. Tuning, not
+/// protocol: sized above a 500-650 ms read lag measured on a localnet.
+pub const GAS_COIN_RESOLVE_ATTEMPTS: u32 = 20;
+const GAS_COIN_RESOLVE_INTERVAL: Duration = Duration::from_millis(100);
+
 #[derive(Clone)]
 pub struct IotaClient {
     client: Client,
@@ -219,6 +224,46 @@ impl IotaClient {
             .into_inner()
     }
 
+    /// Resolves `object_ids`, retrying the ones the fullnode cannot see yet, and
+    /// returns the coins that resolved plus the ids that never did.
+    ///
+    /// Returning the failures rather than dropping them is the point: a coin
+    /// missing from the result is a coin the station permanently loses.
+    pub async fn resolve_gas_coins(
+        &self,
+        object_ids: impl IntoIterator<Item = ObjectId>,
+    ) -> (Vec<GasCoin>, Vec<ObjectId>) {
+        let ids: Vec<ObjectId> = object_ids.into_iter().collect();
+        if ids.is_empty() {
+            return (vec![], vec![]);
+        }
+
+        for attempt in 1..=GAS_COIN_RESOLVE_ATTEMPTS {
+            let latest = self.get_latest_gas_objects(ids.clone()).await;
+            let (resolved, unresolved): (Vec<GasCoin>, Vec<ObjectId>) = partition_resolved(latest);
+
+            if unresolved.is_empty() || attempt == GAS_COIN_RESOLVE_ATTEMPTS {
+                if !unresolved.is_empty() {
+                    warn!(
+                        ?unresolved,
+                        attempts = GAS_COIN_RESOLVE_ATTEMPTS,
+                        "fullnode never resolved these gas coins; the caller decides what that means"
+                    );
+                }
+                return (resolved, unresolved);
+            }
+
+            debug!(
+                unresolved = unresolved.len(),
+                attempt,
+                max_attempts = GAS_COIN_RESOLVE_ATTEMPTS,
+                "fullnode could not resolve gas coins; retrying"
+            );
+            tokio::time::sleep(GAS_COIN_RESOLVE_INTERVAL).await;
+        }
+        unreachable!("the loop returns on its final attempt")
+    }
+
     pub async fn get_latest_gas_objects(
         &self,
         object_ids: impl IntoIterator<Item = ObjectId>,
@@ -294,7 +339,11 @@ impl IotaClient {
         let coin_arg = builder.input(Input::ImmutableOrOwned(gas_coin.object_ref));
         let count_arg = builder.pure(SPLIT_COUNT);
         builder
-            .move_call(ObjectId::FRAMEWORK, Identifier::PAY_MODULE.as_str(), "divide_and_keep")
+            .move_call(
+                ObjectId::FRAMEWORK,
+                Identifier::PAY_MODULE.as_str(),
+                "divide_and_keep",
+            )
             .type_tags([TypeTag::from(StructTag::new_gas())])
             .arguments((coin_arg, count_arg));
         // Built entirely offline (no client, no gas objects) -- the only way
@@ -386,7 +435,9 @@ impl IotaClient {
                         )
                     })
             }
-            Err(err) => Err(anyhow::anyhow!("execute_transaction error for {digest}: {err}")),
+            Err(err) => Err(anyhow::anyhow!(
+                "execute_transaction error for {digest}: {err}"
+            )),
         };
         debug!(?digest, "Transaction execution response: {:?}", effects);
         effects
@@ -498,7 +549,9 @@ fn into_anyhow<T>(outcome: Result<Result<T, GrpcError>, GrpcError>) -> anyhow::R
 #[cfg(test)]
 mod tests {
     use super::*;
-    use iota_sdk_types::{ExecutionStatus, GasCostSummary, TransactionDigest, TransactionEffectsV1};
+    use iota_sdk_types::{
+        ExecutionStatus, GasCostSummary, TransactionDigest, TransactionEffectsV1,
+    };
 
     #[test]
     fn gas_used_from_effects_reads_gas_cost_summary() {
@@ -559,5 +612,73 @@ mod tests {
         ] {
             assert_eq!(rewrite_legacy_fullnode_url(url), None);
         }
+    }
+}
+
+/// Splits a `get_latest_gas_objects` answer into resolved coins and unresolved
+/// ids. Free function so it is testable without a fullnode.
+fn partition_resolved(latest: HashMap<ObjectId, Option<GasCoin>>) -> (Vec<GasCoin>, Vec<ObjectId>) {
+    let mut resolved = Vec::with_capacity(latest.len());
+    let mut unresolved = Vec::new();
+    for (id, coin) in latest {
+        match coin {
+            Some(coin) => resolved.push(coin),
+            None => unresolved.push(id),
+        }
+    }
+    // Deterministic order: the HashMap iteration order is not.
+    unresolved.sort();
+    (resolved, unresolved)
+}
+
+#[cfg(test)]
+mod resolve_tests {
+    use super::*;
+    use crate::types::random_object_ref;
+
+    fn coin(balance: u64) -> GasCoin {
+        GasCoin {
+            object_ref: random_object_ref(),
+            balance,
+        }
+    }
+
+    #[test]
+    fn every_coin_resolving_yields_no_failures() {
+        let a = coin(1);
+        let b = coin(2);
+        let latest = HashMap::from([
+            (a.object_ref.object_id, Some(a.clone())),
+            (b.object_ref.object_id, Some(b.clone())),
+        ]);
+        let (resolved, unresolved) = partition_resolved(latest);
+        assert_eq!(resolved.len(), 2);
+        assert!(unresolved.is_empty());
+    }
+
+    /// The case the release paths got wrong: a `None` must surface as a reported
+    /// id, never be dropped.
+    #[test]
+    fn an_unresolvable_coin_is_reported_not_dropped() {
+        let good = coin(1);
+        let missing = random_object_ref().object_id;
+        let latest = HashMap::from([
+            (good.object_ref.object_id, Some(good.clone())),
+            (missing, None),
+        ]);
+        let (resolved, unresolved) = partition_resolved(latest);
+        assert_eq!(resolved.len(), 1);
+        assert_eq!(unresolved, vec![missing]);
+    }
+
+    #[test]
+    fn unresolved_ids_are_reported_in_a_stable_order() {
+        let ids: Vec<ObjectId> = (0..8).map(|_| random_object_ref().object_id).collect();
+        let latest: HashMap<_, _> = ids.iter().map(|id| (*id, None)).collect();
+        let (resolved, unresolved) = partition_resolved(latest);
+        assert!(resolved.is_empty());
+        let mut expected = ids;
+        expected.sort();
+        assert_eq!(unresolved, expected);
     }
 }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -206,6 +206,7 @@ impl GasStationRpcMetrics {
 pub struct GasStationCoreMetrics {
     pub num_expired_gas_coins: IntCounterVec,
     pub num_smashed_gas_coins: IntCounterVec,
+    pub num_unreleased_gas_coins: IntCounterVec,
     pub reserved_gas_coin_count_per_request: Histogram,
     pub reserve_gas_latency_ms: Histogram,
     pub transaction_signing_latency_ms: Histogram,
@@ -238,6 +239,13 @@ impl GasStationCoreMetrics {
             num_smashed_gas_coins: register_int_counter_vec_with_registry!(
                 "num_smashed_gas_coins",
                 "Total number of gas coins that are smashed (i.e. deleted) during transaction execution",
+                &["sponsor"],
+                registry,
+            )
+                .unwrap(),
+            num_unreleased_gas_coins: register_int_counter_vec_with_registry!(
+                "num_unreleased_gas_coins",
+                "Total number of expired gas coins the fullnode never resolved, so they could not be released back to the pool. Usually these are coins the registry has lost while the sponsor still owns them on chain, recoverable only by a full rescan -- but a coin can also end up here after being legitimately destroyed elsewhere, so check the logged object ids against the chain before scheduling one",
                 &["sponsor"],
                 registry,
             )

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -306,12 +306,13 @@ impl GasStationCoreMetrics {
         Self::new(&Registry::new())
     }
 
+    /// Logs a detected invariant violation and increments the counter.
+    ///
+    /// Deliberately does not panic in debug builds: callers report conditions
+    /// they then handle, so panicking would abort tests on exactly the situation
+    /// the handling exists for.
     pub fn invariant_violation<T: Into<String>>(&self, msg: T) {
-        if cfg!(debug_assertions) {
-            panic!("Invariant violation: {}", msg.into());
-        } else {
-            error!("Invariant violation: {}", msg.into());
-        }
+        error!("Invariant violation: {}", msg.into());
         self.num_gas_station_invariant_violations.inc();
     }
 }


### PR DESCRIPTION
## The problem

A single successful sponsored transaction could permanently remove its gas coin from the pool. The
coin stayed owned by the sponsor on chain, but the station could never spend it again. Under
sustained load this is a slow, silent drain.

Observed end to end against a local network:

```
pool before       495 coins, 4999514604000 nanos
reservation       id 1 with 1 coin
pool while held   494 coins
executed          status: success, net gas 1000000 nanos
pool after        494 coins            <-- unchanged from "while held"
```

The transaction succeeded. The coin never came back.

## Why it happened

Five steps, each individually reasonable, which is why it survived review:

1. **The station asks the fullnode for the coin's balance before executing.** The node answers
   `NOT_FOUND`. The code `flatten()`ed that away, so an unresolvable coin contributed **0** to the
   sum rather than raising an error — a missing coin is documented as "routine" one layer down, so
   this looked like a supported outcome.
2. **`new_balance = 0 - net_gas_usage`** → `-1_000_000`.
3. **`as u64`** wrapped that to roughly `1.8 × 10¹⁹`.
4. **The oversized-coin check** compares against `200 × target_init_balance`, so `1.8e19` looked
   oversized and the check fired.
5. **The oversized branch skipped `release_gas_coins` entirely** — for *every* coin in that
   execution, not just the suspect one.

So one failed balance lookup both misclassified the coin and suppressed the release of all of them.

**And the loss is permanent, not transient.** The oversized branch triggers a rescan, which sounds
like recovery. It is not: the rescan only selects coins *above* `200 × target_init_balance`, and
the coin that was withheld is an ordinary pool coin at roughly `1 ×`. It is structurally invisible
to the only mechanism that could bring it back. Recovering it needs an operator running a full
rescan, which wipes the registry and holds a maintenance window.

The diagnostic actively misleads: the failure presents as **"oversized coin"**, pointing an
operator at `target_init_balance` when the real cause is an arithmetic underflow.

## The root cause underneath it

Investigated and confirmed rather than assumed: **the fullnode's gRPC read path lags its own
execute path.** A coin created by the initializer's split transaction answers `NOT_FOUND` for
roughly 500–650 ms after creation, while the validators already hold it and it works fine as gas.
The transition is checkpoint-gated — measured at 490 of 495 pool coins unreadable at one
checkpoint, and all 495 resolving at the next.

The station is unusually exposed to that window because pool entries are synthesized from
transaction *effects* and never read back, so the registry routinely holds references the read path
cannot yet serve.

## The fix

Four commits, each addressing one link in the chain so each is separately revertable.

**`8ae621c` — make `invariant_violation` usable from the transaction path.** It previously panicked
in debug builds, so nothing on a request path could report through it. A gas station should not
abort a process because a fullnode answered oddly.

**`f33ecd4` — stop a negative derived balance wrapping.** The arithmetic is done in `i128` and
converted with `u64::try_from`. `i128` is not defensive padding: the pre-execution balance is a
`u64` (so values above `i64::MAX` are misread as negative by `as i64`), and `net_gas_usage` is a
signed `i64` that is *legitimately* negative whenever gas smashing refunds more storage than the
transaction spent. `i128` holds every such pair exactly, which makes the single conversion the only
place either direction can be rejected.

**`7ec8715` — report an unresolvable coin instead of summing it to zero.** The balance read now
returns `Option<u64>` and retries a coin the node cannot resolve, up to a bounded budget, before
giving up. Retrying is what makes this a fix rather than a workaround: in practice it *recovers the
real balance* instead of merely avoiding the wrong one. `None` is not a decision to fail the
request — the coin has already left the pool, so it must still be released; it only says the
balance is unknown, and the coin is released with a recorded balance of 0. An understated balance
is recoverable and self-heals on the coin's next successful use; a withheld coin is lost forever.

**`c6f8ebe` — release the non-oversized coins instead of none of them.** Partition rather than
branch. Withholding a genuinely oversized coin is deliberate — the rescan's selection filter and
the pool's admission filter are the same threshold, so a pooled coin above it could be split out
from under the pool — but that argument applies only to the coins actually above the threshold.

### The twin site

`gas_station_initializer.rs` repeated the same wrap, and is worse in one respect: it feeds
`add_new_coins` directly at init and rescan time, bypassing execution entirely, so a wrapped
balance is written straight into the registry. Fixed here too, with saturating arithmetic on the
adjacent unchecked subtraction and count decrement.


## Verification

| Verification | Result |
| --- | --- |
| Station test suite (`cargo nextest run -j 1`) | 172/172 |
| End-to-end reserve / execute / expire run against a local network | 14 of 14 reconciliation checks pass |
| Sustained load: 1000 transactions at concurrency 25 | 24 of 24 checks pass |
| Single round trip at full coin value | clean |

The controls matter more than the totals here, because "the leak stopped" is only meaningful
against a build where it happens:

- **A build carrying only the *other* fix branch** reproduces it too, with 3 coins — same defect,
  count varying with fullnode timing. So the leak is attributable to this defect specifically and
  not to anything else in flight.
- **The 1000-transaction run** reconciles the pool to its exact baseline, with balance conservation
  to the nano and no equivocation across 957 reservations over 495 distinct coins.

## Out of scope

The read-your-writes barrier — resolving every reference before it enters the pool — was considered
and deliberately not applied; it is a larger change and the retry covers the observed window. The
`Err` and expiry release paths, `overflow-checks` in release builds, and whether
`perform_consistency_check` should run periodically rather than once at startup are all recorded as
open questions rather than settled here.
