### PR TITLE
fix: bind a reservation to the gas coins it reserved

### DIFF
--- a/src/gas_station/gas_station_core.rs
+++ b/src/gas_station/gas_station_core.rs
@@ -349,10 +349,11 @@ impl GasStation {
         if payment_count == 0 {
             bail!("Transaction must pay with at least one gas coin");
         }
-        if payment_count > MAX_GAS_PER_QUERY {
+        // `>=`, matching the protocol's strict `<`: the bound is exclusive.
+        if payment_count >= MAX_GAS_PER_QUERY {
             bail!(
-                "Transaction pays with {payment_count} gas coins, but a reservation holds at \
-                 most {MAX_GAS_PER_QUERY}"
+                "Transaction pays with {payment_count} gas coins, but the protocol accepts fewer \
+                 than {MAX_GAS_PER_QUERY}"
             );
         }
 
@@ -556,7 +557,8 @@ mod validity_tests {
 
     #[test]
     fn a_payment_within_the_reservation_limit_is_accepted() {
-        for len in [1, 2, MAX_GAS_PER_QUERY - 1, MAX_GAS_PER_QUERY] {
+        // MAX_GAS_PER_QUERY - 1 is the largest the protocol accepts.
+        for len in [1, 2, MAX_GAS_PER_QUERY - 2, MAX_GAS_PER_QUERY - 1] {
             GasStation::check_transaction_validity(&tx_paying_with(len))
                 .unwrap_or_else(|err| panic!("{len} coins should be accepted: {err}"));
         }
@@ -566,16 +568,19 @@ mod validity_tests {
     /// picks.
     #[test]
     fn a_payment_longer_than_a_reservation_can_be_is_rejected() {
-        let err = GasStation::check_transaction_validity(&tx_paying_with(MAX_GAS_PER_QUERY + 1))
+        // Exactly MAX_GAS_PER_QUERY is the first rejected size: the bound is
+        // exclusive.
+        let err = GasStation::check_transaction_validity(&tx_paying_with(MAX_GAS_PER_QUERY))
             .unwrap_err()
             .to_string();
-        assert!(err.contains("257"), "should name the payment size: {err}");
+        assert!(err.contains("256"), "should name the payment size: {err}");
         assert!(
             err.contains(&MAX_GAS_PER_QUERY.to_string()),
             "should name the limit: {err}"
         );
 
         // Nothing in between is accepted either.
+        assert!(GasStation::check_transaction_validity(&tx_paying_with(MAX_GAS_PER_QUERY + 1)).is_err());
         assert!(GasStation::check_transaction_validity(&tx_paying_with(10_000)).is_err());
     }
 

--- a/src/gas_station/gas_station_core.rs
+++ b/src/gas_station/gas_station_core.rs
@@ -8,7 +8,7 @@ use crate::gas_station_initializer::NEW_COIN_BALANCE_FACTOR_THRESHOLD;
 use crate::iota_client::IotaClient;
 use crate::metrics::GasStationCoreMetrics;
 use crate::rpc::rpc_types::{ExecuteTransactionRequestType, ReserveGasRequest};
-use crate::storage::Storage;
+use crate::storage::{Storage, MAX_GAS_PER_QUERY};
 use crate::tx_signer::TxSigner;
 use crate::types::{GasCoin, ReservationID};
 use crate::{retry_forever, retry_with_max_attempts};
@@ -343,6 +343,19 @@ impl GasStation {
     ///   the `coin` being split is).
     /// - `Command::Upgrade`'s `ticket` argument is not scanned at all.
     fn check_transaction_validity(tx: &Transaction) -> anyhow::Result<()> {
+        // Bound the payment before anything downstream does work proportional to
+        // it. Nothing else caps it -- the body limit is axum's 2 MB default.
+        let payment_count = tx.as_v1().gas_payment.objects.len();
+        if payment_count == 0 {
+            bail!("Transaction must pay with at least one gas coin");
+        }
+        if payment_count > MAX_GAS_PER_QUERY {
+            bail!(
+                "Transaction pays with {payment_count} gas coins, but a reservation holds at \
+                 most {MAX_GAS_PER_QUERY}"
+            );
+        }
+
         let commands: &[Command] = match &tx.as_v1().kind {
             TransactionKind::Programmable(pt) => &pt.commands,
             // Non-programmable transaction kinds (system transactions) carry
@@ -514,5 +527,101 @@ impl GasStationContainer {
 impl Drop for GasStationContainer {
     fn drop(&mut self) {
         self.cancel_sender.take().unwrap().send(()).unwrap();
+    }
+}
+
+#[cfg(test)]
+mod validity_tests {
+    use super::*;
+    use crate::types::random_object_ref;
+
+    /// A sponsored transaction paying with `payment_len` gas coins, doing
+    /// nothing else.
+    fn tx_paying_with(payment_len: usize) -> Transaction {
+        Transaction::V1(TransactionV1 {
+            kind: TransactionKind::Programmable(ProgrammableTransaction {
+                inputs: vec![],
+                commands: vec![],
+            }),
+            sender: Address::ZERO,
+            gas_payment: GasPayment {
+                objects: (0..payment_len).map(|_| random_object_ref()).collect(),
+                owner: Address::ZERO,
+                price: 1000,
+                budget: 1_000_000,
+            },
+            expiration: TransactionExpiration::None,
+        })
+    }
+
+    #[test]
+    fn a_payment_within_the_reservation_limit_is_accepted() {
+        for len in [1, 2, MAX_GAS_PER_QUERY - 1, MAX_GAS_PER_QUERY] {
+            GasStation::check_transaction_validity(&tx_paying_with(len))
+                .unwrap_or_else(|err| panic!("{len} coins should be accepted: {err}"));
+        }
+    }
+
+    /// Nothing downstream should do work proportional to a number the caller
+    /// picks.
+    #[test]
+    fn a_payment_longer_than_a_reservation_can_be_is_rejected() {
+        let err = GasStation::check_transaction_validity(&tx_paying_with(MAX_GAS_PER_QUERY + 1))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("257"), "should name the payment size: {err}");
+        assert!(
+            err.contains(&MAX_GAS_PER_QUERY.to_string()),
+            "should name the limit: {err}"
+        );
+
+        // Nothing in between is accepted either.
+        assert!(GasStation::check_transaction_validity(&tx_paying_with(10_000)).is_err());
+    }
+
+    /// An empty payment consumes the reservation and releases nothing.
+    #[test]
+    fn an_empty_payment_is_rejected() {
+        let err = GasStation::check_transaction_validity(&tx_paying_with(0))
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("at least one gas coin"),
+            "unexpected error: {err}"
+        );
+    }
+
+    /// The bound must be checked before the command scan, so an oversized
+    /// payment is refused without walking a large command list.
+    #[test]
+    fn the_payment_bound_is_checked_before_the_command_scan() {
+        // Oversized payment AND a command the scan rejects: the error that comes
+        // back tells us which ran first.
+        let tx = Transaction::V1(TransactionV1 {
+            kind: TransactionKind::Programmable(ProgrammableTransaction {
+                inputs: vec![],
+                commands: vec![Command::SplitCoins(iota_sdk_types::SplitCoins {
+                    coin: Argument::Gas,
+                    amounts: vec![],
+                })],
+            }),
+            sender: Address::ZERO,
+            gas_payment: GasPayment {
+                objects: (0..=MAX_GAS_PER_QUERY)
+                    .map(|_| random_object_ref())
+                    .collect(),
+                owner: Address::ZERO,
+                price: 1000,
+                budget: 1_000_000,
+            },
+            expiration: TransactionExpiration::None,
+        });
+        let err = GasStation::check_transaction_validity(&tx)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("gas coins"),
+            "the payment bound should win over the gas-argument scan: {err}"
+        );
     }
 }

--- a/src/gas_station/gas_station_core.rs
+++ b/src/gas_station/gas_station_core.rs
@@ -125,8 +125,10 @@ impl GasStation {
             ?reservation_id,
             "Payment coins in transaction: {:?}", payment
         );
+        // Consuming the reservation is also what binds it to these coins. Before
+        // the read and the dispatch, so a mismatch costs nothing.
         self.gas_station_store
-            .ready_for_execution(reservation_id)
+            .ready_for_execution(reservation_id, &payment)
             .await?;
         debug!(?reservation_id, "Reservation is ready for execution");
 

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -12,6 +12,10 @@ use url::Url;
 
 mod redis;
 
+/// The protocol's `max_gas_payment_objects`, mirrored here.
+///
+/// **Exclusive bound** — the validators compare with a strict `<`, so the
+/// largest gas payment they accept is 255. Compare with `<` everywhere.
 pub const MAX_GAS_PER_QUERY: usize = 256;
 pub const MAINTENANCE_MODE_ERROR_MESSAGE: &str =
     "Gas station is in maintenance mode. Please try again later.";
@@ -27,7 +31,8 @@ pub trait Storage: SetGetStorage + Sync + Send {
     /// 1. It never returns the same coin to multiple callers.
     /// 2. It keeps a record of the reserved coins with timestamp, so that in the case
     ///    when caller forgets to release them, some cleanup process can clean them up latter.
-    /// 3. It should never return more than 256 coins at a time since that's the upper bound of gas.
+    /// 3. It must never return `MAX_GAS_PER_QUERY` coins or more -- that bound is
+    ///    exclusive, so such a reservation could never be paid with.
     async fn reserve_gas_coins(
         &self,
         target_budget: u64,
@@ -252,7 +257,9 @@ mod tests {
         assert_coin_count(&storage, 100000, 0).await;
         let mut cur_available = 100000;
         let mut expected_res_id = 1;
-        for i in 1..=MAX_GAS_PER_QUERY {
+        // Up to MAX_GAS_PER_QUERY - 1: the bound is exclusive, matching the
+        // protocol's strict `<` on gas payment objects.
+        for i in 1..MAX_GAS_PER_QUERY {
             let (res_id, reserved_gas_coins) =
                 storage.reserve_gas_coins(i as u64, 1000).await.unwrap();
             assert_eq!(expected_res_id, res_id);
@@ -263,12 +270,27 @@ mod tests {
         assert_coin_count(&storage, cur_available, 100000 - cur_available).await;
     }
 
+    /// A reservation stops one coin short of `MAX_GAS_PER_QUERY`, because the
+    /// protocol's check is `objects.len() < max_gas_payment_objects`. Handing
+    /// out exactly `MAX_GAS_PER_QUERY` coins would create a reservation that no
+    /// validator can execute.
     #[tokio::test]
     async fn test_max_gas_coin_per_query() {
         let sponsor = Address::random();
         let storage = setup(sponsor, vec![1; MAX_GAS_PER_QUERY + 1]).await;
+
+        // The largest reservation the protocol can actually pay with.
+        let (_, coins) = storage
+            .reserve_gas_coins((MAX_GAS_PER_QUERY - 1) as u64, 1000)
+            .await
+            .unwrap();
+        assert_eq!(coins.len(), MAX_GAS_PER_QUERY - 1);
+
+        // One more coin than that cannot be satisfied, even though the pool
+        // holds enough balance for it.
+        let storage = setup(Address::random(), vec![1; MAX_GAS_PER_QUERY + 1]).await;
         assert!(storage
-            .reserve_gas_coins((MAX_GAS_PER_QUERY + 1) as u64, 1000)
+            .reserve_gas_coins(MAX_GAS_PER_QUERY as u64, 1000)
             .await
             .is_err());
         assert_coin_count(&storage, MAX_GAS_PER_QUERY + 1, 0).await;

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -34,7 +34,17 @@ pub trait Storage: SetGetStorage + Sync + Send {
         reserved_duration_ms: u64,
     ) -> anyhow::Result<(ReservationID, Vec<GasCoin>)>;
 
-    async fn ready_for_execution(&self, reservation_id: ReservationID) -> anyhow::Result<()>;
+    /// Consume a reservation, but only if `payment` is exactly the set of gas
+    /// coins it owns.
+    ///
+    /// The check is part of the contract because it must be atomic with the
+    /// consumption. On mismatch, implementations must leave the reservation
+    /// intact and must not disclose the reserved object ids in the error.
+    async fn ready_for_execution(
+        &self,
+        reservation_id: ReservationID,
+        payment: &[ObjectId],
+    ) -> anyhow::Result<()>;
 
     async fn add_new_coins(&self, new_coins: Vec<GasCoin>) -> anyhow::Result<()>;
 
@@ -191,6 +201,12 @@ mod tests {
         assert_eq!(storage.get_reserved_coin_count().await, reserved);
     }
 
+    /// Every coin the reservation handed out, which is what a well-behaved
+    /// caller pays with.
+    fn payment_of(coins: &[GasCoin]) -> Vec<ObjectId> {
+        coins.iter().map(|c| c.object_ref.object_id).collect()
+    }
+
     async fn setup(sponsor: Address, init_balances: Vec<u64>) -> Arc<dyn Storage> {
         let storage = connect_storage_for_testing(sponsor).await;
         let gas_coins = init_balances
@@ -276,7 +292,10 @@ mod tests {
             let (res_id, reserved_gas_coins) = storage.reserve_gas_coins(99, 1000).await.unwrap();
             assert_eq!(reserved_gas_coins.len(), 99);
             assert_coin_count(&storage, 1, 99).await;
-            storage.ready_for_execution(res_id).await.unwrap();
+            storage
+                .ready_for_execution(res_id, &payment_of(&reserved_gas_coins))
+                .await
+                .unwrap();
             storage.add_new_coins(reserved_gas_coins).await.unwrap();
             assert_coin_count(&storage, 100, 0).await;
         }
@@ -298,7 +317,10 @@ mod tests {
                     reserved_gas_coin.balance -= 1;
                 }
             }
-            storage.ready_for_execution(res_id).await.unwrap();
+            storage
+                .ready_for_execution(res_id, &payment_of(&reserved_gas_coins))
+                .await
+                .unwrap();
             storage.add_new_coins(reserved_gas_coins).await.unwrap();
         }
         assert_coin_count(&storage, 100, 0).await;
@@ -313,11 +335,150 @@ mod tests {
         let (res_id, mut reserved_gas_coins) = storage.reserve_gas_coins(100, 1000).await.unwrap();
         assert_eq!(reserved_gas_coins.len(), 100);
 
-        storage.ready_for_execution(res_id).await.unwrap();
+        storage
+            .ready_for_execution(res_id, &payment_of(&reserved_gas_coins))
+            .await
+            .unwrap();
 
         reserved_gas_coins.drain(0..50);
         storage.add_new_coins(reserved_gas_coins).await.unwrap();
         assert_coin_count(&storage, 50, 0).await;
+    }
+
+    /// The reservation-hijack case: naming a reservation id must not be enough
+    /// to consume it. Before the binding this destroyed the victim's reservation
+    /// and permanently leaked its coins.
+    #[tokio::test]
+    async fn test_ready_for_execution_rejects_another_reservations_coins() {
+        let sponsor = Address::random();
+        let storage = setup(sponsor, vec![1; 100]).await;
+        let (victim_id, victim_coins) = storage.reserve_gas_coins(10, 10000).await.unwrap();
+        let (attacker_id, attacker_coins) = storage.reserve_gas_coins(10, 10000).await.unwrap();
+
+        let err = storage
+            .ready_for_execution(victim_id, &payment_of(&attacker_coins))
+            .await
+            .unwrap_err()
+            .to_string();
+        // The reserved ids must not be disclosed to a caller who guessed an id.
+        for coin in &victim_coins {
+            assert!(
+                !err.contains(&coin.object_ref.object_id.to_string()),
+                "error leaked a reserved object id: {err}"
+            );
+        }
+
+        // Both reservations survive the rejection intact, and each still works
+        // with its own coins.
+        assert_coin_count(&storage, 80, 20).await;
+        storage
+            .ready_for_execution(victim_id, &payment_of(&victim_coins))
+            .await
+            .unwrap();
+        storage
+            .ready_for_execution(attacker_id, &payment_of(&attacker_coins))
+            .await
+            .unwrap();
+    }
+
+    /// A rejected attempt must leave the reservation on the expiration queue,
+    /// or its coins are stranded just as the hijack stranded them.
+    #[tokio::test]
+    async fn test_rejected_payment_leaves_the_reservation_expirable() {
+        let sponsor = Address::random();
+        let storage = setup(sponsor, vec![1; 100]).await;
+        let (res_id, coins) = storage.reserve_gas_coins(10, 900).await.unwrap();
+        let foreign = vec![ObjectId::random()];
+
+        assert!(storage
+            .ready_for_execution(res_id, &foreign)
+            .await
+            .is_err());
+        assert_coin_count(&storage, 90, 10).await;
+
+        tokio::time::sleep(Duration::from_secs(1)).await;
+        // `expire_coins` hands the ids back rather than re-adding them, so this
+        // proves the reservation was still on the queue to be found.
+        let expired = storage.expire_coins().await.unwrap();
+        assert_eq!(
+            expired.into_iter().collect::<BTreeSet<_>>(),
+            payment_of(&coins).into_iter().collect::<BTreeSet<_>>()
+        );
+        assert_coin_count(&storage, 90, 0).await;
+    }
+
+    /// A subset is rejected: the `DEL` is wholesale, so omitted coins would be
+    /// dropped from the registry without ever being released.
+    #[tokio::test]
+    async fn test_ready_for_execution_rejects_partial_payment() {
+        let sponsor = Address::random();
+        let storage = setup(sponsor, vec![1; 100]).await;
+        let (res_id, coins) = storage.reserve_gas_coins(10, 10000).await.unwrap();
+
+        let mut short = payment_of(&coins);
+        short.pop();
+        assert!(storage.ready_for_execution(res_id, &short).await.is_err());
+        assert!(storage.ready_for_execution(res_id, &[]).await.is_err());
+
+        // Untouched, so the honest payment still works.
+        storage
+            .ready_for_execution(res_id, &payment_of(&coins))
+            .await
+            .unwrap();
+    }
+
+    /// A repeated coin must not stand in for the one it replaces, which would
+    /// satisfy a naive length check.
+    #[tokio::test]
+    async fn test_ready_for_execution_rejects_repeated_and_extra_coins() {
+        let sponsor = Address::random();
+        let storage = setup(sponsor, vec![1; 100]).await;
+        let (res_id, coins) = storage.reserve_gas_coins(10, 10000).await.unwrap();
+
+        let first = coins[0].object_ref.object_id;
+        let repeated = vec![first; coins.len()];
+        assert!(storage.ready_for_execution(res_id, &repeated).await.is_err());
+
+        let mut padded = payment_of(&coins);
+        padded.push(ObjectId::random());
+        assert!(storage.ready_for_execution(res_id, &padded).await.is_err());
+
+        storage
+            .ready_for_execution(res_id, &payment_of(&coins))
+            .await
+            .unwrap();
+    }
+
+    /// Set comparison, not sequence: a client orders its payment as it likes.
+    #[tokio::test]
+    async fn test_ready_for_execution_ignores_payment_order() {
+        let sponsor = Address::random();
+        let storage = setup(sponsor, vec![1; 100]).await;
+        let (res_id, coins) = storage.reserve_gas_coins(10, 10000).await.unwrap();
+
+        let mut shuffled = payment_of(&coins);
+        shuffled.reverse();
+        storage
+            .ready_for_execution(res_id, &shuffled)
+            .await
+            .unwrap();
+        assert_coin_count(&storage, 90, 0).await;
+    }
+
+    /// An unknown id must still report the original message, which callers match on.
+    #[tokio::test]
+    async fn test_ready_for_execution_unknown_reservation() {
+        let sponsor = Address::random();
+        let storage = setup(sponsor, vec![1; 100]).await;
+        let err = storage
+            .ready_for_execution(999_999, &[ObjectId::random()])
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("Reservation no longer exist: 999999"),
+            "unexpected error: {err}"
+        );
     }
 
     #[tokio::test]

--- a/src/storage/redis/lua_scripts/ready_for_execution.lua
+++ b/src/storage/redis/lua_scripts/ready_for_execution.lua
@@ -6,16 +6,52 @@
 -- It takes out the reservation from the sponsor's reservation map.
 -- We need this such that a concurrent task that calls expire_coins.lua does not expire the same reservation again
 -- right before the transaction is executed.
--- The first argument is the sponsor's address.
+--
+-- Before consuming it, verifies the caller is paying with exactly the coins this
+-- reservation owns: a reservation id alone is not proof of ownership.
+--
+-- The comparison MUST stay in this script, before the DEL. It has to be atomic
+-- with the delete, and Redis does not roll back writes made before an error.
+--
+-- The first argument is the sponsor's namespace.
 -- The second argument is the reservation id.
+-- The third argument is the comma-separated object ids of the transaction's gas
+-- payment, in the same textual form reserve_gas_coins.lua stored them in.
 
 local namespace = ARGV[1]
 local reservation_id = ARGV[2]
+local payment_object_ids = ARGV[3]
 
 local key = namespace .. ':' .. reservation_id
-local exists = redis.call('EXISTS', key)
-if exists == 1 then
-    redis.call('DEL', key)
-else
+local reserved_object_ids = redis.call('GET', key)
+if reserved_object_ids == false then
     error('Reservation no longer exist: ' .. reservation_id)
 end
+
+local reserved = {}
+local reserved_count = 0
+for object_id in string.gmatch(reserved_object_ids, '([^,]+)') do
+    if reserved[object_id] == nil then
+        reserved[object_id] = true
+        reserved_count = reserved_count + 1
+    end
+end
+
+-- Exact set equality. A subset is rejected too: the DEL is wholesale, so coins
+-- left out would be stranded. Errors report counts only, never the reserved ids.
+local payment_count = 0
+for object_id in string.gmatch(payment_object_ids, '([^,]+)') do
+    if reserved[object_id] == nil then
+        error('Gas coins in the transaction do not belong to reservation ' .. reservation_id)
+    end
+    -- Consume it, so a repeated coin cannot stand in for a missing one.
+    reserved[object_id] = nil
+    payment_count = payment_count + 1
+end
+
+if payment_count ~= reserved_count then
+    error('Transaction pays with ' .. payment_count .. ' gas coins but reservation '
+        .. reservation_id .. ' holds ' .. reserved_count)
+end
+
+redis.call('DEL', key)

--- a/src/storage/redis/lua_scripts/reserve_gas_coins.lua
+++ b/src/storage/redis/lua_scripts/reserve_gas_coins.lua
@@ -11,6 +11,7 @@
 -- The second argument is the target budget.
 -- The third argument is the expiration time.
 -- The fourth argument is the current timestamp (for maintenance mode check).
+-- The fifth argument is the most coins one reservation may hold.
 -- Returns a table with the reservation id, reserved coins, new total balance, and new coin count.
 -- Returns {-1, {}, 0, 0} if the gas station is in maintenance mode.
 
@@ -26,7 +27,9 @@ if locked_timestamp ~= false and tonumber(locked_timestamp) >= current_time then
     return {-1, {}, 0, 0}
 end
 
-local MAX_GAS_PER_QUERY = 256
+-- Passed in rather than duplicated as a literal here: the execute-side check is
+-- only correct if it uses the same limit enforced here.
+local max_gas_per_query = tonumber(ARGV[5])
 
 local t_available_gas_coins = namespace .. ':available_gas_coins'
 local t_expiration_queue = namespace .. ':expiration_queue'
@@ -36,7 +39,7 @@ local total_balance = 0
 local coins = {}
 local object_ids = {}
 
-while total_balance < target_budget and #coins < MAX_GAS_PER_QUERY do
+while total_balance < target_budget and #coins < max_gas_per_query do
     local coin = redis.call('LPOP', t_available_gas_coins)
     if not coin then break end
 

--- a/src/storage/redis/lua_scripts/reserve_gas_coins.lua
+++ b/src/storage/redis/lua_scripts/reserve_gas_coins.lua
@@ -11,7 +11,8 @@
 -- The second argument is the target budget.
 -- The third argument is the expiration time.
 -- The fourth argument is the current timestamp (for maintenance mode check).
--- The fifth argument is the most coins one reservation may hold.
+-- The fifth argument is the protocol's max_gas_payment_objects, an exclusive bound:
+-- a reservation may hold at most one fewer coin than this.
 -- Returns a table with the reservation id, reserved coins, new total balance, and new coin count.
 -- Returns {-1, {}, 0, 0} if the gas station is in maintenance mode.
 
@@ -27,9 +28,9 @@ if locked_timestamp ~= false and tonumber(locked_timestamp) >= current_time then
     return {-1, {}, 0, 0}
 end
 
--- Passed in rather than duplicated as a literal here: the execute-side check is
--- only correct if it uses the same limit enforced here.
-local max_gas_per_query = tonumber(ARGV[5])
+-- EXCLUSIVE bound, mirroring the protocol's strict `<`, so a reservation stops
+-- one coin short of it. Passed in rather than duplicated as a literal here.
+local max_gas_payment_objects = tonumber(ARGV[5])
 
 local t_available_gas_coins = namespace .. ':available_gas_coins'
 local t_expiration_queue = namespace .. ':expiration_queue'
@@ -39,7 +40,7 @@ local total_balance = 0
 local coins = {}
 local object_ids = {}
 
-while total_balance < target_budget and #coins < max_gas_per_query do
+while total_balance < target_budget and #coins + 1 < max_gas_payment_objects do
     local coin = redis.call('LPOP', t_available_gas_coins)
     if not coin then break end
 

--- a/src/storage/redis/mod.rs
+++ b/src/storage/redis/mod.rs
@@ -7,7 +7,7 @@ mod script_manager;
 
 use crate::metrics::StorageMetrics;
 use crate::storage::redis::script_manager::ScriptManager;
-use crate::storage::{SetGetStorage, Storage, MAINTENANCE_MODE_ERROR_MESSAGE};
+use crate::storage::{SetGetStorage, Storage, MAINTENANCE_MODE_ERROR_MESSAGE, MAX_GAS_PER_QUERY};
 use crate::types::{GasCoin, ReservationID};
 use anyhow::bail;
 use chrono::Utc;
@@ -149,6 +149,7 @@ impl Storage for RedisStorage {
             .arg(target_budget)
             .arg(expiration_time)
             .arg(current_time)
+            .arg(MAX_GAS_PER_QUERY)
             .invoke_async(&mut conn)
             .await?;
         // The script returns (-1, []) if the gas station is in maintenance mode.

--- a/src/storage/redis/mod.rs
+++ b/src/storage/redis/mod.rs
@@ -176,13 +176,26 @@ impl Storage for RedisStorage {
         Ok((reservation_id, gas_coins))
     }
 
-    async fn ready_for_execution(&self, reservation_id: ReservationID) -> anyhow::Result<()> {
+    async fn ready_for_execution(
+        &self,
+        reservation_id: ReservationID,
+        payment: &[ObjectId],
+    ) -> anyhow::Result<()> {
         self.metrics.num_ready_for_execution_requests.inc();
+
+        // `Display`, never `Debug`: the script compares this text against what
+        // `encode_gas_coin` stored. `Debug` renders `ObjectId("0x..")`.
+        let payment_object_ids = payment
+            .iter()
+            .map(ObjectId::to_string)
+            .collect::<Vec<_>>()
+            .join(",");
 
         let mut conn = self.conn_manager.clone();
         ScriptManager::ready_for_execution_script()
             .arg(self.namespace.clone())
             .arg(reservation_id)
+            .arg(payment_object_ids)
             .invoke_async::<_, ()>(&mut conn)
             .await?;
 


### PR DESCRIPTION
## The problem

The gas station hands out gas coins in two steps. A caller reserves a budget and gets back a
reservation id plus the coins that reservation now owns. Later the caller submits a signed
transaction citing that id, and the station sponsors it.

Nothing ever checked that the coins in the transaction were the coins the reservation held. The
station took the id at face value, consumed the reservation, and paid with whatever coins the
transaction named.

Reservation ids are not secret. They come from a single counter that increments once per
reservation, so a caller who makes one reservation knows roughly every id currently live. Naming
one was enough to consume it.

## What that allowed

A caller reserves normally, then submits their own transaction — paying with their own coins —
while citing *someone else's* reservation id. The station accepted it. Three things followed:

- **The other caller's reservation was destroyed.** Their next execute failed with "reservation no
  longer exist", through no fault of their own. Any live reservation could be broken this way, blind.
- **The other caller's coins were leaked permanently.** Consuming a reservation is what removes its
  coins from the registry. Once removed, only that execution returns them, and this execution
  returned different coins. Nothing else can find them again: the expiry sweep no longer knows about
  them, and the periodic rescan only looks at coins far larger than a normal pool coin. The sponsor
  still owns them on chain; the station can no longer spend them. They are gone until an operator
  intervenes.
- **The attacker's own coins were released twice**, leaving a duplicate in the free list — two
  entries pointing at one coin, which is the precondition for handing the same coin to two
  reservations at once.

The damage is the same whether it is done deliberately or by a client that simply gets its
bookkeeping wrong and reuses a stale id. A pool bleeds coins either way, and the symptom — coins
owned on chain but unknown to the station — gives no hint of the cause.

### The same gap loses coins with no attacker at all

This is the part worth reading even if cross-tenant abuse is not a concern for your deployment.

Consuming a reservation is what removes its coins from the registry, and it happens *before* the
station looks at the transaction. Everything afterwards is derived from the transaction's payment.
So if a caller reserves several coins and pays with only some of them, the coins it left out are
removed from the pool and then never mentioned again — absent from the free list, absent from every
reservation, invisible to the expiry sweep because the reservation record is gone, and below the
`200 × target_init_balance` floor the periodic rescan selects on. They are lost until an operator
runs a full rescan.

Nothing rejected that. No malice is required: a client whose own budget arithmetic, SDK payment
cap, or reused transaction pays with fewer coins than `reserve_gas` handed back triggers it. The
loss is one coin per missing coin, up to 254 in a single request.

Measured on a real stack, same traffic both ways:

| Build | Partial payments | Coins leaked |
| --- | --- | --- |
| Without this fix | 12 accepted | **12 leaked, 121.19 IOTA** |
| With this fix | 12 refused | **0** |

Only reachable with multi-coin reservations — with one coin there is no non-empty subset to leave
out — which is why it survived a 1000-transaction run: every reservation there fit in a single coin.

This is a **tenant-isolation** failure rather than an authentication one. The station has one shared
bearer token and no notion of caller identity, so it cannot tell two callers apart to begin with. In
a single-tenant deployment the exposure is a client bug rather than an attack. In any deployment
where more than one party holds the token, it is a live cross-tenant hazard.

## The fix

`ready_for_execution` — the operation that consumes a reservation — now also receives the
transaction's gas payment, and consumes the reservation only if the payment is exactly the set of
coins that reservation holds.

Three properties are worth calling out, because each rules out a way the fix could have been wrong:

**The check is atomic with the consumption.** It lives inside the same Redis script that deletes the
reservation. Checking in one round trip and deleting in the next would leave a window in which the
expiry sweep could take the reservation in between — precisely the race the script was written to
prevent. Redis does not roll back writes made before an error, so every rejection happens before the
delete rather than after it.

**A partial payment is rejected, not tolerated.** Consuming a reservation removes all its coins at
once. Paying with only some of them would strand the rest exactly as the hijack did, just without a
beneficiary.

**The rejection reveals nothing.** The error reports counts only, never the reserved coin ids. A
caller who guessed an id must not be handed that reservation's coins in the reply.

Well-behaved callers are unaffected: the coins are compared as a set, so a client may order its gas
payment however it likes.

## Second commit: bound the payment at the reservation limit

`ffb070c` adds what the binding makes provable — a payment cannot be longer than a reservation can
be, so anything longer is rejected before it costs anything.

Worth knowing what was there before: `MAX_GAS_PER_QUERY` was **defined in Rust but never used
outside tests**. The only enforcement was a second hardcoded `256` inside `reserve_gas_coins.lua`,
and nothing capped the execute path at all — the request body is bounded only by axum's 2 MB
default, roughly 20 000 object references. The limit is now passed into the Lua script instead of
duplicated there, because the new check is only correct if reserve really never exceeds it.

An empty payment is rejected too, for a different reason: it would consume the reservation and
release nothing, stranding every coin it held.

**This is hardening, not the fix.** It bounds work that scales with the payment, but not the fixed
cost of retrying an unresolvable coin, which is a sleep budget and identical for 1 coin or 256:

| Request | Without the binding | With the binding |
| --- | --- | --- |
| 200 non-existent ids | 2137 ms | 6 ms |
| 10 000 non-existent ids | 5238 ms | 179 ms |

The cap takes the 10 000 case down to roughly the 200 case. Only the binding removes the stall, by
refusing the request before the read happens.

## Third commit: the limit was off by one against the protocol

`4290b9b`. `MAX_GAS_PER_QUERY` mirrors the protocol's `max_gas_payment_objects`, which is 256. But
the protocol compares against it with a **strict `<`**:

```rust
// iota-types/src/transaction.rs, TransactionData::validity_check
self.gas().len() < config.max_gas_payment_objects() as usize
```

so the largest gas payment any validator accepts is **255**. The value is set once at the
protocol's base version and is not overridden by any protocol version or chain — every version
snapshot, Mainnet and Testnet, reads 256.

The station treated it as an inclusive maximum, so a reservation could be handed exactly 256 coins.
A transaction paying with all of them is rejected by every validator, which makes such a
reservation **unusable from the moment it is created**, for a reason the caller cannot see. The
binding turns that from a latent oddity into a dead end: with the payment required to equal the
reserved set, a 256-coin reservation has no payment that both matches it and is accepted on chain.

Fixed by matching the protocol's comparison rather than lowering the constant. Keeping the number
identical to the one it mirrors, and putting the exclusivity where the protocol puts it, is the
change least likely to drift again:

- **reserve** stops one coin short, so every reservation it issues can actually be paid with
- **execute** rejects at `>= MAX_GAS_PER_QUERY`, mirroring the validators' own `<`

The `Storage` trait doc previously said a reservation should "never return more than 256 coins at a
time since that's the upper bound of gas". That is the wrong bound, and is where the off-by-one came
from; it now states the exclusivity explicitly.

## Compatibility

- **No data migration and no schema change.** The reservation record already stored exactly these
  coin ids; nothing had ever read them back. Reservations created before the upgrade are readable
  after it.
- **No client change.** The IOTA SDK's sponsored-transaction builder, this repo's `call_package`
  example, and the documented `curl` flow all pay with the full reserved set already.
- **Rolling upgrade is safe.** Old and new instances can share a namespace; an old instance simply
  remains unprotected until it is replaced.
- **Three narrow breaks.** The `Storage` trait signature changes, so any out-of-tree implementor
  must be updated — a compile error, not a silent one. A transaction with an empty gas payment is now
  rejected where it used to consume the reservation silently; that was one of the holes being closed.
  And the largest possible reservation shrinks from 256 coins to 255 — which only removes
  reservations that no validator would have accepted anyway.

## Verification

This was found by driving the running station as a client: reserve twice, then execute citing one
reservation while paying with the other's coins, and reconcile the Redis registry against on-chain
state afterwards. That abuse case is now refused before the reservation is touched.

| Verification | Result |
| --- | --- |
| Station test suite (`cargo nextest run -j 1`) | 182/182, including 10 new tests |
| Negative control — the new tests against the old script | 4 of 5 fail, as they must |
| End-to-end reserve / execute / expire run against a local network | 14 of 14 reconciliation checks pass |
| Sustained load: 1000 transactions at concurrency 25 | 24 of 24 checks pass |
| Abuse suite: execute citing another reservation | refused (previously accepted) |
| Multi-coin reservations, 3 coins each | foreign set, subset, superset and repeated coin all refused; honest payment accepted in any order |
| Multi-coin partial payments | 12 coins leaked without the fix, 0 with it |
| Protocol bound | verified against the IOTA source, not inferred: `max_gas_payment_objects = 256`, strict `<`, no per-version or per-chain override |

The end-to-end runs use a build that also carries the separate coin-leak fixes from
`fix/registry-inconsitency`, since that defect is independent and would otherwise mask these
results. Verified on this branch alone as well: the binding behaves identically, and the residual
failures are that pre-existing leak — a run against pristine `dev` reproduces the same two.

Two coverage points behind those numbers:

- **Concurrency.** The load run includes 34 pairs of simultaneous executes against one reservation;
  each resolved to exactly one winner. The check-and-delete still serializes.
- **Multi-coin.** Ordinary load happens to produce single-coin reservations, where a set comparison
  cannot fail on ordering or on a subset — so it proves very little. The multi-coin cases above were
  driven deliberately, with a reserve budget large enough to span three coins.

## Out of scope

Reservation ids remain sequential and guessable. That no longer grants anything — an id without the
matching coins is inert — but making them unguessable is still worth doing, and per-tenant
credentials remain the prerequisite for treating this as a real privilege boundary. Four unrelated
findings from the same audit (an endpoint answering 200 with body "Unauthorized", a state-mutating
GET, unauthenticated exposure of the sponsor address and pool balance in `/metrics`, and JSON bodies
with trailing garbage being accepted) are untouched here.
