### PR TITLE
fix: prevent the release paths from dropping coins the fullnode cannot resolve

### DIFF
--- a/src/gas_station/gas_station_core.rs
+++ b/src/gas_station/gas_station_core.rs
@@ -231,25 +231,17 @@ impl GasStation {
                 let (resolved, unresolved) = self.iota_client.resolve_gas_coins(payment).await;
 
                 if !unresolved.is_empty() {
-                    self.metrics
-                        .num_unreleased_gas_coins
-                        .with_label_values(&[&sponsor.to_string()])
-                        .inc_by(unresolved.len() as u64);
-                    // Deliberately NOT `invariant_violation`. These ids come
-                    // from `tx.gas_payment.objects`, which is client-supplied
-                    // until the payment is bound to the reservation, so raising
-                    // an invariant here would hand callers a switch on a counter
-                    // whose whole value is that it means the station's own
-                    // assumptions broke. Upgrade this to `invariant_violation`
-                    // once the reservation/coin binding lands and the payment is
-                    // provably the reserved set.
+                    // Deliberately NOT counted as unreleased and NOT an invariant:
+                    // these ids may have been smashed legitimately, so an alert
+                    // would prescribe a rescan for coins that may not exist.
                     warn!(
                         ?reservation_id,
                         ?unresolved,
                         attempts = GAS_COIN_RESOLVE_ATTEMPTS,
-                        "the fullnode did not resolve {} gas coin(s) after a failed execution, so \
-                         they were not released; if the transaction did not land these are still \
-                         owned on chain and the registry has lost them",
+                        "the fullnode did not resolve {} gas coin(s) after a failed execution. If \
+                         the transaction landed despite the error these were smashed and are gone \
+                         legitimately; if it did not land they are still owned on chain and the \
+                         registry has lost them. This branch cannot tell which.",
                         unresolved.len()
                     );
                 }
@@ -262,9 +254,11 @@ impl GasStation {
         // every coin the node failed to resolve as one the validators
         // legitimately consumed -- so a real loss was reported as a routine
         // smash, and the one signal pointing at the problem argued against it.
+        // On success exactly one coin survives. On failure the retry makes this
+        // derivable too: unresolved ids are the ones smashing deleted.
         let smashed_coin_count = match &response {
             Ok(_) => payment_count.saturating_sub(1),
-            Err(_) => 0,
+            Err(_) => payment_count.saturating_sub(updated_coins.len()),
         };
 
         // Withhold only the coins actually above the threshold. Branching on
@@ -541,17 +535,16 @@ impl GasStation {
                             .num_unreleased_gas_coins
                             .with_label_values(&[&self.signer.get_address().to_string()])
                             .inc_by(unresolved.len() as u64);
-                        // Safe to raise here: these ids come from the station's
-                        // own registry, never from a caller, so no request can
-                        // drive this counter.
-                        self.metrics.invariant_violation(format!(
-                            "the fullnode did not resolve {} of {expired} expired gas coins after \
-                             {GAS_COIN_RESOLVE_ATTEMPTS} attempts, so they were not released and \
-                             the registry has lost them: {unresolved:?}. They were never executed, \
-                             so the sponsor still owns them on chain; recovering them needs a full \
-                             rescan, which wipes the registry and holds a maintenance window.",
+                        // NOT `invariant_violation`: a caller can poison the
+                        // registry with an id that can never resolve until the
+                        // payment binding lands. Upgrade it then, not before.
+                        warn!(
+                            ?unresolved,
+                            attempts = GAS_COIN_RESOLVE_ATTEMPTS,
+                            "the fullnode did not resolve {} of {expired} expired gas coins, so \
+                             they were not released back into the pool",
                             unresolved.len()
-                        ));
+                        );
                     }
 
                     let released = latest_coins.len();

--- a/src/gas_station/gas_station_core.rs
+++ b/src/gas_station/gas_station_core.rs
@@ -5,7 +5,7 @@
 use crate::gas_station::effects_util::gas_object_reference;
 use crate::gas_station::rescan_trigger::RescanGasObjectsTrigger;
 use crate::gas_station_initializer::NEW_COIN_BALANCE_FACTOR_THRESHOLD;
-use crate::iota_client::IotaClient;
+use crate::iota_client::{IotaClient, GAS_COIN_RESOLVE_ATTEMPTS};
 use crate::metrics::GasStationCoreMetrics;
 use crate::rpc::rpc_types::{ExecuteTransactionRequestType, ReserveGasRequest};
 use crate::storage::Storage;
@@ -26,11 +26,6 @@ use tokio::task::JoinHandle;
 use tracing::{debug, error, info, warn};
 
 use super::gas_usage_cap::GasUsageCap;
-
-/// Bounded retry for a gas coin the fullnode cannot resolve yet. Tuning, not
-/// protocol: sized above a 500-650 ms read lag measured on a localnet.
-const GAS_COIN_RESOLVE_ATTEMPTS: u32 = 20;
-const GAS_COIN_RESOLVE_INTERVAL: Duration = Duration::from_millis(100);
 
 pub const NANOS_PER_IOTA: u64 = 1_000_000_000;
 
@@ -68,6 +63,13 @@ impl GasStation {
         checkpoint_inclusion_timeout_ms: u64,
         rescan_config: RescanGasObjectsTrigger,
     ) -> Arc<Self> {
+        // Export the series at zero so it exists from startup: an absent metric
+        // reads as "no data" rather than "nothing was lost".
+        metrics
+            .num_unreleased_gas_coins
+            .with_label_values(&[&signer.get_address().to_string()])
+            .inc_by(0);
+
         let pool = Self {
             signer,
             gas_station_store,
@@ -151,10 +153,20 @@ impl GasStation {
             Ok(effects) => {
                 let new_gas_coin = gas_object_reference(effects);
                 let net_gas_usage = effects.as_v1().gas_cost_summary.net_gas_usage();
-                // i128: neither a u64 total nor a signed i64 gas usage fits the
-                // result. `None` means the pre-execution read never resolved.
-                let new_balance: Option<i128> = total_gas_coin_balance
-                    .map(|total| total as i128 - net_gas_usage as i128);
+                // Computed in i128 because neither operand's range fits the
+                // result: `total_gas_coin_balance` is a u64 (so values above
+                // i64::MAX are misread as negative by `as i64`), and
+                // `net_gas_usage` is a signed i64 that is *legitimately*
+                // negative whenever gas smashing refunds more storage than the
+                // transaction spent. i128 holds every (u64, i64) pair exactly,
+                // so the single conversion below is the only place either
+                // direction can be rejected.
+                // Only derivable when the pre-execution balance is actually
+                // known. `None` here means the fullnode could not resolve the
+                // coin even after retrying, so any number we computed would be
+                // fabricated.
+                let new_balance: Option<i128> =
+                    total_gas_coin_balance.map(|total| total as i128 - net_gas_usage as i128);
                 debug!(
                     ?reservation_id,
                     "New gas coin balance after execution: {:?}", new_balance,
@@ -213,17 +225,47 @@ impl GasStation {
                     ?reservation_id,
                     "Querying latest gas state since transaction failed"
                 );
-                self.iota_client
-                    .get_latest_gas_objects(payment)
-                    .await
-                    .into_values()
-                    .flatten()
-                    .collect()
+                // The dangerous read: whether the coins are live or were smashed
+                // depends on whether the transaction landed, which is not known
+                // here.
+                let (resolved, unresolved) = self.iota_client.resolve_gas_coins(payment).await;
+
+                if !unresolved.is_empty() {
+                    self.metrics
+                        .num_unreleased_gas_coins
+                        .with_label_values(&[&sponsor.to_string()])
+                        .inc_by(unresolved.len() as u64);
+                    // Deliberately NOT `invariant_violation`. These ids come
+                    // from `tx.gas_payment.objects`, which is client-supplied
+                    // until the payment is bound to the reservation, so raising
+                    // an invariant here would hand callers a switch on a counter
+                    // whose whole value is that it means the station's own
+                    // assumptions broke. Upgrade this to `invariant_violation`
+                    // once the reservation/coin binding lands and the payment is
+                    // provably the reserved set.
+                    warn!(
+                        ?reservation_id,
+                        ?unresolved,
+                        attempts = GAS_COIN_RESOLVE_ATTEMPTS,
+                        "the fullnode did not resolve {} gas coin(s) after a failed execution, so \
+                         they were not released; if the transaction did not land these are still \
+                         owned on chain and the registry has lost them",
+                        unresolved.len()
+                    );
+                }
+                resolved
             }
         };
-        // Saturating: `updated_coins` exceeding `payment_count` would be a node
-        // bug, and wrapping would corrupt the metric.
-        let smashed_coin_count = payment_count.saturating_sub(updated_coins.len());
+        // Only a transaction that actually executed smashes anything, and when
+        // one does the success arm above yields exactly the single surviving
+        // coin. Deriving this from `updated_coins.len()` instead used to count
+        // every coin the node failed to resolve as one the validators
+        // legitimately consumed -- so a real loss was reported as a routine
+        // smash, and the one signal pointing at the problem argued against it.
+        let smashed_coin_count = match &response {
+            Ok(_) => payment_count.saturating_sub(1),
+            Err(_) => 0,
+        };
 
         // Withhold only the coins actually above the threshold. Branching on
         // "any oversized" used to skip release for the whole execution, which is
@@ -325,35 +367,15 @@ impl GasStation {
     /// `None` is not a decision to fail the request: the coin has already left
     /// the pool and must still be released. It only says the balance is unknown.
     async fn get_total_gas_coin_balance(&self, gas_coins: Vec<ObjectId>) -> Option<u64> {
-        for attempt in 1..=GAS_COIN_RESOLVE_ATTEMPTS {
-            let latest = self
-                .iota_client
-                .get_latest_gas_objects(gas_coins.clone())
-                .await;
-
-            let unresolved: Vec<ObjectId> = latest
-                .iter()
-                .filter(|(_, coin)| coin.is_none())
-                .map(|(id, _)| *id)
-                .collect();
-
-            if unresolved.is_empty() {
-                // `checked_add`: a decoded-garbage balance must not wrap the sum.
-                return latest
-                    .into_values()
-                    .flatten()
-                    .try_fold(0u64, |acc, coin| acc.checked_add(coin.balance));
-            }
-
-            warn!(
-                ?unresolved,
-                attempt,
-                max_attempts = GAS_COIN_RESOLVE_ATTEMPTS,
-                "fullnode could not resolve gas coins; retrying"
-            );
-            tokio::time::sleep(GAS_COIN_RESOLVE_INTERVAL).await;
+        let (resolved, unresolved) = self.iota_client.resolve_gas_coins(gas_coins).await;
+        if !unresolved.is_empty() {
+            // A partial sum looks like a balance and is silently too low.
+            return None;
         }
-        None
+        // `checked_add`: a decoded-garbage balance must not wrap the sum.
+        resolved
+            .into_iter()
+            .try_fold(0u64, |acc, coin| acc.checked_add(coin.balance))
     }
 
     /// Checks gas reservation request validity.
@@ -505,16 +527,42 @@ impl GasStation {
                 });
                 if !unlocked_coins.is_empty() {
                     debug!("Coins that are expired: {:?}", unlocked_coins);
-                    let latest_coins: Vec<_> = self
-                        .iota_client
-                        .get_latest_gas_objects(unlocked_coins.clone())
-                        .await
-                        .into_values()
-                        .flatten()
-                        .collect();
-                    let count = latest_coins.len();
+                    let expired = unlocked_coins.len();
+
+                    // These coins were never executed, so a `None` here is a read
+                    // failure and nothing else. Dropping one loses it for good:
+                    // `expire_coins` has already taken the reservation off the
+                    // queue.
+                    let (latest_coins, unresolved) =
+                        self.iota_client.resolve_gas_coins(unlocked_coins).await;
+
+                    if !unresolved.is_empty() {
+                        self.metrics
+                            .num_unreleased_gas_coins
+                            .with_label_values(&[&self.signer.get_address().to_string()])
+                            .inc_by(unresolved.len() as u64);
+                        // Safe to raise here: these ids come from the station's
+                        // own registry, never from a caller, so no request can
+                        // drive this counter.
+                        self.metrics.invariant_violation(format!(
+                            "the fullnode did not resolve {} of {expired} expired gas coins after \
+                             {GAS_COIN_RESOLVE_ATTEMPTS} attempts, so they were not released and \
+                             the registry has lost them: {unresolved:?}. They were never executed, \
+                             so the sponsor still owns them on chain; recovering them needs a full \
+                             rescan, which wipes the registry and holds a maintenance window.",
+                            unresolved.len()
+                        ));
+                    }
+
+                    let released = latest_coins.len();
                     self.release_gas_coins(latest_coins).await;
-                    info!("Released {:?} coins after expiration", count);
+                    self.metrics
+                        .num_expired_gas_coins
+                        .with_label_values(&[&self.signer.get_address().to_string()])
+                        .inc_by(released as u64);
+                    // Both numbers: `released` alone used to be computed after the
+                    // drop, so it always agreed with itself.
+                    info!("Released {released} of {expired} coins after expiration");
                 }
                 tokio::select! {
                     _ = tokio::time::sleep(EXPIRATION_JOB_INTERVAL) => {}

--- a/src/gas_station_initializer.rs
+++ b/src/gas_station_initializer.rs
@@ -411,11 +411,27 @@ impl GasStationInitializer {
         // cycle. Re-resolve every candidate to its live state with a point read
         // and re-apply the threshold, so calibration and splitting never
         // operate on stale object refs.
-        let coins: Vec<GasCoin> = iota_client
-            .get_latest_gas_objects(coins.iter().map(|coin| coin.object_ref.object_id))
-            .await
-            .into_values()
-            .flatten()
+        //
+        // Retried rather than flattened: this is the path an operator runs to
+        // *recover* lost coins, and in `RunMode::Init` the threshold is 0, so a
+        // coin dropped here is dropped from the initial pool.
+        let listed = coins.len();
+        let (resolved, unresolved) = iota_client
+            .resolve_gas_coins(coins.iter().map(|coin| coin.object_ref.object_id))
+            .await;
+        if !unresolved.is_empty() {
+            // No metrics reachable from `run_once`, so this has to be loud in the
+            // log instead.
+            error!(
+                ?unresolved,
+                "the fullnode listed {listed} owned gas coins but never resolved {} of them, so \
+                 they are excluded from this scan and stay outside the pool. Re-run the scan once \
+                 the node has caught up.",
+                unresolved.len()
+            );
+        }
+        let coins: Vec<GasCoin> = resolved
+            .into_iter()
             .filter(|coin| coin.balance >= balance_threshold)
             .collect();
         if coins.is_empty() {

--- a/src/iota_client.rs
+++ b/src/iota_client.rs
@@ -44,6 +44,11 @@ const COIN_LIST_PAGE_SIZE: u32 = 1000;
 /// objects (and how much BCS) go into one request/response pair.
 const OBJECT_FETCH_CHUNK_SIZE: usize = 1000;
 
+/// Bounded retry for a gas coin the fullnode cannot resolve yet. Tuning, not
+/// protocol: sized above a 500-650 ms read lag measured on a localnet.
+pub const GAS_COIN_RESOLVE_ATTEMPTS: u32 = 20;
+const GAS_COIN_RESOLVE_INTERVAL: Duration = Duration::from_millis(100);
+
 #[derive(Clone)]
 pub struct IotaClient {
     client: Client,
@@ -219,6 +224,46 @@ impl IotaClient {
             .into_inner()
     }
 
+    /// Resolves `object_ids`, retrying the ones the fullnode cannot see yet, and
+    /// returns the coins that resolved plus the ids that never did.
+    ///
+    /// Returning the failures rather than dropping them is the point: a coin
+    /// missing from the result is a coin the station permanently loses.
+    pub async fn resolve_gas_coins(
+        &self,
+        object_ids: impl IntoIterator<Item = ObjectId>,
+    ) -> (Vec<GasCoin>, Vec<ObjectId>) {
+        let ids: Vec<ObjectId> = object_ids.into_iter().collect();
+        if ids.is_empty() {
+            return (vec![], vec![]);
+        }
+
+        for attempt in 1..=GAS_COIN_RESOLVE_ATTEMPTS {
+            let latest = self.get_latest_gas_objects(ids.clone()).await;
+            let (resolved, unresolved): (Vec<GasCoin>, Vec<ObjectId>) = partition_resolved(latest);
+
+            if unresolved.is_empty() || attempt == GAS_COIN_RESOLVE_ATTEMPTS {
+                if !unresolved.is_empty() {
+                    warn!(
+                        ?unresolved,
+                        attempts = GAS_COIN_RESOLVE_ATTEMPTS,
+                        "fullnode never resolved these gas coins; the caller decides what that means"
+                    );
+                }
+                return (resolved, unresolved);
+            }
+
+            debug!(
+                unresolved = unresolved.len(),
+                attempt,
+                max_attempts = GAS_COIN_RESOLVE_ATTEMPTS,
+                "fullnode could not resolve gas coins; retrying"
+            );
+            tokio::time::sleep(GAS_COIN_RESOLVE_INTERVAL).await;
+        }
+        unreachable!("the loop returns on its final attempt")
+    }
+
     pub async fn get_latest_gas_objects(
         &self,
         object_ids: impl IntoIterator<Item = ObjectId>,
@@ -294,7 +339,11 @@ impl IotaClient {
         let coin_arg = builder.input(Input::ImmutableOrOwned(gas_coin.object_ref));
         let count_arg = builder.pure(SPLIT_COUNT);
         builder
-            .move_call(ObjectId::FRAMEWORK, Identifier::PAY_MODULE.as_str(), "divide_and_keep")
+            .move_call(
+                ObjectId::FRAMEWORK,
+                Identifier::PAY_MODULE.as_str(),
+                "divide_and_keep",
+            )
             .type_tags([TypeTag::from(StructTag::new_gas())])
             .arguments((coin_arg, count_arg));
         // Built entirely offline (no client, no gas objects) -- the only way
@@ -386,7 +435,9 @@ impl IotaClient {
                         )
                     })
             }
-            Err(err) => Err(anyhow::anyhow!("execute_transaction error for {digest}: {err}")),
+            Err(err) => Err(anyhow::anyhow!(
+                "execute_transaction error for {digest}: {err}"
+            )),
         };
         debug!(?digest, "Transaction execution response: {:?}", effects);
         effects
@@ -498,7 +549,9 @@ fn into_anyhow<T>(outcome: Result<Result<T, GrpcError>, GrpcError>) -> anyhow::R
 #[cfg(test)]
 mod tests {
     use super::*;
-    use iota_sdk_types::{ExecutionStatus, GasCostSummary, TransactionDigest, TransactionEffectsV1};
+    use iota_sdk_types::{
+        ExecutionStatus, GasCostSummary, TransactionDigest, TransactionEffectsV1,
+    };
 
     #[test]
     fn gas_used_from_effects_reads_gas_cost_summary() {
@@ -559,5 +612,73 @@ mod tests {
         ] {
             assert_eq!(rewrite_legacy_fullnode_url(url), None);
         }
+    }
+}
+
+/// Splits a `get_latest_gas_objects` answer into resolved coins and unresolved
+/// ids. Free function so it is testable without a fullnode.
+fn partition_resolved(latest: HashMap<ObjectId, Option<GasCoin>>) -> (Vec<GasCoin>, Vec<ObjectId>) {
+    let mut resolved = Vec::with_capacity(latest.len());
+    let mut unresolved = Vec::new();
+    for (id, coin) in latest {
+        match coin {
+            Some(coin) => resolved.push(coin),
+            None => unresolved.push(id),
+        }
+    }
+    // Deterministic order: the HashMap iteration order is not.
+    unresolved.sort();
+    (resolved, unresolved)
+}
+
+#[cfg(test)]
+mod resolve_tests {
+    use super::*;
+    use crate::types::random_object_ref;
+
+    fn coin(balance: u64) -> GasCoin {
+        GasCoin {
+            object_ref: random_object_ref(),
+            balance,
+        }
+    }
+
+    #[test]
+    fn every_coin_resolving_yields_no_failures() {
+        let a = coin(1);
+        let b = coin(2);
+        let latest = HashMap::from([
+            (a.object_ref.object_id, Some(a.clone())),
+            (b.object_ref.object_id, Some(b.clone())),
+        ]);
+        let (resolved, unresolved) = partition_resolved(latest);
+        assert_eq!(resolved.len(), 2);
+        assert!(unresolved.is_empty());
+    }
+
+    /// The case the release paths got wrong: a `None` must surface as a reported
+    /// id, never be dropped.
+    #[test]
+    fn an_unresolvable_coin_is_reported_not_dropped() {
+        let good = coin(1);
+        let missing = random_object_ref().object_id;
+        let latest = HashMap::from([
+            (good.object_ref.object_id, Some(good.clone())),
+            (missing, None),
+        ]);
+        let (resolved, unresolved) = partition_resolved(latest);
+        assert_eq!(resolved.len(), 1);
+        assert_eq!(unresolved, vec![missing]);
+    }
+
+    #[test]
+    fn unresolved_ids_are_reported_in_a_stable_order() {
+        let ids: Vec<ObjectId> = (0..8).map(|_| random_object_ref().object_id).collect();
+        let latest: HashMap<_, _> = ids.iter().map(|id| (*id, None)).collect();
+        let (resolved, unresolved) = partition_resolved(latest);
+        assert!(resolved.is_empty());
+        let mut expected = ids;
+        expected.sort();
+        assert_eq!(unresolved, expected);
     }
 }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -245,7 +245,7 @@ impl GasStationCoreMetrics {
                 .unwrap(),
             num_unreleased_gas_coins: register_int_counter_vec_with_registry!(
                 "num_unreleased_gas_coins",
-                "Total number of gas coins the fullnode never resolved, so they could not be released back to the pool. Non-zero means the registry has lost coins that are still owned on chain; recovering them needs a full rescan",
+                "Total number of expired gas coins the fullnode never resolved, so they could not be released back to the pool. Usually these are coins the registry has lost while the sponsor still owns them on chain, recoverable only by a full rescan -- but a coin can also end up here after being legitimately destroyed elsewhere, so check the logged object ids against the chain before scheduling one",
                 &["sponsor"],
                 registry,
             )

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -206,6 +206,7 @@ impl GasStationRpcMetrics {
 pub struct GasStationCoreMetrics {
     pub num_expired_gas_coins: IntCounterVec,
     pub num_smashed_gas_coins: IntCounterVec,
+    pub num_unreleased_gas_coins: IntCounterVec,
     pub reserved_gas_coin_count_per_request: Histogram,
     pub reserve_gas_latency_ms: Histogram,
     pub transaction_signing_latency_ms: Histogram,
@@ -238,6 +239,13 @@ impl GasStationCoreMetrics {
             num_smashed_gas_coins: register_int_counter_vec_with_registry!(
                 "num_smashed_gas_coins",
                 "Total number of gas coins that are smashed (i.e. deleted) during transaction execution",
+                &["sponsor"],
+                registry,
+            )
+                .unwrap(),
+            num_unreleased_gas_coins: register_int_counter_vec_with_registry!(
+                "num_unreleased_gas_coins",
+                "Total number of gas coins the fullnode never resolved, so they could not be released back to the pool. Non-zero means the registry has lost coins that are still owned on chain; recovering them needs a full rescan",
                 &["sponsor"],
                 registry,
             )


### PR DESCRIPTION
## The problem

Three separate places take a set of coin ids, ask the fullnode to resolve them, and release whatever
comes back:

```rust
get_latest_gas_objects(ids).into_values().flatten().collect()
```

`flatten()` discards every coin the node could not resolve, **with no retry**. A discarded coin is
never released, and it has already been removed from the registry, so nothing can surface it again:
absent from the free list, absent from every reservation, invisible to `expire_coins`, and below the
`200 × target_init_balance` floor the periodic rescan selects on. It is still owned by the sponsor
on chain and permanently unusable by the station.

| Where | What a `NOT_FOUND` means there |
| --- | --- |
| **the expiry sweep** | a read failure, always — the coins were never executed |
| **the failed-execution release** | ambiguous — smashed by a transaction that landed anyway, or lost |
| **the rescan re-read** | a read failure on a coin the node listed as owned moments earlier |

## Why the expiry sweep is the worst of the three

It is the one that looks least alarming and is in fact the most dangerous:

- **Its `None` is unambiguous.** An expired reservation was never executed, so its coins were never
  consumed and are *guaranteed* still live on chain. There is no innocent reading — dropping one is
  always a loss.
- **It is the highest-volume path.** Every reserve-without-execute lands here; a 1000-transaction run
  produces around 110 expiry releases.
- **It reported success while losing coins.** The released count was computed *after* the drop, so
  `Released N coins after expiration` always agreed with itself. Ten in, zero out logged cheerfully
  at INFO. And nothing anywhere incremented `num_expired_gas_coins`, so the one metric an operator
  would reach for was always zero.

The failed-execution release added its own misdirection: the smashed-coin count was derived from how
many coins came back, so every dropped coin was reported as one the validators legitimately consumed.
The only signal pointing at the problem argued against it.

## The fix

All three sites now share `IotaClient::resolve_gas_coins`, which retries on the existing budget and
returns **the ids that never resolved** instead of dropping them. Callers decide what that means,
and they decide differently on purpose:

- **expiry sweep** — `warn!` plus a new `num_unreleased_gas_coins` counter.
- **failed-execution release** — `warn!` only, and deliberately no counter. That branch cannot tell a
  coin smashed by a landed transaction from a lost one, and counting them would fire an alert whose
  documented remedy is a registry-wiping rescan, for coins that may not exist. The ambiguity is
  stated in the log instead.
- **rescan re-read** — a loud `error!`; `run_once` has no handle to the metrics registry.

Three corrections ship alongside:

- `num_expired_gas_coins` is incremented at all, and the expiry log reports **released of expired**
  rather than a number computed after the drop.
- `smashed_coin_count` is derived rather than guessed. The retry makes it derivable on the failure
  path too: a transaction that never landed resolves every coin and yields 0; one that landed
  resolves the survivor once the lag clears and not the deleted ones, giving the true count.
- `num_unreleased_gas_coins` is exported at zero from startup, so an absent series never reads as
  "nothing was lost".

## The second commit

`f258d40` corrects two reporting defects that an adversarial review of the first commit found.
Neither affects custody — no coin is lost or double-released either way — but both made the station
report something untrue.

**The expiry site raised `invariant_violation`**, justified by a comment claiming its ids "come from
the station's own registry, never from a caller". Registry *provenance* is not registry *integrity*.
Until the payment is bound to the reservation, a caller can have a coin held by reservation A
destroyed by paying with it under reservation B; A then references a coin the validators deleted, and
when A expires that id can never resolve. One reserve/execute pair poisons a future expiry batch, and
the sweep runs every second. Downgraded to a warning, with the prerequisite recorded — it can be
raised once `fix/bind-reservation-to-gas-coins` lands.

**The failed-execution path counted smashed coins as lost while zeroing the smash count**, so both
metrics were wrong in the same scenario. It now claims neither.

## What this does not do

**A coin that stays unreadable past the retry budget is reported, not recovered.** It is still not
released. That is the honest limit of this change: it converts a silent leak into a loud one and
bounds the window, but recovering such a coin needs the durable pending-recovery queue described as
Option D in [SOLUTIONS.md](SOLUTIONS.md), which is deliberately deferred until there is data on how
often the budget is actually exhausted.

Deliberately **not** an automatic rescan trigger. A full rescan wipes the registry and holds a
12-hour maintenance lock during which all reservations are refused — a disproportionate remedy for
one coin, and one whose firing rate a caller can influence.

## Verification

| Verification | Result |
| --- | --- |
| Station test suite (`cargo nextest run -j 1`) | 175/175, including 3 new tests |
| Each commit builds independently | yes |
| End-to-end reserve / execute / expire run against a local network | 15 of 15 checks pass |
| Sustained load: 1000 transactions at concurrency 25 | 25 of 25 checks pass, including 29 executions through the failure release path |
| Smashed-coin count | matches an independently computed expectation exactly (36 of 36) |

Two things worth knowing about what the numbers do **not** cover:

- **The dangerous case is not reproduced.** Every deliberately-failing payload is refused *before*
  execution, so the coins' versions never move and the read cannot lag. The 29 failure-path releases
  prove the branch returns every coin when the read succeeds — nothing more. Forcing a
  dispatched-then-errored transaction needs fault injection at the node boundary.
- **The retry now runs where it did not before**, including on the rescan, which in `RunMode::Init`
  lists every owned coin. It sleeps only when something is unresolved, so the common path pays
  nothing, but a startup immediately after a large split can spend up to the full budget.
